### PR TITLE
[BE#152] preproduction cd

### DIFF
--- a/.github/workflows/be-pre-production-workflow.yaml
+++ b/.github/workflows/be-pre-production-workflow.yaml
@@ -1,0 +1,31 @@
+name: BE Pre Production Workflow
+
+on:
+  push:
+    branches: preproduction
+    paths: "BE/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: connect to NCP
+        use: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME }}
+          password: ${{ secrets.NCP_PASSWORD }}
+
+          script: |
+            cd iOS06-FlipMate-preproduction/BE
+            git pull origin preproduction
+            npm install
+            if ! pm2 list | grep -q "flipmate-preproduction"; then
+              pm2 start npm --name "flipmate-preproduction" -- run start
+            else 
+              pm2 restart flipmate-preproduction
+            fi

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -9,7 +9,8 @@ async function bootstrap() {
   const configService = new ConfigService();
 
   let httpsOptions = null;
-  if (configService.get<boolean>('SSL')) {
+  const ssl = configService.get<string>('SSL');
+  if (ssl == 'true') {
     httpsOptions = {
       key: readFileSync(configService.get<string>('HTTPS_KEY_PATH')),
       cert: readFileSync(configService.get<string>('HTTPS_CERT_PATH')),
@@ -29,6 +30,6 @@ async function bootstrap() {
 
   app.useGlobalPipes(new ValidationPipe());
 
-  await app.listen(3000);
+  await app.listen(configService.get<number>('PORT'));
 }
 bootstrap();


### PR DESCRIPTION
# 이슈번호-작업이름

## 완료된 기능
- cd 일단 했는데 잘 되는지 테스트를 해야합니다..

## 고민과 해결과정
preproduction 브랜치의 BE 폴더에 푸쉬가 발생하면 액션이 발생하도록 했습니다.
```ts
configService.get<boolean>('SSL');
```
위 코드가 계속 string 값을 뽑아오길래 그냥 string으로 비교하도록 바꿨습니다
포트 환경변수로 바꿔서 개발용 / 가배포용으로 나눌 예정입니다
개발용 포트 : 3333
가배포용 포트: 3000