### PR TITLE
[iOS#99] 탭바 다크모드 대응

### DIFF
--- a/iOS/FlipMate/FlipMate/Common/Color/FlipMateColor.swift
+++ b/iOS/FlipMate/FlipMate/Common/Color/FlipMateColor.swift
@@ -13,6 +13,8 @@ enum FlipMateColor {
     case gray2
     case gray3
     case gray4
+    case tabBarColor
+    case tabBarLayerColor
 
     var color: UIColor? {
         switch self {
@@ -26,6 +28,10 @@ enum FlipMateColor {
             return UIColor(named: "Gray3")
         case .gray4:
             return UIColor(named: "Gray4")
+        case .tabBarColor:
+            return UIColor(named: "TabBarColor")
+        case .tabBarLayerColor:
+            return UIColor(named: "TabBarLayerColor")
         }
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TabBarViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBarViewController.swift
@@ -24,7 +24,7 @@ final class TabBarViewController: UITabBarController {
         button.layer.borderWidth = Constant.borderWidth
         button.backgroundColor = FlipMateColor.tabBarColor.color
         button.layer.borderColor = FlipMateColor.gray2.color?.cgColor
-        button.tintColor = FlipMateColor.gray3.color
+        button.tintColor = FlipMateColor.gray2.color
         button.addTarget(self, action: #selector(timerButtonAction(sender:)), for: .touchUpInside)
         button.setShadow()
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/iOS/FlipMate/FlipMate/Presentation/TabBarViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBarViewController.swift
@@ -9,16 +9,31 @@ import UIKit
 
 final class TabBarViewController: UITabBarController {
 
+    private lazy var timerButton: UIButton = {
+        let button = UIButton()
+        button.layer.borderWidth = 0.5
+        button.backgroundColor = FlipMateColor.tabBarColor.color
+        button.layer.borderColor = FlipMateColor.gray2.color?.cgColor
+        button.tintColor = FlipMateColor.gray3.color
+        button.addTarget(self, action: #selector(timerButtonAction(sender:)), for: .touchUpInside)
+        button.setShadow()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: "timer",
+                                     withConfiguration: UIImage.SymbolConfiguration(font: .systemFont(ofSize: 40))),
+                                     for: .normal)
+        return button
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        setUpUI()
+        configureUI()
         configureTabBar()
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         setupFrame()
-        configureTimerButton()
+        setUpTimerButton()
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -30,7 +45,7 @@ final class TabBarViewController: UITabBarController {
 
 // MARK: - UI Setting
 private extension TabBarViewController {
-    func setUpUI() {
+    func configureUI() {
         let timerViewController = TimerViewController(timerViewModel: TimerViewModel(timerUseCase: DefaultTimerUseCase()), feedbackManager: FeedbackManager())
         let socialViewController = SocialViewController()
         let chartViewController = ChartViewController()
@@ -61,31 +76,18 @@ private extension TabBarViewController {
         self.tabBar.layer.borderWidth = 1
         self.tabBar.layer.borderColor = FlipMateColor.tabBarLayerColor.color?.cgColor
         self.tabBar.layer.backgroundColor = FlipMateColor.tabBarColor.color?.cgColor
+        view.addSubview(timerButton)
     }
 
-    func configureTimerButton() {
-        let timerButton = UIButton(frame: CGRect(x: 0, y: 0,
-                                                 width: self.tabBar.frame.size.height * 0.5 + 45,
-                                                 height: self.tabBar.frame.size.height * 0.5 + 45))
-        var timerButtonFrame = timerButton.frame
-        timerButtonFrame.origin.y = view.bounds.height - timerButtonFrame.height - self.tabBar.frame.size.height / 2 + 10
-        timerButtonFrame.origin.x = view.bounds.width / 2 - timerButtonFrame.size.width / 2
-        timerButton.frame = timerButtonFrame
-
-        timerButton.backgroundColor = FlipMateColor.tabBarColor.color
-        timerButton.layer.cornerRadius = timerButtonFrame.height / 2
-        timerButton.layer.borderWidth = 0.5
-        timerButton.layer.borderColor = FlipMateColor.gray2.color?.cgColor
-        timerButton.tintColor = FlipMateColor.gray3.color
-        timerButton.setShadow()
-        view.addSubview(timerButton)
-
-        timerButton.setImage(UIImage(systemName: "timer",
-                                     withConfiguration: UIImage.SymbolConfiguration(font: .systemFont(ofSize: 40))),
-                                     for: .normal)
-        timerButton.addTarget(self, action: #selector(timerButtonAction(sender:)), for: .touchUpInside)
-
-        view.layoutIfNeeded()
+    func setUpTimerButton() {
+        let tabBarHeight = tabBar.frame.size.height
+        timerButton.layer.cornerRadius = tabBarHeight / 2
+        NSLayoutConstraint.activate([
+            timerButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            timerButton.widthAnchor.constraint(equalToConstant: tabBarHeight),
+            timerButton.heightAnchor.constraint(equalToConstant: tabBarHeight),
+            timerButton.topAnchor.constraint(equalTo: view.bottomAnchor, constant: -tabBarHeight * 1.5)
+        ])
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/TabBarViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBarViewController.swift
@@ -12,12 +12,19 @@ final class TabBarViewController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpUI()
+        configureTabBar()
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         setupFrame()
         configureTimerButton()
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        self.tabBar.layer.backgroundColor = FlipMateColor.tabBarColor.color?.cgColor
+        self.tabBar.layer.borderColor = FlipMateColor.tabBarLayerColor.color?.cgColor
     }
 }
 
@@ -41,9 +48,6 @@ private extension TabBarViewController {
         setViewControllers([navigationSocial, navigationTimer, navigationChart], animated: false)
 
         self.selectedIndex = 1
-        self.tabBar.layer.borderWidth = 1
-        self.tabBar.layer.borderColor = UIColor.lightGray.cgColor
-        self.tabBar.layer.backgroundColor = UIColor.white.cgColor
     }
 
     func setupFrame() {
@@ -51,6 +55,12 @@ private extension TabBarViewController {
         tabFrame.size.height += 10
         tabFrame.origin.y = self.view.frame.size.height - tabFrame.size.height
         self.tabBar.frame = tabFrame
+    }
+    
+    func configureTabBar() {
+        self.tabBar.layer.borderWidth = 1
+        self.tabBar.layer.borderColor = FlipMateColor.tabBarLayerColor.color?.cgColor
+        self.tabBar.layer.backgroundColor = FlipMateColor.tabBarColor.color?.cgColor
     }
 
     func configureTimerButton() {
@@ -62,10 +72,11 @@ private extension TabBarViewController {
         timerButtonFrame.origin.x = view.bounds.width / 2 - timerButtonFrame.size.width / 2
         timerButton.frame = timerButtonFrame
 
-        timerButton.backgroundColor = .white
+        timerButton.backgroundColor = FlipMateColor.tabBarColor.color
         timerButton.layer.cornerRadius = timerButtonFrame.height / 2
         timerButton.layer.borderWidth = 0.5
-        timerButton.layer.borderColor = UIColor.lightGray.cgColor
+        timerButton.layer.borderColor = FlipMateColor.gray2.color?.cgColor
+        timerButton.tintColor = FlipMateColor.gray3.color
         timerButton.setShadow()
         view.addSubview(timerButton)
 
@@ -74,7 +85,6 @@ private extension TabBarViewController {
                                      for: .normal)
         timerButton.addTarget(self, action: #selector(timerButtonAction(sender:)), for: .touchUpInside)
 
-        timerButton.tintColor = .darkGray
         view.layoutIfNeeded()
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TabBarViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBarViewController.swift
@@ -9,17 +9,27 @@ import UIKit
 
 final class TabBarViewController: UITabBarController {
 
+    private enum Constant {
+        static let timerImageName = "timer"
+        static let socialNomalImageName = "person.3"
+        static let socialSelectedImageName = "person.3.fill"
+        static let chartNomalImageName = "chart.bar"
+        static let chartSelectedImageName = "chart.bar.fill"
+        static let borderWidth: CGFloat = 1.0
+        static let timerImageSize: CGFloat = 40
+    }
+    
     private lazy var timerButton: UIButton = {
         let button = UIButton()
-        button.layer.borderWidth = 0.5
+        button.layer.borderWidth = Constant.borderWidth
         button.backgroundColor = FlipMateColor.tabBarColor.color
         button.layer.borderColor = FlipMateColor.gray2.color?.cgColor
         button.tintColor = FlipMateColor.gray3.color
         button.addTarget(self, action: #selector(timerButtonAction(sender:)), for: .touchUpInside)
         button.setShadow()
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setImage(UIImage(systemName: "timer",
-                                     withConfiguration: UIImage.SymbolConfiguration(font: .systemFont(ofSize: 40))),
+        button.setImage(UIImage(systemName: Constant.timerImageName,
+                                withConfiguration: UIImage.SymbolConfiguration(font: .systemFont(ofSize: Constant.timerImageSize))),
                                      for: .normal)
         return button
     }()
@@ -50,11 +60,11 @@ private extension TabBarViewController {
         let socialViewController = SocialViewController()
         let chartViewController = ChartViewController()
 
-        socialViewController.tabBarItem.image = UIImage(systemName: "person.3")
-        socialViewController.tabBarItem.selectedImage = UIImage(systemName: "person.3.fill")
+        socialViewController.tabBarItem.image = UIImage(systemName: Constant.socialNomalImageName)
+        socialViewController.tabBarItem.selectedImage = UIImage(systemName: Constant.socialSelectedImageName)
 
-        chartViewController.tabBarItem.image = UIImage(systemName: "chart.bar")
-        chartViewController.tabBarItem.selectedImage = UIImage(systemName: "chart.bar.fill")
+        chartViewController.tabBarItem.image = UIImage(systemName: Constant.chartNomalImageName)
+        chartViewController.tabBarItem.selectedImage = UIImage(systemName: Constant.chartSelectedImageName)
 
         let navigationTimer = UINavigationController(rootViewController: timerViewController)
         let navigationSocial = UINavigationController(rootViewController: socialViewController)
@@ -73,7 +83,7 @@ private extension TabBarViewController {
     }
     
     func configureTabBar() {
-        tabBar.layer.borderWidth = 1
+        tabBar.layer.borderWidth = Constant.borderWidth
         tabBar.layer.borderColor = FlipMateColor.tabBarLayerColor.color?.cgColor
         tabBar.layer.backgroundColor = FlipMateColor.tabBarColor.color?.cgColor
         view.addSubview(timerButton)

--- a/iOS/FlipMate/FlipMate/Presentation/TabBarViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBarViewController.swift
@@ -38,8 +38,8 @@ final class TabBarViewController: UITabBarController {
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        self.tabBar.layer.backgroundColor = FlipMateColor.tabBarColor.color?.cgColor
-        self.tabBar.layer.borderColor = FlipMateColor.tabBarLayerColor.color?.cgColor
+        tabBar.layer.backgroundColor = FlipMateColor.tabBarColor.color?.cgColor
+        tabBar.layer.borderColor = FlipMateColor.tabBarLayerColor.color?.cgColor
     }
 }
 
@@ -62,20 +62,20 @@ private extension TabBarViewController {
 
         setViewControllers([navigationSocial, navigationTimer, navigationChart], animated: false)
 
-        self.selectedIndex = 1
+        selectedIndex = 1
     }
 
     func setupFrame() {
-        var tabFrame = self.tabBar.frame
+        var tabFrame = tabBar.frame
         tabFrame.size.height += 10
-        tabFrame.origin.y = self.view.frame.size.height - tabFrame.size.height
-        self.tabBar.frame = tabFrame
+        tabFrame.origin.y = view.frame.size.height - tabFrame.size.height
+        tabBar.frame = tabFrame
     }
     
     func configureTabBar() {
-        self.tabBar.layer.borderWidth = 1
-        self.tabBar.layer.borderColor = FlipMateColor.tabBarLayerColor.color?.cgColor
-        self.tabBar.layer.backgroundColor = FlipMateColor.tabBarColor.color?.cgColor
+        tabBar.layer.borderWidth = 1
+        tabBar.layer.borderColor = FlipMateColor.tabBarLayerColor.color?.cgColor
+        tabBar.layer.backgroundColor = FlipMateColor.tabBarColor.color?.cgColor
         view.addSubview(timerButton)
     }
 

--- a/iOS/FlipMate/FlipMate/Resources/Assets.xcassets/FilpMateColor/TabBarColor.colorset/Contents.json
+++ b/iOS/FlipMate/FlipMate/Resources/Assets.xcassets/FilpMateColor/TabBarColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.362",
+          "green" : "0.205",
+          "red" : "0.187"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/FlipMate/FlipMate/Resources/Assets.xcassets/FilpMateColor/TabBarLayerColor.colorset/Contents.json
+++ b/iOS/FlipMate/FlipMate/Resources/Assets.xcassets/FilpMateColor/TabBarLayerColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.553",
+          "green" : "0.553",
+          "red" : "0.553"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.362",
+          "green" : "0.205",
+          "red" : "0.187"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
closed #99 
## 완료된 기능
- TabBar 백그라운드 컬러에 대응되는 컬러 Asset 추가
- TabBar Layer BorderColor에 대응되는 컬러 Asset 추가
- 탭 전환 시 타이머 버튼이 지속적으로 생성되는 이슈 수정

## 고민과 해결과정
### CGColor 다크모드 대응
기존에 AssetCatalog로 Dynamic Color를 생성해서 다크모드에 대응했었지만
CGColor는 컴파일 시점에 다크모드와 라이트모드 대응이 되지만 런타임 시점에 사용자 테마가 바뀌게 되면 자동으로 적용이 안되는 문제가 있었습니다. traitCollectionDidChange 메소드를 오버라이드하여 사용자 디바이스의 테마가 바뀔 때 마다 컬러를 다시 설정해주었습니다.

## 실행 결과

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/880cfa7e-524a-4f48-9e03-68147c71e25f


