### PR TITLE
[iOS#113] 카테고리 추가 / 수정 UI 구현

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		ED3595B92B0C88A300558FAA /* TimerFinishResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595B82B0C88A300558FAA /* TimerFinishResponseDTO.swift */; };
 		ED3595BD2B0DB29F00558FAA /* CategoryModifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595BC2B0DB29F00558FAA /* CategoryModifyViewController.swift */; };
 		ED3595BF2B0DB68200558FAA /* CategoryTitleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595BE2B0DB68200558FAA /* CategoryTitleTextView.swift */; };
+		ED3595C12B0DC2F100558FAA /* CategoryColorSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595C02B0DC2F100558FAA /* CategoryColorSelectView.swift */; };
 		ED9B2A7F2B06033F008FE1C5 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9B2A7E2B06033F008FE1C5 /* Category.swift */; };
 		ED9B2A812B06048D008FE1C5 /* CategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9B2A802B06048D008FE1C5 /* CategoryViewModel.swift */; };
 		EDC851C72B021492009031EA /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC851C62B021492009031EA /* TabBarViewController.swift */; };
@@ -143,6 +144,7 @@
 		ED3595B82B0C88A300558FAA /* TimerFinishResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishResponseDTO.swift; sourceTree = "<group>"; };
 		ED3595BC2B0DB29F00558FAA /* CategoryModifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModifyViewController.swift; sourceTree = "<group>"; };
 		ED3595BE2B0DB68200558FAA /* CategoryTitleTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTitleTextView.swift; sourceTree = "<group>"; };
+		ED3595C02B0DC2F100558FAA /* CategoryColorSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryColorSelectView.swift; sourceTree = "<group>"; };
 		ED9B2A7E2B06033F008FE1C5 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		ED9B2A802B06048D008FE1C5 /* CategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewModel.swift; sourceTree = "<group>"; };
 		EDC851C62B021492009031EA /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
@@ -647,6 +649,7 @@
 				EDC851D12B04EE83009031EA /* CategoryListCollectionViewCell.swift */,
 				2CE84EF82B0B8A0B00E2FB71 /* CategorySettingFooterView.swift */,
 				ED3595BE2B0DB68200558FAA /* CategoryTitleTextView.swift */,
+				ED3595C02B0DC2F100558FAA /* CategoryColorSelectView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -926,6 +929,7 @@
 				60DE49402B05E67200ACE6DD /* FlipMateConstant.swift in Sources */,
 				2C801D832B04C64F00A7ABAE /* TimerManager.swift in Sources */,
 				2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */,
+				ED3595C12B0DC2F100558FAA /* CategoryColorSelectView.swift in Sources */,
 				EDC851D92B05C37C009031EA /* DeviceMotionManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -56,7 +56,7 @@
 		ED3595B72B0C887C00558FAA /* TimerFinishRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595B62B0C887C00558FAA /* TimerFinishRequestDTO.swift */; };
 		ED3595B92B0C88A300558FAA /* TimerFinishResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595B82B0C88A300558FAA /* TimerFinishResponseDTO.swift */; };
 		ED3595BD2B0DB29F00558FAA /* CategoryModifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595BC2B0DB29F00558FAA /* CategoryModifyViewController.swift */; };
-		ED3595BF2B0DB68200558FAA /* CustomTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595BE2B0DB68200558FAA /* CustomTextView.swift */; };
+		ED3595BF2B0DB68200558FAA /* CategoryTitleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595BE2B0DB68200558FAA /* CategoryTitleTextView.swift */; };
 		ED9B2A7F2B06033F008FE1C5 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9B2A7E2B06033F008FE1C5 /* Category.swift */; };
 		ED9B2A812B06048D008FE1C5 /* CategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9B2A802B06048D008FE1C5 /* CategoryViewModel.swift */; };
 		EDC851C72B021492009031EA /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC851C62B021492009031EA /* TabBarViewController.swift */; };
