### PR TITLE
[BE#155] 아이폰용 로그인

### DIFF
--- a/BE/src/app.controller.ts
+++ b/BE/src/app.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get('')
+  @ApiExcludeEndpoint()
   getHello(): string {
     return this.appService.getHello();
   }

--- a/BE/src/auth/google.strategy.ts
+++ b/BE/src/auth/google.strategy.ts
@@ -20,9 +20,9 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     email: any,
     done: VerifyCallback,
   ): Promise<any> {
+    console.log(accessToken);
     const user = {
       email: email.emails[0].value,
-      accessToken,
     };
     done(null, user);
   }

--- a/BE/src/categories/categories.controller.ts
+++ b/BE/src/categories/categories.controller.ts
@@ -12,6 +12,7 @@ import {
   ApiBadRequestResponse,
   ApiBearerAuth,
   ApiCreatedResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiTags,
@@ -23,7 +24,7 @@ import { CategoryDto } from './dto/response/category.dto';
 import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
 import { User } from 'src/users/decorator/user.decorator';
 
-@ApiTags('Categories')
+@ApiTags('카테고리 페이지')
 @Controller('categories')
 export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
@@ -31,7 +32,7 @@ export class CategoriesController {
   @Get()
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: '카테고리 조회' })
+  @ApiOperation({ summary: '카테고리 조회 (완)' })
   @ApiCreatedResponse({
     type: [CategoryDto],
     description: '카테고리 조회 성공',
@@ -46,7 +47,7 @@ export class CategoriesController {
   @Post()
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: '카테고리 생성' })
+  @ApiOperation({ summary: '카테고리 생성 (완)' })
   @ApiCreatedResponse({
     type: CategoryDto,
     description: '카테고리 생성 성공',
@@ -64,14 +65,14 @@ export class CategoriesController {
   @Patch(':category_id')
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: '카테고리 수정' })
+  @ApiOperation({ summary: '카테고리 수정 (완)' })
   @ApiParam({
     name: 'category_id',
     description: '카테고리 id',
     type: Number,
     required: true,
   })
-  @ApiCreatedResponse({
+  @ApiOkResponse({
     type: CategoryDto,
     description: '카테고리 수정 성공',
   })

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -27,7 +27,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('StudyLog API')
     .setDescription('StudyLog 애플리케이션 API 문서')
-    .setVersion('1.0')
+    .setVersion('2.0')
     .addBearerAuth()
     .build();
 

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -2,21 +2,19 @@ import { Controller, Delete, Get, Param, Post } from '@nestjs/common';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @Controller('mates')
+@ApiTags('소셜 페이지')
 export class MatesController {
   @Get()
-  @ApiTags('Social')
   @ApiOperation({ summary: '모든 친구들 조회하기' })
   getMates() {}
 
   @Get('/:mate_id/stats')
-  @ApiTags('Mate Stats')
   @ApiOperation({ summary: '특정 친구의 통계 조회하기' })
   getMateStats(@Param('mate_id') id: string) {
     id;
   }
 
   @Post()
-  @ApiTags('Social')
   @ApiCreatedResponse({
     description: '친구가 성공적으로 구독되었습니다.',
   })
@@ -24,7 +22,6 @@ export class MatesController {
   crateMate() {}
 
   @Delete('/:mate_id')
-  @ApiTags('Social')
   @ApiOperation({ summary: '구독한 친구 구독 취소하기' })
   deleteMate(@Param('mate_id') id: string) {
     id;

--- a/BE/src/study-logs/study-logs.controller.ts
+++ b/BE/src/study-logs/study-logs.controller.ts
@@ -1,12 +1,4 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Post,
-  Query,
-  Delete,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { StudyLogsService } from './study-logs.service';
 import { StudyLogs } from './study-logs.entity';
 import {
@@ -21,14 +13,14 @@ import { StudyLogsDto } from './dto/response/study-logs.dto';
 import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
 import { User } from 'src/users/decorator/user.decorator';
 
-@ApiTags('Timer')
+@ApiTags('타이머 페이지')
 @Controller('study-logs')
 export class StudyLogsController {
   constructor(private readonly studyLogsService: StudyLogsService) {}
 
   @Post()
   @UseGuards(AccessTokenGuard)
-  @ApiOperation({ summary: '학습시간 생성 및 종료' })
+  @ApiOperation({ summary: '학습시간 생성 및 종료 (완)' })
   @ApiCreatedResponse({
     type: StudyLogsCreateDto,
     description: '학습 기록이 성공적으로 생성되었습니다.',
@@ -60,10 +52,10 @@ export class StudyLogsController {
   }
 }
 
+@ApiTags('통계 페이지')
 @Controller('/study-logs/stats')
 export class StatsController {
   @Get()
-  @ApiTags('Stats')
   @ApiOperation({ summary: '일간 통계 조회하기' })
   getStats(
     @Query('year') year: number,
@@ -74,12 +66,10 @@ export class StatsController {
   }
 
   @Get('/weekly')
-  @ApiTags('Stats')
   @ApiOperation({ summary: '주간 통계 조회하기' })
   getWeeklyStats() {}
 
   @Get('/monthly')
-  @ApiTags('Stats')
   @ApiOperation({ summary: '주간 통계 조회하기' })
   getMonthlyStats() {}
 }

--- a/BE/src/users/dto/update-user.dto.ts
+++ b/BE/src/users/dto/update-user.dto.ts
@@ -1,30 +1,22 @@
-import { PickType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/mapped-types';
 import { UsersModel } from '../entity/users.entity';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional } from 'class-validator';
 
-export class CreateUserDto extends PickType(UsersModel, [
-  'nickname',
-  'email',
-  'image_url',
-]) {
+export class UpdateUserDto extends PartialType(UsersModel) {
   @ApiProperty({
     type: 'string',
     example: '어린콩',
     description: '닉네임',
   })
-  nickname: string;
+  @IsOptional()
+  nickname?: string;
 
   @ApiProperty({
     type: 'string',
     example: 'https://sldkjfds/dsflkdsjf.png',
     description: '이미지 링크',
   })
-  image_url: string;
-
-  @ApiProperty({
-    type: 'string',
-    example: '2343242@ildskjf.com',
-    description: '이메일',
-  })
-  email: string;
+  @IsOptional()
+  image_url?: string;
 }

--- a/BE/src/users/entity/users.entity.ts
+++ b/BE/src/users/entity/users.entity.ts
@@ -16,11 +16,11 @@ export class UsersModel {
     description: '유저 닉네임',
   })
   @Column({
-    length: 20,
+    length: 84,
     unique: true,
   })
   @IsString()
-  @Length(1, 20)
+  @Length(1, 84)
   nickname: string;
 
   @ApiProperty({

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -6,15 +6,15 @@ import {
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
-import { UsersService } from './users.service';
 
-@ApiTags('Users')
-@Controller('users')
+import { UsersService } from './users.service';
+@ApiTags('로그인 페이지')
+@Controller('user')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get('/nickname-validation')
-  @ApiOperation({ summary: '유저 닉네임 유효한지 확인' })
+  @ApiOperation({ summary: '유저 닉네임 유효한지 확인 (완)' })
   @ApiQuery({
     name: 'nickname',
     example: '어린콩',
@@ -29,9 +29,7 @@ export class UsersController {
   @ApiBadRequestResponse({
     description: '잘못된 요청',
   })
-  async validateNickname(
-    @Query('nickname') nickname: string,
-  ): Promise<boolean> {
+  async validateNickname(@Query('nickname') nickname: string): Promise<object> {
     return this.usersService.isUniqueNickname(nickname);
   }
 }

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UsersModel } from './entity/users.entity';
 import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @Injectable()
 export class UsersService {
@@ -29,11 +30,29 @@ export class UsersService {
     }
   }
 
-  async isUniqueNickname(nickname: string): Promise<boolean> {
+  async updateUser(user_id: number, user: UpdateUserDto): Promise<UsersModel> {
+    const selectedUser = await this.usersRepository.findOne({
+      where: { id: user_id },
+    });
+    if (user.nickname) {
+      selectedUser.nickname = user.nickname;
+    }
+    if (user.image_url) {
+      selectedUser.image_url = user.image_url;
+    }
+
+    const updatedUser = await this.usersRepository.save(selectedUser);
+    return updatedUser;
+  }
+
+  async isUniqueNickname(nickname: string): Promise<object> {
     const isDuplicated = await this.usersRepository.exist({
       where: { nickname },
     });
-    return !isDuplicated;
+
+    return {
+      is_unique: !isDuplicated,
+    };
   }
 
   async findUserByEmail(email: string): Promise<UsersModel> {


### PR DESCRIPTION
- fetch 요청을 통해 구글 서버에 access_token 보내기
- 새로운 사용자는 is_member false 반환
- 사용자는 base64 닉네임으로 미리 생성 후 유저정보 변경하도록 유도

## 고민과 해결과정
- 사용자를 미리 생성해두고 닉네임 변경하도록 유도 한다면 닉네임 중복은 어떻게 피하지? -> '이메일 + 타입'을 base64로 인코딩
