### PR TITLE
[iOS#148] 네트워크 기능 개선

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2C3430972B0C7ED8008CBC85 /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3430962B0C7ED8008CBC85 /* EndPoint.swift */; };
 		2C3430992B0C8427008CBC85 /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3430982B0C8427008CBC85 /* Provider.swift */; };
 		2C34309B2B0C8674008CBC85 /* URLSessionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C34309A2B0C8674008CBC85 /* URLSessionable.swift */; };
+		2C3430A12B0DA4E6008CBC85 /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3430A02B0DA4E6008CBC85 /* BaseURL.swift */; };
 		2C43A0D82B037BBC0005596A /* FeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C43A0D72B037BBC0005596A /* FeedbackManager.swift */; };
 		2C4D55AB2B033029006D7C26 /* UIView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4D55AA2B033029006D7C26 /* UIView++Extension.swift */; };
 		2C4D55B02B0348FB006D7C26 /* TimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4D55AF2B0348FB006D7C26 /* TimerViewModel.swift */; };
@@ -85,6 +86,7 @@
 		2C3430962B0C7ED8008CBC85 /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
 		2C3430982B0C8427008CBC85 /* Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
 		2C34309A2B0C8674008CBC85 /* URLSessionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionable.swift; sourceTree = "<group>"; };
+		2C3430A02B0DA4E6008CBC85 /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
 		2C43A0D72B037BBC0005596A /* FeedbackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackManager.swift; sourceTree = "<group>"; };
 		2C4D55AA2B033029006D7C26 /* UIView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView++Extension.swift"; sourceTree = "<group>"; };
 		2C4D55AF2B0348FB006D7C26 /* TimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerViewModel.swift; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 				2C3430962B0C7ED8008CBC85 /* EndPoint.swift */,
 				2C3430982B0C8427008CBC85 /* Provider.swift */,
 				2C34309A2B0C8674008CBC85 /* URLSessionable.swift */,
+				2C3430A02B0DA4E6008CBC85 /* BaseURL.swift */,
 			);
 			path = NetworkService;
 			sourceTree = "<group>";
@@ -892,6 +895,7 @@
 				2C801D802B04B68900A7ABAE /* TimerUseCase.swift in Sources */,
 				601773E42B021E6000D175D9 /* TimerViewController.swift in Sources */,
 				600908C22AFCD7DF0065DFFB /* ViewController.swift in Sources */,
+				2C3430A12B0DA4E6008CBC85 /* BaseURL.swift in Sources */,
 				2C5CDA5B2B025440007AFC57 /* ChartViewController.swift in Sources */,
 				6057A58D2B0C7F0F00EE58E8 /* Requestable.swift in Sources */,
 				6057A58F2B0C801300EE58E8 /* NetworkError.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2C3430992B0C8427008CBC85 /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3430982B0C8427008CBC85 /* Provider.swift */; };
 		2C34309B2B0C8674008CBC85 /* URLSessionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C34309A2B0C8674008CBC85 /* URLSessionable.swift */; };
 		2C3430A12B0DA4E6008CBC85 /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3430A02B0DA4E6008CBC85 /* BaseURL.swift */; };
+		2C3430A32B0DA5A5008CBC85 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3430A22B0DA5A5008CBC85 /* HTTPHeader.swift */; };
 		2C43A0D82B037BBC0005596A /* FeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C43A0D72B037BBC0005596A /* FeedbackManager.swift */; };
 		2C4D55AB2B033029006D7C26 /* UIView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4D55AA2B033029006D7C26 /* UIView++Extension.swift */; };
 		2C4D55B02B0348FB006D7C26 /* TimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4D55AF2B0348FB006D7C26 /* TimerViewModel.swift */; };