@@ -142,7 +142,7 @@
 		ED3595B62B0C887C00558FAA /* TimerFinishRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishRequestDTO.swift; sourceTree = "<group>"; };
 		ED3595B82B0C88A300558FAA /* TimerFinishResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishResponseDTO.swift; sourceTree = "<group>"; };
 		ED3595BC2B0DB29F00558FAA /* CategoryModifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModifyViewController.swift; sourceTree = "<group>"; };
-		ED3595BE2B0DB68200558FAA /* CustomTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextView.swift; sourceTree = "<group>"; };
+		ED3595BE2B0DB68200558FAA /* CategoryTitleTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTitleTextView.swift; sourceTree = "<group>"; };
 		ED9B2A7E2B06033F008FE1C5 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		ED9B2A802B06048D008FE1C5 /* CategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewModel.swift; sourceTree = "<group>"; };
 		EDC851C62B021492009031EA /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
@@ -646,7 +646,7 @@
 			children = (
 				EDC851D12B04EE83009031EA /* CategoryListCollectionViewCell.swift */,
 				2CE84EF82B0B8A0B00E2FB71 /* CategorySettingFooterView.swift */,
-				ED3595BE2B0DB68200558FAA /* CustomTextView.swift */,
+				ED3595BE2B0DB68200558FAA /* CategoryTitleTextView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -901,7 +901,7 @@
 				2C5CDA5B2B025440007AFC57 /* ChartViewController.swift in Sources */,
 				6057A58D2B0C7F0F00EE58E8 /* Requestable.swift in Sources */,
 				6057A58F2B0C801300EE58E8 /* NetworkError.swift in Sources */,
-				ED3595BF2B0DB68200558FAA /* CustomTextView.swift in Sources */,
+				ED3595BF2B0DB68200558FAA /* CategoryTitleTextView.swift in Sources */,
 				600908BE2AFCD7DF0065DFFB /* AppDelegate.swift in Sources */,
 				2CE84EFB2B0B92BA00E2FB71 /* UICollectionReusableView++Extension.swift in Sources */,
 				ED3595B72B0C887C00558FAA /* TimerFinishRequestDTO.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		ED3595B22B0C83D700558FAA /* TimerStartResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595B12B0C83D700558FAA /* TimerStartResponseDTO.swift */; };
 		ED3595B72B0C887C00558FAA /* TimerFinishRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595B62B0C887C00558FAA /* TimerFinishRequestDTO.swift */; };
 		ED3595B92B0C88A300558FAA /* TimerFinishResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595B82B0C88A300558FAA /* TimerFinishResponseDTO.swift */; };
+		ED3595BD2B0DB29F00558FAA /* CategoryModifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595BC2B0DB29F00558FAA /* CategoryModifyViewController.swift */; };
+		ED3595BF2B0DB68200558FAA /* CustomTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595BE2B0DB68200558FAA /* CustomTextView.swift */; };
 		ED9B2A7F2B06033F008FE1C5 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9B2A7E2B06033F008FE1C5 /* Category.swift */; };
 		ED9B2A812B06048D008FE1C5 /* CategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9B2A802B06048D008FE1C5 /* CategoryViewModel.swift */; };
 		EDC851C72B021492009031EA /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC851C62B021492009031EA /* TabBarViewController.swift */; };
@@ -139,6 +141,8 @@
 		ED3595B12B0C83D700558FAA /* TimerStartResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerStartResponseDTO.swift; sourceTree = "<group>"; };
 		ED3595B62B0C887C00558FAA /* TimerFinishRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishRequestDTO.swift; sourceTree = "<group>"; };
 		ED3595B82B0C88A300558FAA /* TimerFinishResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishResponseDTO.swift; sourceTree = "<group>"; };
+		ED3595BC2B0DB29F00558FAA /* CategoryModifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModifyViewController.swift; sourceTree = "<group>"; };
+		ED3595BE2B0DB68200558FAA /* CustomTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextView.swift; sourceTree = "<group>"; };
 		ED9B2A7E2B06033F008FE1C5 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		ED9B2A802B06048D008FE1C5 /* CategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewModel.swift; sourceTree = "<group>"; };
 		EDC851C62B021492009031EA /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
@@ -236,6 +240,7 @@
 			children = (
 				601773E32B021E6000D175D9 /* TimerViewController.swift */,
 				2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */,
+				ED3595BC2B0DB29F00558FAA /* CategoryModifyViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -641,6 +646,7 @@
 			children = (
 				EDC851D12B04EE83009031EA /* CategoryListCollectionViewCell.swift */,
 				2CE84EF82B0B8A0B00E2FB71 /* CategorySettingFooterView.swift */,
