### PR TITLE
[iOS#112] 카테고리 관리 화면 UI 구현

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
+		2CE84EF72B0B7F3C00E2FB71 /* CategorySettingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF62B0B7F3C00E2FB71 /* CategorySettingSection.swift */; };
 		600908BE2AFCD7DF0065DFFB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908BD2AFCD7DF0065DFFB /* AppDelegate.swift */; };
 		600908C02AFCD7DF0065DFFB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908BF2AFCD7DF0065DFFB /* SceneDelegate.swift */; };
 		600908C22AFCD7DF0065DFFB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908C12AFCD7DF0065DFFB /* ViewController.swift */; };
@@ -86,6 +87,7 @@
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
 		2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell++Extension.swift"; sourceTree = "<group>"; };
+		2CE84EF62B0B7F3C00E2FB71 /* CategorySettingSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingSection.swift; sourceTree = "<group>"; };
 		52B11F58319D7A81A41943F5 /* Pods-FlipMateTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMateTests.debug.xcconfig"; path = "Target Support Files/Pods-FlipMateTests/Pods-FlipMateTests.debug.xcconfig"; sourceTree = "<group>"; };
 		600908BA2AFCD7DF0065DFFB /* FlipMate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FlipMate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		600908BD2AFCD7DF0065DFFB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 			children = (
 				2C4D55B22B035484006D7C26 /* DeviceOrientation.swift */,
 				ED9B2A7E2B06033F008FE1C5 /* Category.swift */,
+				2CE84EF62B0B7F3C00E2FB71 /* CategorySettingSection.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -830,6 +833,7 @@
 				2C5CDA5B2B025440007AFC57 /* ChartViewController.swift in Sources */,
 				600908BE2AFCD7DF0065DFFB /* AppDelegate.swift in Sources */,
 				2C5CDA562B025426007AFC57 /* BaseViewController.swift in Sources */,
+				2CE84EF72B0B7F3C00E2FB71 /* CategorySettingSection.swift in Sources */,
 				2C6717F82B0535A8004D118D /* Int++Extension.swift in Sources */,
 				ED9B2A7F2B06033F008FE1C5 /* Category.swift in Sources */,
 				2C4D55B32B035484006D7C26 /* DeviceOrientation.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		2C801D802B04B68900A7ABAE /* TimerUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C801D7F2B04B68900A7ABAE /* TimerUseCase.swift */; };
 		2C801D832B04C64F00A7ABAE /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C801D822B04C64F00A7ABAE /* TimerManager.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
+		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
+		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
 		600908BE2AFCD7DF0065DFFB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908BD2AFCD7DF0065DFFB /* AppDelegate.swift */; };
 		600908C02AFCD7DF0065DFFB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908BF2AFCD7DF0065DFFB /* SceneDelegate.swift */; };
 		600908C22AFCD7DF0065DFFB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908C12AFCD7DF0065DFFB /* ViewController.swift */; };
@@ -82,6 +84,8 @@
 		2C801D822B04C64F00A7ABAE /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
+		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
+		2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell++Extension.swift"; sourceTree = "<group>"; };
 		52B11F58319D7A81A41943F5 /* Pods-FlipMateTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMateTests.debug.xcconfig"; path = "Target Support Files/Pods-FlipMateTests/Pods-FlipMateTests.debug.xcconfig"; sourceTree = "<group>"; };
 		600908BA2AFCD7DF0065DFFB /* FlipMate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FlipMate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		600908BD2AFCD7DF0065DFFB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -478,6 +482,8 @@
 		600908FF2AFCDF990065DFFB /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */,
+				2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -828,12 +834,14 @@
 				ED9B2A7F2B06033F008FE1C5 /* Category.swift in Sources */,
 				2C4D55B32B035484006D7C26 /* DeviceOrientation.swift in Sources */,
 				EDC851C72B021492009031EA /* TabBarViewController.swift in Sources */,
