### PR TITLE
[BE#121] 인가된 사용자인지 확인

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.0.0",
         "@nestjs/jwt": "^10.2.0",
+        "@nestjs/mapped-types": "^2.0.4",
         "@nestjs/passport": "^10.0.2",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/swagger": "^7.1.15",
@@ -1696,9 +1697,9 @@
       }
     },
     "node_modules/@nestjs/mapped-types": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.3.tgz",
-      "integrity": "sha512-40Zdqg98lqoF0+7ThWIZFStxgzisK6GG22+1ABO4kZiGF/Tu2FE+DYLw+Q9D94vcFWizJ+MSjNN4ns9r6hIGxw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.4.tgz",
+      "integrity": "sha512-xl+gUSp0B+ln1VSNoUftlglk8dfpUes3DHGxKZ5knuBxS5g2H/8p9/DSBOYWUfO5f4u9s6ffBPZ71WO+tbe5SA==",
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
@@ -1782,6 +1783,25 @@
         "@fastify/static": {
           "optional": true
         },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.3.tgz",
+      "integrity": "sha512-40Zdqg98lqoF0+7ThWIZFStxgzisK6GG22+1ABO4kZiGF/Tu2FE+DYLw+Q9D94vcFWizJ+MSjNN4ns9r6hIGxw==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
         "class-transformer": {
           "optional": true
         },

--- a/BE/package.json
+++ b/BE/package.json
@@ -24,6 +24,7 @@
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.2.0",
+    "@nestjs/mapped-types": "^2.0.4",
     "@nestjs/passport": "^10.0.2",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^7.1.15",

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -2,8 +2,9 @@ import { AuthService } from './auth.service';
 
 import { Controller, Get, UseGuards, Req, Res } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { AccessTokenGuard } from './guard/bearer-token.guard';