+				ED3595BE2B0DB68200558FAA /* CustomTextView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -895,6 +901,7 @@
 				2C5CDA5B2B025440007AFC57 /* ChartViewController.swift in Sources */,
 				6057A58D2B0C7F0F00EE58E8 /* Requestable.swift in Sources */,
 				6057A58F2B0C801300EE58E8 /* NetworkError.swift in Sources */,
+				ED3595BF2B0DB68200558FAA /* CustomTextView.swift in Sources */,
 				600908BE2AFCD7DF0065DFFB /* AppDelegate.swift in Sources */,
 				2CE84EFB2B0B92BA00E2FB71 /* UICollectionReusableView++Extension.swift in Sources */,
 				ED3595B72B0C887C00558FAA /* TimerFinishRequestDTO.swift in Sources */,
@@ -905,6 +912,7 @@
 				2C6717F82B0535A8004D118D /* Int++Extension.swift in Sources */,
 				ED3595B92B0C88A300558FAA /* TimerFinishResponseDTO.swift in Sources */,
 				ED9B2A7F2B06033F008FE1C5 /* Category.swift in Sources */,
+				ED3595BD2B0DB29F00558FAA /* CategoryModifyViewController.swift in Sources */,
 				2C34309B2B0C8674008CBC85 /* URLSessionable.swift in Sources */,
 				2CE84EF92B0B8A0B00E2FB71 /* CategorySettingFooterView.swift in Sources */,
 				2C3430972B0C7ED8008CBC85 /* EndPoint.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryColorSelectView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryColorSelectView.swift
@@ -1,0 +1,59 @@
+//
+//  CategoryColorSelectView.swift
+//  FlipMate
+//
+//  Created by 신민규 on 11/22/23.
+//
+
+import UIKit
+
+final class CategoryColorSelectView: UIView {
+    private var colorLabel: UILabel = {
+        let colorLabel = UILabel()
+        colorLabel.translatesAutoresizingMaskIntoConstraints = false
+        colorLabel.font = FlipMateFont.mediumRegular.font
+        colorLabel.text = "# 000000"
+        
+        return colorLabel
+    }()
+    
+    private let colorCircle: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = UIImage(systemName: "circle.fill")
+        
+        return imageView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Don't use storyboard")
+    }
+}
+
+private extension CategoryColorSelectView {
+    func configureUI() {
+        addSubview(colorLabel)
+        addSubview(colorCircle)
+        NSLayoutConstraint.activate([
+            colorCircle.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -24.0),
+            colorCircle.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            colorCircle.widthAnchor.constraint(equalToConstant: 24.0),
+            colorCircle.heightAnchor.constraint(equalToConstant: 24.0)
+        ])
+        
+        NSLayoutConstraint.activate([
+            colorLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 24),
+            colorLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        ])
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    CategoryColorSelectView()
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryColorSelectView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryColorSelectView.swift
@@ -11,13 +11,14 @@ final class CategoryColorSelectView: UIView {
     private var colorLabel: UILabel = {
         let colorLabel = UILabel()
         colorLabel.translatesAutoresizingMaskIntoConstraints = false
+        colorLabel.textColor = .label
         colorLabel.font = FlipMateFont.mediumRegular.font
         colorLabel.text = "# 000000"
         
         return colorLabel
     }()
     
-    private let colorCircle: UIImageView = {
+    private var colorCircle: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.image = UIImage(systemName: "circle.fill")
@@ -39,6 +40,7 @@ private extension CategoryColorSelectView {
     func configureUI() {
         addSubview(colorLabel)
         addSubview(colorCircle)
+        self.backgroundColor = .systemBackground
         NSLayoutConstraint.activate([
             colorCircle.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -24.0),
             colorCircle.centerYAnchor.constraint(equalTo: self.centerYAnchor),

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryTitleTextView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryTitleTextView.swift
@@ -20,10 +20,10 @@ final class CategoryTitleTextView: UIView {
         return textView
     }()
     
-    private(set) var placeholder: String? = nil
-    private(set) var isShowPlaceholder: Bool = true
+    private var placeholder: String?
+    private var isShowPlaceholder: Bool = true
     
-    init(placeholder: String){
+    init(placeholder: String) {
         super.init(frame: .zero)
         self.placeholder = placeholder
         configureUI()
@@ -47,23 +47,6 @@ final class CategoryTitleTextView: UIView {
 }
 
 extension CategoryTitleTextView: UITextViewDelegate {
-    func showPlaceholder() {
-        isShowPlaceholder = true
-        textView.text = placeholder
-        textView.textColor = FlipMateColor.gray3.color
-    }
-    
-    func hidePlaceholder() {
-        isShowPlaceholder = false
-        textView.text = ""
-        textView.textColor = .label
-    }
-    
-    func text() -> String? {
-        guard !isShowPlaceholder else { return nil }
-        return textView.text
-    }
-    
     func textViewDidBeginEditing(_ textView: UITextView) {
         if isShowPlaceholder {
             hidePlaceholder()
@@ -77,6 +60,24 @@ extension CategoryTitleTextView: UITextViewDelegate {
     }
 }
 
+private extension CategoryTitleTextView {
+    func showPlaceholder() {
+        isShowPlaceholder = true
+        textView.text = placeholder
+        textView.textColor = FlipMateColor.gray2.color
+    }
+    
+    func hidePlaceholder() {
+        isShowPlaceholder = false
+        textView.text = ""
+        textView.textColor = .label
+    }
+    
+    func text() -> String? {
+        guard !isShowPlaceholder else { return nil }
+        return textView.text
+    }
+}
 @available(iOS 17.0, *)
 #Preview {
     CategoryTitleTextView(placeholder: "HELLO")

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryTitleTextView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryTitleTextView.swift
@@ -7,14 +7,14 @@
 
 import UIKit
 
-final class CustomTextView: UIView {
+final class CategoryTitleTextView: UIView {
     private var textView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.isEditable = true
         textView.isScrollEnabled = false
         textView.backgroundColor = .systemBackground
-        textView.font = FlipMateFont.smallRegular.font
+        textView.font = FlipMateFont.mediumRegular.font
         textView.contentInset = .init(top: 5, left: 10, bottom: 5, right: 10)
         
         return textView
@@ -46,7 +46,7 @@ final class CustomTextView: UIView {
     }
 }
 
-extension CustomTextView: UITextViewDelegate {
+extension CategoryTitleTextView: UITextViewDelegate {
     func showPlaceholder() {
         isShowPlaceholder = true
         textView.text = placeholder
@@ -75,4 +75,9 @@ extension CustomTextView: UITextViewDelegate {
             showPlaceholder()
         }
     }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    CategoryTitleTextView(placeholder: "HELLO")
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryTitleTextView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryTitleTextView.swift
@@ -26,7 +26,7 @@ final class CategoryTitleTextView: UIView {
     init(placeholder: String){
         super.init(frame: .zero)
         self.placeholder = placeholder
-        setupUI()
+        configureUI()
         showPlaceholder()
     }
     
@@ -34,7 +34,7 @@ final class CategoryTitleTextView: UIView {
         fatalError("Don't use storyboard")
     }
     
-    private func setupUI() {
+    private func configureUI() {
         textView.delegate = self
         addSubview(textView)
         NSLayoutConstraint.activate([

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CustomTextView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CustomTextView.swift
@@ -1,0 +1,78 @@
+//
+//  CustomTextView.swift
+//  FlipMate
+//
+//  Created by 신민규 on 11/22/23.
+//
+
+import UIKit
+
+final class CustomTextView: UIView {
+    private var textView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.isEditable = true
+        textView.isScrollEnabled = false
+        textView.backgroundColor = .systemBackground
+        textView.font = FlipMateFont.smallRegular.font
+        textView.contentInset = .init(top: 5, left: 10, bottom: 5, right: 10)
+        
+        return textView
+    }()
+    
+    private(set) var placeholder: String? = nil
+    private(set) var isShowPlaceholder: Bool = true
+    
+    init(placeholder: String){
+        super.init(frame: .zero)
+        self.placeholder = placeholder
+        setupUI()
+        showPlaceholder()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Don't use storyboard")
+    }
+    
+    private func setupUI() {
+        textView.delegate = self
+        addSubview(textView)
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: self.topAnchor),
+            textView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            textView.leftAnchor.constraint(equalTo: self.leftAnchor),
+            textView.rightAnchor.constraint(equalTo: self.rightAnchor)
+        ])
+    }
+}
+
+extension CustomTextView: UITextViewDelegate {
+    func showPlaceholder() {
+        isShowPlaceholder = true
+        textView.text = placeholder
+        textView.textColor = FlipMateColor.gray3.color
+    }
+    
+    func hidePlaceholder() {
+        isShowPlaceholder = false
+        textView.text = ""
+        textView.textColor = .label
+    }
+    
+    func text() -> String? {
+        guard !isShowPlaceholder else { return nil }
+        return textView.text
+    }
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if isShowPlaceholder {
+            hidePlaceholder()
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            showPlaceholder()
+        }
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
@@ -83,7 +83,7 @@ final class CategoryModifyViewController: BaseViewController {
         ])
         
         NSLayoutConstraint.activate([
-            categoryTitleTextView.topAnchor.constraint(equalTo: firstSectionTitleLabel.bottomAnchor, constant: 20),
+            categoryTitleTextView.topAnchor.constraint(equalTo: firstSectionTitleLabel.bottomAnchor, constant: 12),
             categoryTitleTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 30),
             categoryTitleTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -30)
         ])
@@ -94,7 +94,7 @@ final class CategoryModifyViewController: BaseViewController {
         ])
         
         NSLayoutConstraint.activate([
-            categoryColorSelectView.topAnchor.constraint(equalTo: secondSectionTitleLabel.bottomAnchor, constant: 20),
+            categoryColorSelectView.topAnchor.constraint(equalTo: secondSectionTitleLabel.bottomAnchor, constant: 12),
             categoryColorSelectView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 30),
             categoryColorSelectView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -30),
             categoryColorSelectView.heightAnchor.constraint(equalTo: categoryTitleTextView.heightAnchor)

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
@@ -1,0 +1,8 @@
+//
+//  CategoryModifyViewController.swift
+//  FlipMate
+//
+//  Created by 신민규 on 11/22/23.
+//
+
+import Foundation

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
@@ -30,13 +30,34 @@ final class CategoryModifyViewController: BaseViewController {
         return label
     }()
     
+    private lazy var secondSectionTitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = ConstantString.sectionNames.last
+        label.font = FlipMateFont.mediumBold.font
+        label.textColor = .label
+        
+        return label
+    }()
+    
     private lazy var categoryTitleTextView: CategoryTitleTextView = {
         let textView = CategoryTitleTextView(placeholder: ConstantString.placeHolders[0])
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.layer.masksToBounds = true
         textView.layer.cornerRadius = 6
+        
         return textView
     }()
+    
+    private lazy var categoryColorSelectView: CategoryColorSelectView = {
+        let colorView = CategoryColorSelectView()
+        colorView.translatesAutoresizingMaskIntoConstraints = false
+        colorView.layer.masksToBounds = true
+        colorView.layer.cornerRadius = 6
+        
+        return colorView
+    }()
+    
     // MARK: View LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -47,7 +68,9 @@ final class CategoryModifyViewController: BaseViewController {
     override func configureUI() {
         view.backgroundColor = FlipMateColor.gray4.color
         let subViews = [firstSectionTitleLabel,
-                        categoryTitleTextView
+                        categoryTitleTextView,
+                        secondSectionTitleLabel,
+                        categoryColorSelectView
                         ]
 
         subViews.forEach {
@@ -63,6 +86,18 @@ final class CategoryModifyViewController: BaseViewController {
             categoryTitleTextView.topAnchor.constraint(equalTo: firstSectionTitleLabel.bottomAnchor, constant: 20),
             categoryTitleTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 30),
             categoryTitleTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -30)
+        ])
+        
+        NSLayoutConstraint.activate([
+            secondSectionTitleLabel.topAnchor.constraint(equalTo: categoryTitleTextView.bottomAnchor, constant: 60),
+            secondSectionTitleLabel.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 32)
+        ])
+        
+        NSLayoutConstraint.activate([
+            categoryColorSelectView.topAnchor.constraint(equalTo: secondSectionTitleLabel.bottomAnchor, constant: 20),
+            categoryColorSelectView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 30),
+            categoryColorSelectView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -30),
+            categoryColorSelectView.heightAnchor.constraint(equalTo: categoryTitleTextView.heightAnchor)
         ])
     }
 }
@@ -92,7 +127,7 @@ private extension CategoryModifyViewController {
         // TODO: 완료 버튼 눌렸을 때 동작
     }
 }
-//@available(iOS 17.0, *)
-//#Preview {
-//    CategoryModifyViewController()
-//}
+@available(iOS 17.0, *)
+#Preview {
+    CategoryModifyViewController()
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
@@ -5,4 +5,65 @@
 //  Created by 신민규 on 11/22/23.
 //
 
-import Foundation
+import UIKit
+
+final class CategoryModifyViewController: BaseViewController {
+    private enum ConstantString {
+        static let title = "카테고리 수정"
+        static let leftNavigationBarItemTitle = "닫기"
+        static let rightNavigationBarItemTitle = "완료"
+        static let sectionNames: [String] = ["카테고리 명", "색상"]
+        static let placeHolders: [String] = ["카테고리 이름을 입력해주세요", "색상을 선택해주세요"]
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
+    }
+    // MARK: UI Components
+    private lazy var firstSectionTitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = ConstantString.sectionNames.first
+        label.font = FlipMateFont.mediumBold.font
+        label.textColor = .label
+        
+        return label
+    }()
+    
+    private lazy var categoryTitleTextView: CategoryTitleTextView = {
+        let textView = CategoryTitleTextView(placeholder: ConstantString.placeHolders[0])
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.layer.masksToBounds = true
+        textView.layer.cornerRadius = 6
+        return textView
+    }()
+    
+    // MARK: Configure UI
+    override func configureUI() {
+        view.backgroundColor = FlipMateColor.gray4.color
+        let subViews = [firstSectionTitleLabel,
+                        categoryTitleTextView
+                        ]
+
+        subViews.forEach {
+                view.addSubview($0)
+            }
+        
+        NSLayoutConstraint.activate([
+            firstSectionTitleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 60),
+            firstSectionTitleLabel.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 32)
+        ])
+        
+        NSLayoutConstraint.activate([
+            categoryTitleTextView.topAnchor.constraint(equalTo: firstSectionTitleLabel.bottomAnchor, constant: 20),
+            categoryTitleTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 30),
+            categoryTitleTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -30)
+        ])
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    CategoryModifyViewController()
+}
+

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
@@ -37,6 +37,11 @@ final class CategoryModifyViewController: BaseViewController {
         textView.layer.cornerRadius = 6
         return textView
     }()
+    // MARK: View LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUpNavigation()
+    }
     
     // MARK: Configure UI
     override func configureUI() {
@@ -62,8 +67,32 @@ final class CategoryModifyViewController: BaseViewController {
     }
 }
 
-@available(iOS 17.0, *)
-#Preview {
-    CategoryModifyViewController()
+// MARK: Navigation Bar
+private extension CategoryModifyViewController {
+    func setUpNavigation() {
+        navigationItem.title = ConstantString.title
+        navigationItem.largeTitleDisplayMode = .never
+        
+        setupNavigationBarButton()
+    }
+    
+    func setupNavigationBarButton() {
+        let closeButton = UIBarButtonItem(title: ConstantString.leftNavigationBarItemTitle, style: .plain, target: self, action: #selector(closeButtonTapped))
+        let doneButton = UIBarButtonItem(title: ConstantString.rightNavigationBarItemTitle, style: .done, target: self, action: #selector(doneButtonTapped))
+    }
 }
 
+// MARK: objc function
+private extension CategoryModifyViewController {
+    @objc func closeButtonTapped(_ sender: UIBarButtonItem) {
+        dismiss(animated: true)
+    }
+    
+    @objc func doneButtonTapped(_ sender: UIBarButtonItem) {
+        // TODO: 완료 버튼 눌렸을 때 동작
+    }
+}
+//@available(iOS 17.0, *)
+//#Preview {
+//    CategoryModifyViewController()
+//}


### PR DESCRIPTION
close #113 

## 완료된 기능

UI만 구현했습니다. 

<img width="334" alt="image" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/138603822/ab6b24e7-eaff-4b61-a46d-1fa398538a41">

## 고민과 해결과정

1. 기존 피그마 디자인 색상 섹션에 이름이 그대로 들어가는 데, 구현해보니 조금 어색해서 Hex를 넣으려고 하는데 어떻게 생각하시나요?

2. 추후 화면 연결 시 Navigation Controller를 사용할 지, 아니면 사용 안 할 지 확실하지 않아서 Navigation Bar를 구체화해서 넣지는 않았습니다. 다만 로직은 모두 구현해두었기에 NavigationController를 사용하지 않는다면 NavigationBar Component만 추가하면 될 것 같습니다. 만약 사용하면 코드 그대로 두셔도 됩니다.

3. Cell 말고 모두 Custom View로 구현했습니다.