@@ -87,6 +88,7 @@
 		2C3430982B0C8427008CBC85 /* Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
 		2C34309A2B0C8674008CBC85 /* URLSessionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionable.swift; sourceTree = "<group>"; };
 		2C3430A02B0DA4E6008CBC85 /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
+		2C3430A22B0DA5A5008CBC85 /* HTTPHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeader.swift; sourceTree = "<group>"; };
 		2C43A0D72B037BBC0005596A /* FeedbackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackManager.swift; sourceTree = "<group>"; };
 		2C4D55AA2B033029006D7C26 /* UIView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView++Extension.swift"; sourceTree = "<group>"; };
 		2C4D55AF2B0348FB006D7C26 /* TimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerViewModel.swift; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 				2C3430982B0C8427008CBC85 /* Provider.swift */,
 				2C34309A2B0C8674008CBC85 /* URLSessionable.swift */,
 				2C3430A02B0DA4E6008CBC85 /* BaseURL.swift */,
+				2C3430A22B0DA5A5008CBC85 /* HTTPHeader.swift */,
 			);
 			path = NetworkService;
 			sourceTree = "<group>";
@@ -878,6 +881,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C3430A32B0DA5A5008CBC85 /* HTTPHeader.swift in Sources */,
 				EDC851D22B04EE83009031EA /* CategoryListCollectionViewCell.swift in Sources */,
 				2C43A0D82B037BBC0005596A /* FeedbackManager.swift in Sources */,
 				ED3595AB2B0C81B800558FAA /* Responsable.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/TimerScene/TimerStartRequestDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/TimerScene/TimerStartRequestDTO.swift
@@ -8,8 +8,19 @@
 import Foundation
 
 struct TimerStartRequestDTO: Encodable {
+    let date: String
+    let createdAt: String
     let type: String
-    let currentTime: String
-    let learningSeconds: Int
-    let category: String
+    let learningTime: Int
+    let userID: Int
+    let categoryID: Int
+    
+    private enum CodingKeys: String, CodingKey {
+        case date
+        case createdAt = "created_at"
+        case type
+        case learningTime = "learning_time"
+        case userID = "user_id"
+        case categoryID = "category_id"
+    }
 }

--- a/iOS/FlipMate/FlipMate/NetworkService/BaseURL.swift
+++ b/iOS/FlipMate/FlipMate/NetworkService/BaseURL.swift
@@ -7,4 +7,4 @@
 
 import Foundation
 
-let BaseURL = "https://flipmate.site:3000"
+let baseURL = "https://flipmate.site:3000"

--- a/iOS/FlipMate/FlipMate/NetworkService/BaseURL.swift
+++ b/iOS/FlipMate/FlipMate/NetworkService/BaseURL.swift
@@ -1,0 +1,10 @@
+//
+//  BaseURL.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/22.
+//
+
+import Foundation
+
+let BaseURL = "https://flipmate.site:3000"

--- a/iOS/FlipMate/FlipMate/NetworkService/EndPoint.swift
+++ b/iOS/FlipMate/FlipMate/NetworkService/EndPoint.swift
@@ -15,12 +15,14 @@ final class EndPoint<R: Decodable>: ReqeustResponseable {
     var baseURL: String
     var path: String
     var method: HTTPMethod
-    var bodyParameters: Encodable?
+    var data: Data?
     var headers: [String : String]?
     
-    init(baseURL: String, path: String, method: HTTPMethod) {
+    init(baseURL: String, path: String, method: HTTPMethod, data: Data? = nil, headers: [String: String]? = nil) {
         self.baseURL = baseURL
         self.path = path
         self.method = method
+        self.data = data
+        self.headers = headers
     }
 }

--- a/iOS/FlipMate/FlipMate/NetworkService/EndPoint.swift
+++ b/iOS/FlipMate/FlipMate/NetworkService/EndPoint.swift
@@ -16,9 +16,9 @@ final class EndPoint<R: Decodable>: ReqeustResponseable {
     var path: String
     var method: HTTPMethod
     var data: Data?
-    var headers: [String : String]?
+    var headers: [HTTPHeader]?
     
-    init(baseURL: String, path: String, method: HTTPMethod, data: Data? = nil, headers: [String: String]? = nil) {
+    init(baseURL: String, path: String, method: HTTPMethod, data: Data? = nil, headers: [HTTPHeader]? = nil) {
         self.baseURL = baseURL
         self.path = path
         self.method = method

--- a/iOS/FlipMate/FlipMate/NetworkService/HTTPHeader.swift
+++ b/iOS/FlipMate/FlipMate/NetworkService/HTTPHeader.swift
@@ -1,0 +1,13 @@
+//
+//  HTTPHeader.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/22.
+//
+
+import Foundation
+
+struct HTTPHeader {
+    var value: String
+    var field: String
+}

--- a/iOS/FlipMate/FlipMate/NetworkService/Provider.swift
+++ b/iOS/FlipMate/FlipMate/NetworkService/Provider.swift
@@ -22,7 +22,7 @@ struct Provider: Providable {
     
     func request<E: ReqeustResponseable>(with endpoint: E) -> AnyPublisher<E.Response, NetworkError> {
         do {
-            let urlReqeust = try endpoint.getUrlRequest()
+            let urlReqeust = try endpoint.makeURLRequest()
             return urlSession.response(for: urlReqeust)
                 .tryMap { data, response in
                     guard let response = response as? HTTPURLResponse else { throw NetworkError.invalidURLComponents }

--- a/iOS/FlipMate/FlipMate/NetworkService/Requestable.swift
+++ b/iOS/FlipMate/FlipMate/NetworkService/Requestable.swift
@@ -11,17 +11,16 @@ protocol Requestable {
     var baseURL: String { get }
     var path: String { get }
     var method: HTTPMethod { get }
-    var bodyParameters: Encodable? { get }
+    var data: Data? { get }
     var headers: [String: String]? { get }
 }
 
 extension Requestable {
-    func getUrlRequest() throws -> URLRequest {
+    func makeURLRequest() throws -> URLRequest {
         let url = try makeURL()
         var urlRequest = URLRequest(url: url)
-        
         urlRequest.httpMethod = method.rawValue
-        
+        urlRequest.httpBody = data
         headers?.forEach { urlRequest.setValue($1, forHTTPHeaderField: $0)}
         return urlRequest
     }

--- a/iOS/FlipMate/FlipMate/NetworkService/Requestable.swift
+++ b/iOS/FlipMate/FlipMate/NetworkService/Requestable.swift
@@ -12,7 +12,7 @@ protocol Requestable {
     var path: String { get }
     var method: HTTPMethod { get }
     var data: Data? { get }
-    var headers: [String: String]? { get }
+    var headers: [HTTPHeader]? { get }
 }
 
 extension Requestable {
@@ -22,7 +22,7 @@ extension Requestable {
         urlRequest.httpMethod = method.rawValue
         urlRequest.httpBody = data
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        headers?.forEach { urlRequest.setValue($1, forHTTPHeaderField: $0)}
+        headers?.forEach { urlRequest.setValue($0.value, forHTTPHeaderField: $0.field)}
         return urlRequest
     }
 

--- a/iOS/FlipMate/FlipMate/NetworkService/Requestable.swift
+++ b/iOS/FlipMate/FlipMate/NetworkService/Requestable.swift
@@ -21,6 +21,7 @@ extension Requestable {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method.rawValue
         urlRequest.httpBody = data
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         headers?.forEach { urlRequest.setValue($1, forHTTPHeaderField: $0)}
         return urlRequest
     }


### PR DESCRIPTION
closed #149 

## 완료된 기능
- Swagger 문서와 DTO 맞추기
- HTTP 헤더 필드 Content-Type 추가
- baseURL 파일 분리하여 생성

## 고민과 해결과정
### 각 기능 별 API 기능마다 method 및 path 추상화
이미 추상화된 EndPoint을 한 번 더 추상화한다는 느낌이 생들어서 해당 부분은 일단 구현하지 않았습니다.
위의 방식대로 추상화하는 것보단 기능에 맞는 EndPoint을 생성해주는 객체를 만들어서 관리하는 방식이 현재 저희가 구현한 네트워크 레이어에 더 적합한 것 같다는 생각이 들었습니다.
이미 method와 path가 추상화된 프로토콜이 Requestable인데 추상화에 추상화를 한 번 더 해주는 느낌입니다.


