### PR TITLE
[iOS#62] 타이머 뷰 컨트롤러 상수 처리

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -10,7 +10,6 @@ import Combine
 import OSLog
 
 final class TimerViewController: BaseViewController {
-   
     // MARK: - Properties
     private var timerViewModel: TimerViewModelProtocol
     private var feedbackManager: FeedbackManager
@@ -32,7 +31,7 @@ final class TimerViewController: BaseViewController {
     /// 오늘 학습한 총 시간 타이머
     private lazy var timerLabel: UILabel = {
         let label = UILabel()
-        label.text = "00:00:00"
+        label.text = Constant.startTime
         label.font = FlipMateFont.extraLargeBold.font
         label.textColor = .label
         return label
@@ -52,8 +51,8 @@ final class TimerViewController: BaseViewController {
     
     private lazy var categoryManageButton: UIButton = {
         let button = UIButton(type: .custom)
-        button.setImage(UIImage(systemName: "gearshape"), for: .normal)
-        button.setTitle("관리", for: .normal)
+        button.setImage(UIImage(systemName: Constant.categoryManageButtonImageName), for: .normal)
+        button.setTitle(Constant.categoryManageButtonTitle, for: .normal)
         button.setTitleColor(FlipMateColor.gray1.color, for: .normal)
         button.tintColor = FlipMateColor.gray1.color
         button.layer.borderWidth = 1.0
@@ -219,6 +218,15 @@ extension TimerViewController: UICollectionViewDelegate, UICollectionViewDataSou
     /// 위아래 간격
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 10
+    }
+}
+        
+// MARK: - Constants
+private extension TimerViewController {
+    enum Constant {
+        static let startTime = "00:00:00"
+        static let categoryManageButtonImageName = "gearshape"
+        static let categoryManageButtonTitle = "관리"
     }
 }
 


### PR DESCRIPTION
close #62 

## 완료된 기능
- 관리 버튼의 이미지 이름과 타이틀 리터럴 상수화
- 타이머 시간의 초기 시간 리터럴 상수화

## 고민과 해결과정
- 상수를 담는 타입의 위치를 고민해 보았는데, 타이머 뷰 컨트롤러에서만 사용하기 때문에 타이머 뷰 컨트롤러 내부에 private한 enum을 선언해 주었습니다.