+				2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */,
 				2C5CDA572B025426007AFC57 /* FlipMateColor.swift in Sources */,
 				600908C02AFCD7DF0065DFFB /* SceneDelegate.swift in Sources */,
 				2C5CDA4F2B025403007AFC57 /* SocialViewController.swift in Sources */,
 				ED9B2A812B06048D008FE1C5 /* CategoryViewModel.swift in Sources */,
 				60DE49402B05E67200ACE6DD /* FlipMateConstant.swift in Sources */,
 				2C801D832B04C64F00A7ABAE /* TimerManager.swift in Sources */,
+				2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */,
 				EDC851D92B05C37C009031EA /* DeviceMotionManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		2C801D7E2B04B65400A7ABAE /* DefaultTimerUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C801D7D2B04B65400A7ABAE /* DefaultTimerUseCase.swift */; };
 		2C801D802B04B68900A7ABAE /* TimerUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C801D7F2B04B68900A7ABAE /* TimerUseCase.swift */; };
 		2C801D832B04C64F00A7ABAE /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C801D822B04C64F00A7ABAE /* TimerManager.swift */; };
+		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		600908BE2AFCD7DF0065DFFB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908BD2AFCD7DF0065DFFB /* AppDelegate.swift */; };
 		600908C02AFCD7DF0065DFFB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908BF2AFCD7DF0065DFFB /* SceneDelegate.swift */; };
 		600908C22AFCD7DF0065DFFB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908C12AFCD7DF0065DFFB /* ViewController.swift */; };
@@ -80,6 +81,7 @@
 		2C801D7F2B04B68900A7ABAE /* TimerUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerUseCase.swift; sourceTree = "<group>"; };
 		2C801D822B04C64F00A7ABAE /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		52B11F58319D7A81A41943F5 /* Pods-FlipMateTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMateTests.debug.xcconfig"; path = "Target Support Files/Pods-FlipMateTests/Pods-FlipMateTests.debug.xcconfig"; sourceTree = "<group>"; };
 		600908BA2AFCD7DF0065DFFB /* FlipMate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FlipMate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		600908BD2AFCD7DF0065DFFB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 			isa = PBXGroup;
 			children = (
 				601773E32B021E6000D175D9 /* TimerViewController.swift */,
+				2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -811,6 +814,7 @@
 				2C801D7E2B04B65400A7ABAE /* DefaultTimerUseCase.swift in Sources */,
 				2C4D55AB2B033029006D7C26 /* UIView++Extension.swift in Sources */,
 				2C5CDA4B2B0252C1007AFC57 /* LoginType.swift in Sources */,
+				2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */,
 				2C5CDA482B0252B2007AFC57 /* LoginViewController.swift in Sources */,
 				2C5CDA582B025426007AFC57 /* FlipMateFont.swift in Sources */,
 				60DE493D2B05DEA400ACE6DD /* FlipMateLogger.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
 		2CE84EF72B0B7F3C00E2FB71 /* CategorySettingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF62B0B7F3C00E2FB71 /* CategorySettingSection.swift */; };
+		2CE84EF92B0B8A0B00E2FB71 /* CategorySettingFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF82B0B8A0B00E2FB71 /* CategorySettingFooterView.swift */; };
+		2CE84EFB2B0B92BA00E2FB71 /* UICollectionReusableView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EFA2B0B92BA00E2FB71 /* UICollectionReusableView++Extension.swift */; };
 		600908BE2AFCD7DF0065DFFB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908BD2AFCD7DF0065DFFB /* AppDelegate.swift */; };
 		600908C02AFCD7DF0065DFFB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908BF2AFCD7DF0065DFFB /* SceneDelegate.swift */; };
 		600908C22AFCD7DF0065DFFB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600908C12AFCD7DF0065DFFB /* ViewController.swift */; };
