### PR TITLE
[iOS#29] 로그인 UI 구현

### DIFF
--- a/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
+++ b/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = ViewController()
+        window.rootViewController = LoginViewController()
         window.makeKeyAndVisible()
         
         self.window = window

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/Model/LoginType.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/Model/LoginType.swift
@@ -1,0 +1,30 @@
+//
+//  LoginType.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/13.
+//
+
+enum LoginType {
+    case google
+    case apple
+    
+    var description: String {
+        switch self {
+        case .google:
+            "구글 계정으로 로그인"
+        case .apple:
+            "애플 계정으로 로그인"
+        }
+    }
+    
+    // TODO: - 이미지 Assets 추가 후 작업
+    var logoImage: String {
+        switch self {
+        case .google:
+            ""
+        case .apple:
+            ""
+        }
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -8,8 +8,33 @@
 import UIKit
 
 final class LoginViewController: UIViewController {
-
     // MARK: - UI Components
+    private var logoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "FlipMate_icon")
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private var logoMainTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 30, weight: .bold)
+        label.text = "FLIP MATE"
+        label.textColor = .blue
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private var logoSubTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .bold)
+        label.text = "우리들이 공부하는 시간"
+        label.textColor = .systemGray
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
     private var googleLoginButton: UIButton = {
         let button = UIButton()
         button.setLoginButton(type: .google)
@@ -45,9 +70,24 @@ private extension LoginViewController {
     func configureUI() {
         view.backgroundColor = .systemBackground
 
-        [ googleLoginButton, appleLoginButton, loginSkipButton ].forEach { view.addSubview($0) }
+        [ logoImageView,
+          logoMainTitleLabel,
+          logoSubTitleLabel,
+          googleLoginButton,
+          appleLoginButton,
+          loginSkipButton ].forEach { view.addSubview($0) }
         
         NSLayoutConstraint.activate([
+            logoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            logoImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -100),
+            
+            logoMainTitleLabel.bottomAnchor.constraint(equalTo: logoSubTitleLabel.topAnchor, constant: -5),
+            logoMainTitleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            
+            logoSubTitleLabel.bottomAnchor.constraint(equalTo: logoImageView.topAnchor, constant: -20),
+            logoSubTitleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            
+            
             googleLoginButton.bottomAnchor.constraint(equalTo: appleLoginButton.topAnchor, constant: -20),
             googleLoginButton.leadingAnchor.constraint(equalTo: appleLoginButton.leadingAnchor),
             googleLoginButton.trailingAnchor.constraint(equalTo: appleLoginButton.trailingAnchor),

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -1,0 +1,14 @@
+//
+//  LoginViewController.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/13.
+//
+
+import UIKit
+
+final class LoginViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -23,6 +23,16 @@ final class LoginViewController: UIViewController {
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
+    
+    private var loginSkipButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("로그인하지 않고 이용하기", for: .normal)
+        button.setTitleColor(.systemGray, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 14)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,7 +45,7 @@ private extension LoginViewController {
     func configureUI() {
         view.backgroundColor = .systemBackground
 
-        [ googleLoginButton, appleLoginButton ].forEach { view.addSubview($0) }
+        [ googleLoginButton, appleLoginButton, loginSkipButton ].forEach { view.addSubview($0) }
         
         NSLayoutConstraint.activate([
             googleLoginButton.bottomAnchor.constraint(equalTo: appleLoginButton.topAnchor, constant: -20),
@@ -46,7 +56,10 @@ private extension LoginViewController {
             appleLoginButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -100),
             appleLoginButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
             appleLoginButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),
-            appleLoginButton.heightAnchor.constraint(equalToConstant: 44)
+            appleLoginButton.heightAnchor.constraint(equalToConstant: 44),
+            
+            loginSkipButton.topAnchor.constraint(equalTo: appleLoginButton.bottomAnchor, constant: 20),
+            loginSkipButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
         ])
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -8,7 +8,16 @@
 import UIKit
 
 final class LoginViewController: UIViewController {
+    // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureUI()
+    }
+}
+
+// MARK: - UI Setting
+private extension LoginViewController {
+    func configureUI() {
+        view.backgroundColor = .systemBackground
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -8,6 +8,21 @@
 import UIKit
 
 final class LoginViewController: UIViewController {
+
+    // MARK: - UI Components
+    private var googleLoginButton: UIButton = {
+        let button = UIButton()
+        button.setLoginButton(type: .google)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private var appleLoginButton: UIButton = {
+        let button = UIButton()
+        button.setLoginButton(type: .apple)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -19,5 +34,37 @@ final class LoginViewController: UIViewController {
 private extension LoginViewController {
     func configureUI() {
         view.backgroundColor = .systemBackground
+
+        [ googleLoginButton, appleLoginButton ].forEach { view.addSubview($0) }
+        
+        NSLayoutConstraint.activate([
+            googleLoginButton.bottomAnchor.constraint(equalTo: appleLoginButton.topAnchor, constant: -20),
+            googleLoginButton.leadingAnchor.constraint(equalTo: appleLoginButton.leadingAnchor),
+            googleLoginButton.trailingAnchor.constraint(equalTo: appleLoginButton.trailingAnchor),
+            googleLoginButton.heightAnchor.constraint(equalToConstant: 44),
+            
+            appleLoginButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -100),
+            appleLoginButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
+            appleLoginButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),
+            appleLoginButton.heightAnchor.constraint(equalToConstant: 44)
+        ])
+    }
+}
+
+// MARK: - UIButton extension
+fileprivate extension UIButton {
+    func setLoginButton(type: LoginType) {
+        self.setTitle(type.description, for: .normal)
+        self.backgroundColor = .systemBackground
+        self.titleLabel?.font = .systemFont(ofSize: 16)
+        self.setTitleColor(.black, for: .normal)
+        self.titleLabel?.textColor = .black
+        self.layer.cornerRadius = 11
+        self.layer.borderWidth = 1.0
+        self.layer.borderColor = UIColor.systemGray2.cgColor
+        self.layer.shadowColor = UIColor.black.cgColor
+        self.layer.shadowOffset = CGSize(width: 3.0, height: 3.0)
+        self.layer.shadowOpacity = 0.3
+        self.layer.shadowRadius = 2.0
     }
 }


### PR DESCRIPTION
close #29 
## 완료된 기능
- 구글 로그인 버튼 UI 구현
- 애플 로그인 버튼 UI 구현
- 비로그인 버튼 UI 구현
- 로고 UI 구현

## 고민과 해결과정
[버튼 다크모드 대응](https://yeim.notion.site/UIButton-Title-d74b5df592274ff1a0c32789c146b4f3?pvs=4)

## 실행결과
다크모드, 라이트모드의 이미지의 사이즈 크기가 달라서 현재 크기가 다르게 보이는 이슈가 있습니다.
이슈 목록에 추가해놓도록 하겠습니다~~!!

| 다크모드 | 라이트모드  |
| -------- | -------- |
| ![simulator_screenshot_1034AAF7-367B-474A-8E94-6B478DE59602](https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/3501f5f3-dae8-45e8-8bcc-8e72a7ae4145)     | ![simulator_screenshot_E78F8F52-D275-4F53-985D-80492CA19736](https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/fc205bab-9837-49ea-adc5-5e2739065336)     |

