### PR TITLE
[iOS#88] pbxproj 수정

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -514,6 +514,7 @@
 			children = (
 			);
 			path = AHAP;
+        };
 		EDC851D02B04EE74009031EA /* View */ = {
 			isa = PBXGroup;
 			children = (


### PR DESCRIPTION
close #88 

## 완료된 기능

pbxproj 파일의 중괄호를 안닫아 발생한 오류

## 고민과 해결과정