@@ -88,6 +90,8 @@
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
 		2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell++Extension.swift"; sourceTree = "<group>"; };
 		2CE84EF62B0B7F3C00E2FB71 /* CategorySettingSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingSection.swift; sourceTree = "<group>"; };
+		2CE84EF82B0B8A0B00E2FB71 /* CategorySettingFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingFooterView.swift; sourceTree = "<group>"; };
+		2CE84EFA2B0B92BA00E2FB71 /* UICollectionReusableView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionReusableView++Extension.swift"; sourceTree = "<group>"; };
 		52B11F58319D7A81A41943F5 /* Pods-FlipMateTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMateTests.debug.xcconfig"; path = "Target Support Files/Pods-FlipMateTests/Pods-FlipMateTests.debug.xcconfig"; sourceTree = "<group>"; };
 		600908BA2AFCD7DF0065DFFB /* FlipMate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FlipMate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		600908BD2AFCD7DF0065DFFB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -487,6 +491,7 @@
 			children = (
 				2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */,
 				2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */,
+				2CE84EFA2B0B92BA00E2FB71 /* UICollectionReusableView++Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -583,6 +588,7 @@
 			isa = PBXGroup;
 			children = (
 				EDC851D12B04EE83009031EA /* CategoryListCollectionViewCell.swift */,
+				2CE84EF82B0B8A0B00E2FB71 /* CategorySettingFooterView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -832,10 +838,12 @@
 				600908C22AFCD7DF0065DFFB /* ViewController.swift in Sources */,
 				2C5CDA5B2B025440007AFC57 /* ChartViewController.swift in Sources */,
 				600908BE2AFCD7DF0065DFFB /* AppDelegate.swift in Sources */,
+				2CE84EFB2B0B92BA00E2FB71 /* UICollectionReusableView++Extension.swift in Sources */,
 				2C5CDA562B025426007AFC57 /* BaseViewController.swift in Sources */,
 				2CE84EF72B0B7F3C00E2FB71 /* CategorySettingSection.swift in Sources */,
 				2C6717F82B0535A8004D118D /* Int++Extension.swift in Sources */,
 				ED9B2A7F2B06033F008FE1C5 /* Category.swift in Sources */,
+				2CE84EF92B0B8A0B00E2FB71 /* CategorySettingFooterView.swift in Sources */,
 				2C4D55B32B035484006D7C26 /* DeviceOrientation.swift in Sources */,
 				EDC851C72B021492009031EA /* TabBarViewController.swift in Sources */,
 				2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Model/CategorySettingSection.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Model/CategorySettingSection.swift
