### PR TITLE
[iOS/#52] 로그인 뷰의 이미지 및 라벨 크기 조정

### DIFF
--- a/iOS/FlipMate/FlipMate/Common/Font/FlipMateFont.swift
+++ b/iOS/FlipMate/FlipMate/Common/Font/FlipMateFont.swift
@@ -23,7 +23,7 @@ enum FlipMateFont {
         case .mediumRegular: return .systemFont(ofSize: 18, weight: .regular)
         case .smallRegular: return .systemFont(ofSize: 14, weight: .regular)
         case .caption: return .systemFont(ofSize: 12, weight: .regular)
-        case .extraLargeBold: return .systemFont(ofSize: 64, weight: .bold)
+        case .extraLargeBold: return .systemFont(ofSize: 58, weight: .bold)
         case .largeBold: return .systemFont(ofSize: 32, weight: .bold)
         case .mediumBold: return .systemFont(ofSize: 18, weight: .bold)
         case .smallBold: return .systemFont(ofSize: 14, weight: .bold)

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -26,7 +26,7 @@ final class LoginViewController: BaseViewController {
     
     private var logoMainTitleLabel: UILabel = {
         let label = UILabel()
-        label.font = FlipMateFont.largeBold.font
+        label.font = FlipMateFont.extraLargeBold.font
         label.textColor = FlipMateColor.darkBlue.color
         label.text = Constant.logoMainTitle
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -35,7 +35,7 @@ final class LoginViewController: BaseViewController {
     
     private var logoSubTitleLabel: UILabel = {
         let label = UILabel()
-        label.font = FlipMateFont.smallBold.font
+        label.font = FlipMateFont.mediumRegular.font
         label.textColor = FlipMateColor.gray2.color
         label.text = Constant.logoSubTitle
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -84,14 +84,14 @@ final class LoginViewController: BaseViewController {
         
         NSLayoutConstraint.activate([
             logoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            logoImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -100),
+            logoImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            logoImageView.widthAnchor.constraint(equalToConstant: 150),
             
             logoMainTitleLabel.bottomAnchor.constraint(equalTo: logoSubTitleLabel.topAnchor, constant: -5),
             logoMainTitleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             
-            logoSubTitleLabel.bottomAnchor.constraint(equalTo: logoImageView.topAnchor, constant: -20),
+            logoSubTitleLabel.bottomAnchor.constraint(equalTo: logoImageView.topAnchor, constant: -50),
             logoSubTitleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            
             
             googleLoginButton.bottomAnchor.constraint(equalTo: appleLoginButton.topAnchor, constant: -20),
             googleLoginButton.leadingAnchor.constraint(equalTo: appleLoginButton.leadingAnchor),
@@ -131,4 +131,9 @@ fileprivate extension UIButton {
         self.layer.borderColor = FlipMateColor.gray2.color?.cgColor
         self.setShadow()
     }
+}
+
+@available(iOS 17, *)
+#Preview {
+    LoginViewController()
 }


### PR DESCRIPTION
## 완료된 기능
- FlipMateFont의 extraLargeBold 폰트 크기 조금 작게 조정
- 폰트 적용 이미지 크기 변경

## 고민과 해결과정
- 제목 타이틀 등 한정적으로 쓰이는 폰트는 그 제목 타이틀이 따로 갖고 있는 것이 좋을까?
- 아니면 공통 폰트를 사용하는 것이 옳을까?