+import { User } from 'src/users/decorator/user.decorator';
 
 @Controller('auth')
 export class AuthController {
@@ -18,7 +19,8 @@ export class AuthController {
 
   @Get('logout')
   @UseGuards(AccessTokenGuard)
-  logout(@Req() req: Request, @Res() res: Response) {
+  logout(@User('id') userId: number, @Res() res: Response) {
+    console.log(`${userId}를 로그아웃 시키는 로직`);
     res.redirect('/');
   }
 }

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -3,23 +3,21 @@ import { AuthService } from './auth.service';
 import { Controller, Get, UseGuards, Req, Res } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Request, Response } from 'express';
+import { AccessTokenGuard } from './guard/bearer-token.guard';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  @Get('')
-  @UseGuards(AuthGuard('google'))
-  async googleAuth() {} // Google 로그인 페이지로 리디렉션합니다
-
   @Get('google')
   @UseGuards(AuthGuard('google'))
-  googleAuthRedirect(@Req() req) {
+  googleAuth(@Req() req) {
     const user = req.user;
     return this.authService.loginWithGoogle(user);
   }
 
   @Get('logout')
+  @UseGuards(AccessTokenGuard)
   logout(@Req() req: Request, @Res() res: Response) {
     res.redirect('/');
   }

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -5,13 +5,23 @@ import { AuthGuard } from '@nestjs/passport';
 import { Response } from 'express';
 import { AccessTokenGuard } from './guard/bearer-token.guard';
 import { User } from 'src/users/decorator/user.decorator';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Get('google')
   @UseGuards(AuthGuard('google'))
+  @ApiOperation({ summary: 'Google 로그인' })
+  @ApiResponse({ status: 200, description: '로그인 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
   googleAuth(@Req() req) {
     const user = req.user;
     return this.authService.loginWithGoogle(user);
@@ -19,6 +29,10 @@ export class AuthController {
 
   @Get('logout')
   @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: '로그아웃' })
+  @ApiResponse({ status: 200, description: '로그아웃 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiBearerAuth()
   logout(@User('id') userId: number, @Res() res: Response) {
     console.log(`${userId}를 로그아웃 시키는 로직`);
     res.redirect('/');

--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -1,13 +1,24 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
-import { UsersService } from 'src/users/users.service';
 import { UsersModule } from 'src/users/users.module';
 import { JwtModule } from '@nestjs/jwt';
 
 @Module({
-  imports: [JwtModule.register({}), UsersModule],
+  imports: [
+    ConfigModule.forRoot(),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get('JWT_SECRET'),
+        signOptions: { expiresIn: configService.get('JWT_EXPIRES_IN') },
+      }),
+    }),
+    UsersModule,
+  ],
   controllers: [AuthController],
-  providers: [AuthService, UsersService],
+  providers: [AuthService],
 })
 export class AuthModule {}

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from 'src/users/users.service';
 
@@ -8,16 +8,34 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly usersService: UsersService,
   ) {}
+
+  public extractBearerTokenFromHeader(header: string) {
+    const splitToken = header.split(' ');
+
+    if (splitToken.length !== 2 || splitToken[0] !== 'Bearer') {
+      throw new UnauthorizedException('잘못된 토큰입니다!');
+    }
+
+    const token = splitToken[1];
+
+    return token;
+  }
+
+  public verifyToken(token: string) {
+    try {
+      return this.jwtService.verify(token);
+    } catch (e) {
+      throw new UnauthorizedException('유효하지 않은 토큰입니다!');
+    }
+  }
+
   private signToken(user) {
     const payload = {
       email: user.email,
       nickname: user.nickname,
       type: 'access',
     };
-    return this.jwtService.sign(payload, {
-      secret: 'slkdjf',
-      expiresIn: 300,
-    });
+    return this.jwtService.sign(payload);
   }
 
   public async loginWithGoogle(user) {

--- a/BE/src/auth/guard/bearer-token.guard.ts
+++ b/BE/src/auth/guard/bearer-token.guard.ts
@@ -1,0 +1,52 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthService } from '../auth.service';
+import { UsersService } from 'src/users/users.service';
+
+@Injectable()
+class BearerTokenGuard implements CanActivate {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly usersService: UsersService,
+  ) {}
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+
+    const rawToken = req.headers['authorization'];
+
+    if (!rawToken) {
+      throw new UnauthorizedException('토큰이 없습니다!');
+    }
+
+    const token = this.authService.extractBearerTokenFromHeader(rawToken);
+
+    const result = this.authService.verifyToken(token);
+
+    const user = await this.usersService.findUserByEmail(result.email);
+
+    req.user = user;
+    req.token = token;
+    req.tokenType = result.type;
+
+    return true;
+  }
+}
+
+@Injectable()
+export class AccessTokenGuard extends BearerTokenGuard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    await super.canActivate(context);
+
+    const req = context.switchToHttp().getRequest();
+
+    if (req.tokenType !== 'access') {
+      throw new UnauthorizedException('Access Token이 아닙니다.');
+    }
+
+    return true;
+  }
+}

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -10,6 +10,7 @@ async function bootstrap() {
     .setTitle('StudyLog API')
     .setDescription('StudyLog 애플리케이션 API 문서')
     .setVersion('1.0')
+    .addBearerAuth()
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/BE/src/users/decorator/user.decorator.ts
+++ b/BE/src/users/decorator/user.decorator.ts
@@ -1,0 +1,25 @@
+import {
+  ExecutionContext,
+  InternalServerErrorException,
+  createParamDecorator,
+} from '@nestjs/common';
+import { UsersModel } from '../entity/users.entity';
+
+export const User = createParamDecorator(
+  (data: keyof UsersModel | undefined, context: ExecutionContext) => {
+    const req = context.switchToHttp().getRequest();
+
+    const user = req.user as UsersModel;
+
+    if (!user) {
+      throw new InternalServerErrorException(
+        'User 데코레이터는 AccessTokenGuard와 함께 사용해야 합니다',
+      );
+    }
+
+    if (data) {
+      return user[data];
+    }
+    return user;
+  },
+);

--- a/BE/src/users/dto/create-user.dto.ts
+++ b/BE/src/users/dto/create-user.dto.ts
@@ -1,0 +1,8 @@
+import { PickType } from '@nestjs/mapped-types';
+import { UsersModel } from '../entity/users.entity';
+
+export class CreateUserDto extends PickType(UsersModel, [
+  'nickname',
+  'email',
+  'image_url',
+]) {}

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -1,14 +1,37 @@
-import { Controller, Patch, Get } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Query } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { UsersService } from './users.service';
 
 @ApiTags('Users')
 @Controller('users')
 export class UsersController {
-  @Get('/nickname-validation')
-  @ApiOperation({ summary: '유저 닉네임 중복 확인' })
-  validateNickname() {}
+  constructor(private readonly usersService: UsersService) {}
 
-  @Patch()
-  @ApiOperation({ summary: '유저 정보 수정' })
-  updateInfo() {}
+  @Get('/nickname-validation')
+  @ApiOperation({ summary: '유저 닉네임 유효한지 확인' })
+  @ApiQuery({
+    name: 'nickname',
+    example: '어린콩',
+    required: true,
+    type: String,
+    description: '검증할 유저 닉네임',
+  })
+  @ApiOkResponse({
+    type: Boolean,
+    description: '닉네임 검증 확인 결과 true(사용가능), false(불가능)',
+  })
+  @ApiBadRequestResponse({
+    description: '잘못된 요청',
+  })
+  async validateNickname(
+    @Query('nickname') nickname: string,
+  ): Promise<boolean> {
+    return this.usersService.isUniqueNickname(nickname);
+  }
 }

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UsersModel } from './entity/users.entity';
+import { CreateUserDto } from './dto/create-user.dto';
 
 @Injectable()
 export class UsersService {
@@ -10,17 +11,36 @@ export class UsersService {
     private usersRepository: Repository<UsersModel>,
   ) {}
 
-  async createUser(user: UserCreateDto): Promise<UsersModel> {
-    const users = this.usersRepository.create(user);
-    return this.usersRepository.save(users);
+  async createUser(user: CreateUserDto): Promise<UsersModel> {
+    try {
+      const userObject = this.usersRepository.create({
+        nickname: user.nickname,
+        email: user.email,
+        image_url: user.image_url,
+      });
+      return await this.usersRepository.save(userObject);
+    } catch (error) {
+      if (error.code === 'ER_DUP_ENTRY' || error.errno === 1062) {
+        throw new BadRequestException(
+          '닉네임 또는 이메일이 이미 사용 중입니다.',
+        );
+      }
+      throw error;
+    }
+  }
+
+  async isUniqueNickname(nickname: string): Promise<boolean> {
+    const isDuplicated = await this.usersRepository.exist({
+      where: { nickname },
+    });
+    return !isDuplicated;
   }
 
   async findUserByEmail(email: string): Promise<UsersModel> {
-    const user = await this.usersRepository.findOne({
+    const selectedUser = await this.usersRepository.findOne({
       where: { email },
     });
-    return user;
+
+    return selectedUser;
   }
 }
-
-export type UserCreateDto = {};


### PR DESCRIPTION
close #121 

## 완료된 기능
- [x] Service계층 및 Controller계층 작성
- [x] auth bearer-token 가드 작성
- [x] User 프로퍼티 커스텀 데코레이터 작성
- [x] authorization API 문서화

## 고민한 사항
### CreateUserDto에 PickType 작성
CreateUserDto에 아래와 같이 PickType을 사용했습니다.
```ts
import { PickType } from '@nestjs/mapped-types';
import { UsersModel } from '../entity/users.entity';

export class CreateUserDto extends PickType(UsersModel, [
  'nickname',
  'email',
  'image_url',
]) {}
```
이유는 CreateUserDto는 결국 User 엔티티 값 내에서 사용하는데 이를 위한 Validator를 중복적으로 작성하는게 과연 맞을까? 라는 의구심이 들어서 찾아보니 기존 ts의 유틸리티 타입을 활용하여 작성하는 경우도 많더라고요 여기서 UpdateUserDto는 아래처럼 작성한답니다.

```ts
import { PartialType } from "@nestjs/mapped-types";
import { CreateUserDto } from "./create-user.dto";

// UpdateUserDto는 CreateUserDto와 인터페이스 동일하나 필수 값이 아니다
export class UpdateUserDto extends PartialType(CreateUserDto) {}
```

### createUser에서 유니크 에러가 났을 경우에 대한 예외처리
유저 생성과정에서 중복되면 어떡하지? 일단 쿼리를 날리기전에 확인을 해야하나? 라는 생각에 아래와 같이 작성했다.
```ts
async createUser(user: RegisterUserDto): Promise<UsersModel> {
    const nicknameExists = await this.usersRepository.exist({
      where: {
        nickname: user.nickname,
      },
    });

    if (nicknameExists) {
      throw new BadRequestException(`${user.nickname}은 이미 존재하는 nickname 입니다!`);
    }

    const emailExists = await this.usersRepository.exist({
      where: { email: user.email },
    });

    if (emailExists) {
      throw new BadRequestException(`${user.email}은 이미 가입한 이메일입니다!`);
    }

    const userObject = this.usersRepository.create({
      nickname: user.nickname,
      email: user.email,
      image_url: user.image_url,
    });
...
}
```
음.. db에 요청을 3번이나 하는게 과연 옳은가? 에 대해서 뭔가 잘못됐다고 생각하여, 요청을 보낸 후에 에러가 나면 이를 처리해주는 방식으로 작성했다.

```ts
async createUser(user: CreateUserDto): Promise<UsersModel> {
  try {
    const userObject = this.usersRepository.create({
      nickname: user.nickname,
      email: user.email,
      image_url: user.image_url,
    });
    return await this.usersRepository.save(userObject);
  } catch (error) {
    if (error.code === 'ER_DUP_ENTRY' || error.errno === 1062) {
      throw new BadRequestException(
        '닉네임 또는 이메일이 이미 사용 중입니다.',
      );
    }
    throw error;
  }
}
```
위의 에러코드를 적용했는데, 기타 에러코드들에 대한 내용은 BE참고자료에 넣어두었다.

### auth bearer-token가드 만들기
이전에 로그인/회원가입 까지 만들었다. 정확히는, 구글 리다이렉션이 성공하면 jwt access토큰을 발급해주는 코드를 작성했다. 하지만.. 토큰을 주면 뭐해? 이 토큰이 유효한 토큰인지 검증해서 인가된 사용자만 우리 api를 사용할 수 있도록 하는게 필요한데..?
그래서 아래와 같이 NestJS에서 제공해주는 @UseGuards를 활용하여 우리가 만든 가드에 통과하지 못하면 해당 함수를 실행시키지 않고, 통과하면 req객체에 user를 넣어주는 커스텀 가드를 만들어 보기로 했다.

```ts
@Get('logout')
@UseGuards(AccessTokenGuard) // 통과 못하면 아래의 함수 실행 안댐
logout(@Req() req: any, @Res() res: Response) {
  const userId = req.user.id; //통과 하면 req.user가 있음! 따라서 여기서는 req.user?.id라던가.. 예외처리 안해도 댐
  console.log(`${userId}를 로그아웃 시키는 로직`);
  res.redirect('/');
}
```
우선 service계층에는 'Bearer 머시기머시기'에서 token을 추출하는 함수와 현재 받은 토큰이 유효한지, 유효하다면 값을 반환하는 함수를 만들었다.

```ts
public extractBearerTokenFromHeader(header: string) {
  const splitToken = header.split(' ');

  if (splitToken.length !== 2 || splitToken[0] !== 'Bearer') {
    throw new UnauthorizedException('잘못된 토큰입니다!');
  }
  const token = splitToken[1];
  return token;
}

public verifyToken(token: string) {
  try {
    return this.jwtService.verify(token);
  } catch (e) {
    throw new UnauthorizedException('유효하지 않은 토큰입니다!');
  }
}
```
이제 위의 함수를 사용하는 guard를 만들어보자 @nestjs/common 에서 제공해주는 CanActivate를 구현하는 방식을 통해 Guard를 제공할 것이다.

```ts
//bearer-token.guard.ts
import {
  CanActivate,
  ExecutionContext,
  Injectable,
  UnauthorizedException,
} from '@nestjs/common';
import { AuthService } from '../auth.service';
import { UsersService } from 'src/users/users.service';

@Injectable()
class BearerTokenGuard implements CanActivate {
  constructor(
    private readonly authService: AuthService,
    private readonly usersService: UsersService,
  ) {}
  async canActivate(context: ExecutionContext): Promise<boolean> {
    const req = context.switchToHttp().getRequest(); // (1)

    const rawToken = req.headers['authorization']; // (2)
    if (!rawToken) {
      throw new UnauthorizedException('토큰이 없습니다!');
    }

    const token = this.authService.extractBearerTokenFromHeader(rawToken); // (3)
    const result = this.authService.verifyToken(token); // (4)

    const user = await this.usersService.findUserByEmail(result.email); //(5)
    req.user = user;
    req.token = token;
    req.tokenType = result.type;

    return true; //(6)
  }
}
```
1. context.switchToHttp().getRequest()를 통해 request객체를 불러온다.
2. request객체로부터 authorization헤더의 토큰을 불러온다. 없을시 예외처리
3. 위에서 만들었던 토큰 추출 함수를 통해 토큰만 추출
4. 토큰이 유효한지 검증
5. email을 토대로 user를 찾아서 이를 req객체에 넣어준다.
6. true반환시 이제 이 가드가 통과함을 의미한다.

여기서 추가적으로 이를 확장한 AccessTokenGuard를 구현했다. 그 이유는 나중에 refreshToken도 구현할 거니깐..
```ts
@Injectable()
export class AccessTokenGuard extends BearerTokenGuard {
  async canActivate(context: ExecutionContext): Promise<boolean> {
    await super.canActivate(context);
    const req = context.switchToHttp().getRequest();
    if (req.tokenType !== 'access') {
      throw new UnauthorizedException('Access Token이 아닙니다.');
    }
    return true;
  }
}
```
작성한 코드가 정상적으로 동작하는지 확인해보자

<img width="615" alt="스크린샷 2023-11-21 오전 12 20 39" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/e7082c60-2bc3-4470-b564-52d390c72147">

- 유효한 토큰의 경우 정상 응답

<img width="607" alt="스크린샷 2023-11-21 오전 12 22 57" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/3723c6b1-eff8-4d1b-9bac-4ef3f4925237">

- 두번째 자리를 b로 바꾸니 예외

<img width="602" alt="스크린샷 2023-11-21 오전 12 24 02" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/e6c939b9-bfb7-46cf-807e-7107fac77351">

- 토큰을 헤더에 안넣으니 예외

### User프로퍼티 데코레이터 생성
이제 guard에서 넣어준 req에 접근해보자

```tsx
@Get('logout')
@UseGuards(AccessTokenGuard)
logout(@Req() req: any, @Res() res: Response) {
  const userId = req.user.id;
  console.log(`${userId}를 로그아웃 시키는 로직`);
  res.redirect('/');
}
```
이렇게 매번 필요한 것을 가져와야 할까? 앞으로 대부분의 컨트롤러들은 이 user정보를 분명 받아올텐데 이걸 다른 파라미터 데코레이터처럼 편리하게 받아오면 좋겠다고 생각이 들었다. 그래서 커스텀 프로퍼티 데코레이터를 만들어보자! 하게 되었다.

```tsx
// user.decorator.ts
import { ExecutionContext, InternalServerErrorException, createParamDecorator} from '@nestjs/common';
import { UsersModel } from '../entity/users.entity';

export const User = createParamDecorator(
  (data, context: ExecutionContext) => {
    const req = context.switchToHttp().getRequest();
    const user = req.user as UsersModel;

    if (!user) {
      throw new InternalServerErrorException('User 데코레이터는 AccessTokenGuard와 함께 사용해야 합니다');
    }

    return user;
  },
);


// auth.controller.ts
@Get('logout')
@UseGuards(AccessTokenGuard)
logout(@User() user: UsersModel, @Res() res: Response) {
  console.log(`${user.id}를 로그아웃 시키는 로직`);
  res.redirect('/');
}
```
위와 같이 되었다! 코드 한 줄만 줄은 것처럼 보이지만 앞으로의 대부분의 컨트롤러들이 사용할 이 데코레이터를 만든게 보람차다! 다만 user.id 말고 파라미터에서 바로 받아오는 것도 할 수 있으면 좋겠다고 생각해서 아래와 같이 변경!

```tsx
// user.decorator.ts
import { ExecutionContext, InternalServerErrorException, createParamDecorator} from '@nestjs/common';
import { UsersModel } from '../entity/users.entity';

export const User = createParamDecorator(
  (data: keyof UsersModel | undefined, context: ExecutionContext) => {
    const req = context.switchToHttp().getRequest();
    const user = req.user as UsersModel;

    if (!user) {
      throw new InternalServerErrorException('User 데코레이터는 AccessTokenGuard와 함께 사용해야 합니다');
    }

    if (data) return user[data];
    return user;
  },
);


// auth.controller.ts
@Get('logout')
@UseGuards(AccessTokenGuard)
logout(@User('id') userId: number, @Res() res: Response) {
  console.log(`${userId}를 로그아웃 시키는 로직`);
  res.redirect('/');
}
```

### 인증을 적용한 swagger
인증을 필요로 하는 문서화는 어떻게 해야할까? 예를들어 logout api호출은 로그인 한 사용자만 호출이 가능하다는 것을 어떻게 표현할까?
`@ApiBearerAuth()` 라는게 있는 것을 알았다. 단, main.ts에 addBearerAuth()를 호출해야한다고 한다. 이를 적용해보자
```ts
//main.ts

async function bootstrap() {
...
const config = new DocumentBuilder()
  .setTitle('StudyLog API')
  .setDescription('StudyLog 애플리케이션 API 문서')
  .setVersion('1.0')
  .addBearerAuth() //이 행만 추가댐!
  .build();
...
}

//auth.controller.ts

@Get('logout')
  @UseGuards(AccessTokenGuard)
  @ApiOperation({ summary: '로그아웃' })
  @ApiResponse({ status: 200, description: '로그아웃 성공' })
  @ApiResponse({ status: 401, description: '인증 실패' })
  @ApiBearerAuth()
  logout(@User('id') userId: number, @Res() res: Response) {
    console.log(`${userId}를 로그아웃 시키는 로직`);
    res.redirect('/');
  }
```

결과를!!! 결과를보자!!
<img width="649" alt="스크린샷 2023-11-21 오전 1 09 04" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/39925b0a-4c85-4558-b7d6-334466056e1c">
<img width="654" alt="스크린샷 2023-11-21 오전 1 09 20" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/0e8c1f7e-f103-431f-9760-91624627cc6b">

오른쪽 위에 해당 api만 자물쇠가 나오는 것을 확인할 수 있다!! 이를 눌러봤을때의 화면을 캡처했다.

