### PR TITLE
[iOS#93] 타이머 페이지 카테고리 리스트 레이아웃

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryListCollectionViewCell.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryListCollectionViewCell.swift
@@ -38,6 +38,7 @@ final class CategoryListCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
+        configureCell()
     }
     
     required init?(coder: NSCoder) {
@@ -74,6 +75,11 @@ private extension CategoryListCollectionViewCell {
         ])
     }
     
+    func configureCell() {
+        layer.borderWidth = 1.0
+        layer.borderColor = FlipMateColor.gray2.color?.cgColor
+        layer.cornerRadius = 8.0
+    }
 }
 
 @available(iOS 17.0, *)

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -108,9 +108,9 @@ final class TimerViewController: BaseViewController {
         
         NSLayoutConstraint.activate([
             categoryListCollectionView.topAnchor.constraint(equalTo: categoryManageButton.bottomAnchor, constant: 10),
-            categoryListCollectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
-            categoryListCollectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
-            categoryListCollectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            categoryListCollectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            categoryListCollectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            categoryListCollectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
         ])
         
         NSLayoutConstraint.activate([
@@ -209,12 +209,12 @@ extension TimerViewController: UICollectionViewDelegate, UICollectionViewDataSou
     
     /// cell size
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: 363, height: 58)
+        return CGSize(width: view.frame.size.width - 20, height: 58)
     }
     
     /// 위아래 간격
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return 3
+        return 10
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -44,21 +44,10 @@ final class TimerViewController: BaseViewController {
         return divider
     }()
     
-    private lazy var categoryInstructionBlock: UIView = {
-        let view = UIView()
-        let label = UILabel()
-        label.text = "관리 버튼을 눌러\n카테고리를 설정해주세요"
-        label.numberOfLines = 2
-        label.textAlignment = .center
-        view.addSubview(label)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
-        ])
-        view.layer.borderWidth = 10
-        view.layer.borderColor = UIColor.gray.cgColor
-        return view
+    private lazy var categoryListCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        return collectionView
     }()
     
     private lazy var categoryManageButton: UIButton = {
@@ -79,6 +68,7 @@ final class TimerViewController: BaseViewController {
     // MARK: - View LifeCycles
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureCollectionView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -94,7 +84,7 @@ final class TimerViewController: BaseViewController {
     override func configureUI() {
         let subViews = [timerLabel,
                         divider,
-                        categoryInstructionBlock,
+                        categoryListCollectionView,
                         categoryManageButton,
                         instructionImage
                         ]
@@ -117,13 +107,14 @@ final class TimerViewController: BaseViewController {
         ])
         
         NSLayoutConstraint.activate([
-            categoryInstructionBlock.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 30),
-            categoryInstructionBlock.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
-            categoryInstructionBlock.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
+            categoryListCollectionView.topAnchor.constraint(equalTo: categoryManageButton.bottomAnchor, constant: 10),
+            categoryListCollectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            categoryListCollectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+            categoryListCollectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
         
         NSLayoutConstraint.activate([
-            categoryManageButton.topAnchor.constraint(equalTo: categoryInstructionBlock.bottomAnchor, constant: 10),
+            categoryManageButton.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 10),
             categoryManageButton.leadingAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.leadingAnchor),
             categoryManageButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
             
@@ -198,7 +189,36 @@ private extension TimerViewController {
     }
 }
 
-@available(iOS 17.0, *)
-#Preview {
-    TimerViewController(timerViewModel: TimerViewModel(timerUseCase: DefaultTimerUseCase()), feedbackManager: FeedbackManager())
+// MARK: CollectionView function
+extension TimerViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    func configureCollectionView() {
+        categoryListCollectionView.register(CategoryListCollectionViewCell.self, forCellWithReuseIdentifier: CategoryListCollectionViewCell.identifier)
+        categoryListCollectionView.delegate = self
+        categoryListCollectionView.dataSource = self
+    }
+    
+    // TODO: Category Model 생성 후 수정
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 10
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryListCollectionViewCell.identifier, for: indexPath) as? CategoryListCollectionViewCell else { return UICollectionViewCell() }
+        return cell
+    }
+    
+    /// cell size
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 363, height: 58)
+    }
+    
+    /// 위아래 간격
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 3
+    }
 }
+
+//@available(iOS 17.0, *)
+//#Preview {
+//    TimerViewController(timerViewModel: TimerViewModel(timerUseCase: DefaultTimerUseCase()), feedbackManager: FeedbackManager())
+//}


### PR DESCRIPTION
## 완료된 기능

타이머 페이지 카테고리 리스트 레이아웃

<img width="224" alt="image" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/138603822/e8a9555e-96d8-4f1e-b40c-65efa06e0357">

추후 Category Model 구현 후 있을 때 / 없을 때 분기로 레이아웃 추가 작업 해야합니다.

## 고민과 해결과정

당장 LayOut 잡기 용으로 Datasource 사용