### PR TITLE
[iOS#80] CategoryListCollectionView 파일 생성

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		601773E42B021E6000D175D9 /* TimerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601773E32B021E6000D175D9 /* TimerViewController.swift */; };
 		A18D97900627849B3EFACF76 /* Pods_FlipMate_FlipMateUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */; };
 		EDC851C72B021492009031EA /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC851C62B021492009031EA /* TabBarViewController.swift */; };
+		EDC851D22B04EE83009031EA /* CategoryListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC851D12B04EE83009031EA /* CategoryListCollectionViewCell.swift */; };
 		F7A950D65406B09770F804B3 /* Pods_FlipMateTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6BD4FEF5337019834533B60 /* Pods_FlipMateTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -84,6 +85,7 @@
 		D7C2A09FEADF1334BDCDF5EB /* Pods-FlipMate-FlipMateUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMate-FlipMateUITests.debug.xcconfig"; path = "Target Support Files/Pods-FlipMate-FlipMateUITests/Pods-FlipMate-FlipMateUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		E67C5E61F07640B8F89AB356 /* Pods_FlipMate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EDC851C62B021492009031EA /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
+		EDC851D12B04EE83009031EA /* CategoryListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListCollectionViewCell.swift; sourceTree = "<group>"; };
 		FD66C3A5CB659DEB2A0165B8 /* Pods-FlipMate-FlipMateUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMate-FlipMateUITests.release.xcconfig"; path = "Target Support Files/Pods-FlipMate-FlipMateUITests/Pods-FlipMate-FlipMateUITests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -325,6 +327,7 @@
 			isa = PBXGroup;
 			children = (
 				2C4D55B12B035476006D7C26 /* Model */,
+				EDC851D02B04EE74009031EA /* View */,
 				2C4D55AC2B0348D1006D7C26 /* ViewModel */,
 				2C4D55AE2B0348EC006D7C26 /* ViewController */,
 			);
@@ -497,6 +500,14 @@
 			children = (
 			);
 			path = Repositories;
+			sourceTree = "<group>";
+		};
+		EDC851D02B04EE74009031EA /* View */ = {
+			isa = PBXGroup;
+			children = (
+				EDC851D12B04EE83009031EA /* CategoryListCollectionViewCell.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -719,6 +730,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EDC851D22B04EE83009031EA /* CategoryListCollectionViewCell.swift in Sources */,
 				2C43A0D82B037BBC0005596A /* FeedbackManager.swift in Sources */,
 				2C4D55B02B0348FB006D7C26 /* TimerViewModel.swift in Sources */,
 				2C4D55AB2B033029006D7C26 /* UIView++Extension.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryListCollectionViewCell.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryListCollectionViewCell.swift
@@ -1,0 +1,83 @@
+//
+//  CategoryListCollectionViewCell.swift
+//  FlipMate
+//
+//  Created by 신민규 on 11/15/23.
+//
+
+import UIKit
+import Combine
+
+final class CategoryListCollectionViewCell: UICollectionViewCell {
+    static let cellID = "CategoryListCollectionViewCell"
+    
+    var cancellable: AnyCancellable?
+    
+    private let subjectLabel: UILabel = {
+        let label = UILabel()
+        label.font = FlipMateFont.mediumBold.font
+        label.textColor = UIColor.black
+        label.text = "과목명"
+        return label
+    }()
+    
+    private let timeLabel: UILabel = {
+        let label = UILabel()
+        label.font = FlipMateFont.mediumBold.font
+        label.textColor = UIColor.black
+        label.text = "00:00:00"
+        return label
+    }()
+    
+    private let colorCircle: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "circle.fill")
+        return imageView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Don't use storyboard")
+    }
+}
+
+private extension CategoryListCollectionViewCell {
+    func configureUI() {
+        [colorCircle, subjectLabel, timeLabel].forEach {
+            contentView.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            colorCircle.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24.0),
+            colorCircle.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            colorCircle.widthAnchor.constraint(equalToConstant: 24.0),
+            colorCircle.heightAnchor.constraint(equalToConstant: 24.0)
+        ])
+        
+        NSLayoutConstraint.activate([
+            timeLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: 24.0),
+            timeLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            timeLabel.widthAnchor.constraint(equalToConstant: 120.0),
+            timeLabel.heightAnchor.constraint(equalToConstant: 24.0)
+        ])
+        
+        NSLayoutConstraint.activate([
+            subjectLabel.leadingAnchor.constraint(equalTo: colorCircle.trailingAnchor, constant: 24.0),
+            subjectLabel.trailingAnchor.constraint(equalTo: timeLabel.leadingAnchor),
+            subjectLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            timeLabel.heightAnchor.constraint(equalToConstant: 24.0)
+        ])
+    }
+    
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    CategoryListCollectionViewCell()
+}
+

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryListCollectionViewCell.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryListCollectionViewCell.swift
@@ -9,14 +9,14 @@ import UIKit
 import Combine
 
 final class CategoryListCollectionViewCell: UICollectionViewCell {
-    static let cellID = "CategoryListCollectionViewCell"
+    static let identifier = "CategoryListCollectionViewCell"
     
     var cancellable: AnyCancellable?
     
     private let subjectLabel: UILabel = {
         let label = UILabel()
         label.font = FlipMateFont.mediumBold.font
-        label.textColor = UIColor.black
+        label.textColor = UIColor.label
         label.text = "과목명"
         return label
     }()
@@ -24,7 +24,7 @@ final class CategoryListCollectionViewCell: UICollectionViewCell {
     private let timeLabel: UILabel = {
         let label = UILabel()
         label.font = FlipMateFont.mediumBold.font
-        label.textColor = UIColor.black
+        label.textColor = UIColor.label
         label.text = "00:00:00"
         return label
     }()


### PR DESCRIPTION
close #80 

## 완료된 기능

- CollectionView에 재사용될 Cell Layout 구현

<img width="224" alt="image" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/138603822/62664448-7191-4ffa-8f9b-f80e59e45176">


## 고민과 해결과정

1. 시간 라벨 같은 경우 `59:59`, `01:59:59` 처럼 1시간을 초과한 경우 조금 문제가 있습니다. 텍스트라벨을 오른쪽 정렬하는 기능을 search 하면 쉽게 될 듯 합니다.
2. 추후 카테고리 선택 기능 구현 시 그림자 기능을 Cell 자체에 만들어 두는 것은 부자연스럽겠지요??

+)
추가로 왼쪽에 색깔 라벨은 SFSymbol `"circle.fill"`  사용하였는 데, 색깔 바꾸는 것이 조금 까다로운 것 같네요