@@ -31,7 +31,7 @@ extension CategorySettingSection {
     var footerSize: NSCollectionLayoutSize {
         return NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(58))
+            heightDimension: .absolute(58))
     }
     
     var sectionInset: NSDirectionalEdgeInsets {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Model/CategorySettingSection.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Model/CategorySettingSection.swift
@@ -14,3 +14,31 @@ enum CategorySettingSection: Hashable {
 enum CategorySettingItem: Hashable {
     case categoryCell
 }
+
+extension CategorySettingSection {
+    var itemSize: NSCollectionLayoutSize {
+        return NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(58))
+    }
+    
+    var groupSize: NSCollectionLayoutSize {
+        return NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(58))
+    }
+    
+    var footerSize: NSCollectionLayoutSize {
+        return NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(58))
+    }
+    
+    var sectionInset: NSDirectionalEdgeInsets {
+        return NSDirectionalEdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20)
+    }
+    
+    var itemSpacing: CGFloat {
+        return 10
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Model/CategorySettingSection.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Model/CategorySettingSection.swift
@@ -1,0 +1,16 @@
+//
+//  CategorySettingSection.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/20.
+//
+
+import UIKit
+
+enum CategorySettingSection: Hashable {
+    case categorySection([CategorySettingItem])
+}
+
+enum CategorySettingItem: Hashable {
+    case categoryCell
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
@@ -12,7 +12,7 @@ final class CategorySettingFooterView: UICollectionReusableView {
     private enum Constant {
         static let addButtonTitle = "카테고리 추가 +"
         static let addButtonborderWidth: CGFloat = 1
-        static let addButtoncorenrRedius: CGFloat = 8
+        static let addButtoncornerRedius: CGFloat = 8
     }
     
     // MARK: - UI Components
@@ -23,7 +23,7 @@ final class CategorySettingFooterView: UICollectionReusableView {
         button.titleLabel?.font = FlipMateFont.mediumBold.font
         button.layer.borderColor = FlipMateColor.gray2.color?.cgColor
         button.layer.borderWidth = Constant.addButtonborderWidth
-        button.layer.cornerRadius = Constant.addButtoncorenrRedius
+        button.layer.cornerRadius = Constant.addButtoncornerRedius
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
@@ -1,0 +1,55 @@
+//
+//  CategorySettingFooterView.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/20.
+//
+
+import UIKit
+
+final class CategorySettingFooterView: UICollectionReusableView {
+    // MARK: - Constant
+    private enum Constant {
+        static let addButtonTitle = "카테고리 추가 +"
+        static let addButtonborderWidth: CGFloat = 1
+        static let addButtoncorenrRedius: CGFloat = 8
+    }
+    
+    // MARK: - UI Components
+    private lazy var addButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(Constant.addButtonTitle, for: .normal)
+        button.setTitleColor(FlipMateColor.gray2.color, for: .normal)
+        button.titleLabel?.font = FlipMateFont.mediumBold.font
+        button.layer.borderColor = FlipMateColor.gray2.color?.cgColor
+        button.layer.borderWidth = Constant.addButtonborderWidth
+        button.layer.cornerRadius = Constant.addButtoncorenrRedius
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureUI()
+    }
+}
+
+// MARK: - UI Setting
+private extension CategorySettingFooterView {
+    func configureUI() {
+        addSubview(addButton)
+        
+        NSLayoutConstraint.activate([
+            addButton.topAnchor.constraint(equalTo: topAnchor),
+            addButton.leadingAnchor.constraint(equalTo: leadingAnchor),
+            addButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+            addButton.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
@@ -35,8 +35,7 @@ final class CategorySettingFooterView: UICollectionReusableView {
     }
     
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        configureUI()
+        fatalError("Don't use storyboard")
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -1,0 +1,29 @@
+//
+//  CategorySettingViewController.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/20.
+//
+
+import UIKit
+
+class CategorySettingViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -8,16 +8,25 @@
 import UIKit
 
 final class CategorySettingViewController: BaseViewController {
+    typealias CateogoryDataSource = UICollectionViewDiffableDataSource<CategorySettingSection,CategorySettingItem>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<CategorySettingSection, CategorySettingItem>
+
+    // MARK: - Properties
+    private var dataSource: CateogoryDataSource?
+    
     // MARK: - UI Components
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.register(CategoryListCollectionViewCell.self)
         return collectionView
     }()
     
     // MARK: - Life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        setDataSource()
+        setSnapshot()
     }
     
     // MARK: - Configure UI
@@ -30,6 +39,27 @@ final class CategorySettingViewController: BaseViewController {
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
+    }
+}
+
+// MARK: - DiffableDataSource
+private extension CategorySettingViewController {
+    func setDataSource() {
+        dataSource = CateogoryDataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            switch itemIdentifier {
+            case .categoryCell:
+                let cell: CategoryListCollectionViewCell = collectionView.dequeueReusableCell(for: indexPath)
+                return cell
+            }
+        })
+    }
+    
+    func setSnapshot() {
+        var snapshot = Snapshot()
+        let sections: [CategorySettingSection] = [.categorySection([])]
+        snapshot.appendSections(sections)
+        snapshot.appendItems([CategorySettingItem.categoryCell])
+        dataSource?.apply(snapshot)
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -7,23 +7,33 @@
 
 import UIKit
 
-class CategorySettingViewController: UIViewController {
-
+final class CategorySettingViewController: BaseViewController {
+    // MARK: - UI Components
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        return collectionView
+    }()
+    
+    // MARK: - Life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    // MARK: - Configure UI
+    override func configureUI() {
+        view.addSubview(collectionView)
+        
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
     }
-    */
+}
 
+@available(iOS 17.0, *)
+#Preview {
+    CategorySettingViewController()
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -16,7 +16,7 @@ final class CategorySettingViewController: BaseViewController {
     
     // MARK: - UI Components
     private lazy var collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: setCollectionViewLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.register(CategoryListCollectionViewCell.self)
         return collectionView
@@ -60,6 +60,25 @@ private extension CategorySettingViewController {
         snapshot.appendSections(sections)
         snapshot.appendItems([CategorySettingItem.categoryCell])
         dataSource?.apply(snapshot)
+    }
+}
+
+// MARK: - CompositionalLayout
+private extension CategorySettingViewController {
+    func makeLayoutSection(sectionType: CategorySettingSection) -> NSCollectionLayoutSection {
+        let item = NSCollectionLayoutItem(layoutSize: sectionType.itemSize)
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: sectionType.groupSize, subitems: [item])
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = sectionType.sectionInset
+        section.interGroupSpacing = sectionType.itemSpacing
+        return section
+    }
+    
+    func setCollectionViewLayout() -> UICollectionViewCompositionalLayout {
+        return UICollectionViewCompositionalLayout { [weak self] sectionIndex, _ in
+            guard let sectionType = self?.dataSource?.snapshot().sectionIdentifiers[sectionIndex] else { return nil }
+            return self?.makeLayoutSection(sectionType: sectionType)
+        }
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -19,6 +19,7 @@ final class CategorySettingViewController: BaseViewController {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: setCollectionViewLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.register(CategoryListCollectionViewCell.self)
+        collectionView.register(CategorySettingFooterView.self, kind: .footer)
         return collectionView
     }()
     
@@ -52,6 +53,11 @@ private extension CategorySettingViewController {
                 return cell
             }
         })
+        
+        dataSource?.supplementaryViewProvider = { collectionView, kind, indexPath in
+            let footer: CategorySettingFooterView = collectionView.dequeueReusableView(for: indexPath, kind: kind)
+            return footer
+        }
     }
     
     func setSnapshot() {
@@ -69,6 +75,11 @@ private extension CategorySettingViewController {
         let item = NSCollectionLayoutItem(layoutSize: sectionType.itemSize)
         let group = NSCollectionLayoutGroup.vertical(layoutSize: sectionType.groupSize, subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
+        let footer = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: sectionType.footerSize,
+            elementKind: UICollectionView.elementKindSectionFooter,
+            alignment: .bottom)
+        section.boundarySupplementaryItems = [footer]
         section.contentInsets = sectionType.sectionInset
         section.interGroupSpacing = sectionType.itemSpacing
         return section

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/UICollectionReusableView++Extension.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/UICollectionReusableView++Extension.swift
@@ -1,0 +1,10 @@
+//
+//  UICollectionReusableView++Extension.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/20.
+//
+
+import UIKit
+
+extension UICollectionReusableView: ReusableView {}

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/UICollectionView++Extension.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/UICollectionView++Extension.swift
@@ -1,0 +1,24 @@
+//
+//  UICollectionView++Extension.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/20.
+//
+
+import UIKit
+
+extension UICollectionView {
+    /// UICollectionViewCell을 상속하는 Cell 타입을 전달받아 해당 Cell을 collectionView에 등록합니다.
+    func register<T: UICollectionViewCell>(_: T.Type) {
+        register(T.self, forCellWithReuseIdentifier: T.defaultReuseIdentifier)
+    }
+    
+    /// IndexPath에 따라 전달받은 Cell 타입에 맞는 Cell을 가져옵니다.
+    /// 만약 전달받은 T 타입으로 캐스팅 할 수 없으면 fatalError 발생시킵니다.
+    func dequeueReusableCell<T: UICollectionViewCell>(for indexPath: IndexPath) -> T {
+        guard let cell = dequeueReusableCell(withReuseIdentifier: T.defaultReuseIdentifier, for: indexPath) as? T else {
+            fatalError("identifier가 \(T.defaultReuseIdentifier)인 Cell을 dequeue할 수 없습니다.")
+        }
+        return cell
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/UICollectionView++Extension.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/UICollectionView++Extension.swift
@@ -8,6 +8,20 @@
 import UIKit
 
 extension UICollectionView {
+    enum SupplementaryViewKind {
+        case header
+        case footer
+        
+        var identifier: String {
+            switch self {
+            case .header:
+                return UICollectionView.elementKindSectionHeader
+            case .footer:
+                return UICollectionView.elementKindSectionFooter
+            }
+        }
+    }
+    
     /// UICollectionViewCell을 상속하는 Cell 타입을 전달받아 해당 Cell을 collectionView에 등록합니다.
     func register<T: UICollectionViewCell>(_: T.Type) {
         register(T.self, forCellWithReuseIdentifier: T.defaultReuseIdentifier)
@@ -20,5 +34,21 @@ extension UICollectionView {
             fatalError("identifier가 \(T.defaultReuseIdentifier)인 Cell을 dequeue할 수 없습니다.")
         }
         return cell
+    }
+    
+    /// UICollectionReusableView을 상속하는 ReusableView 타입과 종류를 전달받아 해당 ReusableVeiw을 collectionView에 등록합니다.
+    func register<T: UICollectionReusableView>(_: T.Type, kind: SupplementaryViewKind) {
+        register(T.self,
+                 forSupplementaryViewOfKind: kind.identifier,
+                 withReuseIdentifier: T.defaultReuseIdentifier)
+    }
+    
+    /// IndexPath와 ReusableView 종류에 따라 전달받은 ReusableView 타입에 맞는 ReusableView을 가져옵니다.
+    /// 만약 전달받은 T 타입으로 캐스팅 할 수 없으면 fatalError 발생시킵니다.
+    func dequeueReusableView<T: UICollectionReusableView>(for indexPath: IndexPath, kind: String) -> T {
+        guard let view = dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: T.defaultReuseIdentifier, for: indexPath) as? T else {
+            fatalError("identifier가 \(T.defaultReuseIdentifier)인 View을 dequeue할 수 없습니다.")
+        }
+        return view
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/UICollectionViewCell++Extension.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/UICollectionViewCell++Extension.swift
@@ -1,0 +1,20 @@
+//
+//  UICollectionViewCell++Extension.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/20.
+//
+
+import UIKit
+
+protocol ReusableView: AnyObject {
+    static var defaultReuseIdentifier: String { get }
+}
+
+extension ReusableView where Self: UIView {
+    static var defaultReuseIdentifier: String {
+        return String(describing: self)
+    }
+}
+
+extension UICollectionViewCell: ReusableView {}


### PR DESCRIPTION
closed #112 
## 완료된 기능
- 카테고리 관리 collectionView 구현
- 추가 버튼은 footerView를 사용하여 구현
- UICollectionVIewCell, UICollectionReusableView 재사용성을 높이기 위해 제네릭을 사용하여 register, dequeue 메소드 구현

## 실행 결과
| 라이트모드 | 다크모드 |
| -------- | -------- |
| <img width="376" alt="image" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/c18ac947-d9e4-46ca-83d2-e8d63b4a4d9f"> | <img width="392" alt="image" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/c77a2622-0e07-4812-8dc2-75dea1dc5eae"> |

## 고민과 해결과정
### dataSource의 위치
dataSource을 ViewModel이 가지고 있으면 ViewModel이 UIKit에 의존하게 되어 UIKit에 독립적인 ViewModel로 관리하기 위해 dataSource을 ViewController가 가지고 있도록 구현했습니다.
추후에 ViewModel을 통해서 dataSource의 snapshot을 변경하도록 구현하면 될 것 같습니다.

### register, dequeue 메소드 구현
- cell과 ReusableView을 register, dequeue할때마다 타입 캐스팅을 줄이고, 재사용이 높은 작업을 위해 해당 로직을 제네릭을 통해 메소드로 구현해놨습니다. collectionView을 사용하실 때 해당 메소드 사용해주시면 될 것 같습니다.
``` swift
 // register
collectionView.register(CategoryListCollectionViewCell.self)
collectionView.register(CategorySettingFooterView.self, kind: .footer)

// dequeue
let cell: CategoryListCollectionViewCell = collectionView.dequeueReusableCell(for: indexPath)
let footer: CategorySettingFooterView = collectionView.dequeueReusableView(for: indexPath, kind: kind)
```
