### PR TITLE
[iOS#201] DI Conatiner 및 Coordinator 패턴 적용

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -47,6 +47,10 @@
 		2C88DCF92B1242DA000B4686 /* TimerFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCF82B1242DA000B4686 /* TimerFlowCoordinator.swift */; };
 		2C88DCFB2B124451000B4686 /* LoginDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCFA2B124451000B4686 /* LoginDIContainer.swift */; };
 		2C88DCFE2B1244A6000B4686 /* LoginFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCFD2B1244A6000B4686 /* LoginFlowCoordinator.swift */; };
+		2C88DD052B1256D0000B4686 /* TabBarFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD042B1256D0000B4686 /* TabBarFlowCoordinator.swift */; };
+		2C88DD072B125781000B4686 /* TabBarDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD062B125781000B4686 /* TabBarDIContainer.swift */; };
+		2C88DD092B1274FA000B4686 /* CategorySettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD082B1274FA000B4686 /* CategorySettingCoordinator.swift */; };
+		2C88DD0B2B1340E4000B4686 /* CategoryDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD0A2B1340E4000B4686 /* CategoryDIContainer.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -164,6 +168,10 @@
 		2C88DCF82B1242DA000B4686 /* TimerFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFlowCoordinator.swift; sourceTree = "<group>"; };
 		2C88DCFA2B124451000B4686 /* LoginDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginDIContainer.swift; sourceTree = "<group>"; };
 		2C88DCFD2B1244A6000B4686 /* LoginFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFlowCoordinator.swift; sourceTree = "<group>"; };
+		2C88DD042B1256D0000B4686 /* TabBarFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarFlowCoordinator.swift; sourceTree = "<group>"; };
+		2C88DD062B125781000B4686 /* TabBarDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarDIContainer.swift; sourceTree = "<group>"; };
+		2C88DD082B1274FA000B4686 /* CategorySettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingCoordinator.swift; sourceTree = "<group>"; };
+		2C88DD0A2B1340E4000B4686 /* CategoryDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDIContainer.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -414,6 +422,7 @@
 			isa = PBXGroup;
 			children = (
 				2C88DCF82B1242DA000B4686 /* TimerFlowCoordinator.swift */,
+				2C88DD082B1274FA000B4686 /* CategorySettingCoordinator.swift */,
 			);
 			path = Flows;
 			sourceTree = "<group>";
@@ -422,6 +431,31 @@
 			isa = PBXGroup;
 			children = (
 				2C88DCFD2B1244A6000B4686 /* LoginFlowCoordinator.swift */,
+			);
+			path = Flows;
+			sourceTree = "<group>";
+		};
+		2C88DD012B1256B5000B4686 /* TabBar */ = {
+			isa = PBXGroup;
+			children = (
+				2C88DD032B1256C4000B4686 /* Flows */,
+				2C88DD022B1256BD000B4686 /* ViewController */,
+			);
+			path = TabBar;
+			sourceTree = "<group>";
+		};
+		2C88DD022B1256BD000B4686 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				EDC851C62B021492009031EA /* TabBarViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		2C88DD032B1256C4000B4686 /* Flows */ = {
+			isa = PBXGroup;
+			children = (
+				2C88DD042B1256D0000B4686 /* TabBarFlowCoordinator.swift */,
 			);
 			path = Flows;
 			sourceTree = "<group>";
@@ -520,6 +554,7 @@
 		600908EF2AFCDBC90065DFFB /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				2C88DD012B1256B5000B4686 /* TabBar */,
 				2C2F21812B0F53AB00B45BA8 /* Mocks */,
 				600908F62AFCDDDC0065DFFB /* Splash */,
 				600908F42AFCDCFA0065DFFB /* LoginScene */,
@@ -528,7 +563,6 @@
 				600908F22AFCDCE10065DFFB /* SocialScene */,
 				600908F52AFCDD0A0065DFFB /* MyPageScene */,
 				600908FE2AFCDF8D0065DFFB /* Utils */,
-				EDC851C62B021492009031EA /* TabBarViewController.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -709,6 +743,8 @@
 				2C88DCF32B124272000B4686 /* AppDIContainer.swift */,
 				2C88DCF52B124292000B4686 /* TimerSceneDIContainer.swift */,
 				2C88DCFA2B124451000B4686 /* LoginDIContainer.swift */,
+				2C88DD062B125781000B4686 /* TabBarDIContainer.swift */,
+				2C88DD0A2B1340E4000B4686 /* CategoryDIContainer.swift */,
 			);
 			path = DIContainer;
 			sourceTree = "<group>";
@@ -1097,6 +1133,8 @@
 				ED3842252B0F1DDA001E2803 /* DefaultGoogleAuthUseCase.swift in Sources */,
 				2C801D7E2B04B65400A7ABAE /* DefaultTimerUseCase.swift in Sources */,
 				2C88DCFB2B124451000B4686 /* LoginDIContainer.swift in Sources */,
+				2C88DD072B125781000B4686 /* TabBarDIContainer.swift in Sources */,
+				2C88DD092B1274FA000B4686 /* CategorySettingCoordinator.swift in Sources */,
 				2C4D55AB2B033029006D7C26 /* UIView++Extension.swift in Sources */,
 				60F67C6A2B0E1868002C8BF3 /* DefaultCategoryUseCase.swift in Sources */,
 				2C5CDA4B2B0252C1007AFC57 /* LoginType.swift in Sources */,
@@ -1166,11 +1204,13 @@
 				2C3430B12B0DE3D0008CBC85 /* Date++Extension.swift in Sources */,
 				2C2F217E2B0F4D7F00B45BA8 /* DefaultStudyLogRepository.swift in Sources */,
 				2C5CDA4F2B025403007AFC57 /* SocialViewController.swift in Sources */,
+				2C88DD052B1256D0000B4686 /* TabBarFlowCoordinator.swift in Sources */,
 				ED9B2A812B06048D008FE1C5 /* CategoryViewModel.swift in Sources */,
 				60DE49402B05E67200ACE6DD /* FlipMateConstant.swift in Sources */,
 				ED3842232B0F1D70001E2803 /* GoogleAuthRepostiory.swift in Sources */,
 				2C801D832B04C64F00A7ABAE /* TimerManager.swift in Sources */,
 				2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */,
+				2C88DD0B2B1340E4000B4686 /* CategoryDIContainer.swift in Sources */,
 				ED3842312B0F94E6001E2803 /* DefaultCategoryRepository.swift in Sources */,
 				ED3595C12B0DC2F100558FAA /* CategoryColorSelectView.swift in Sources */,
 				ED38421B2B0F1B7E001E2803 /* GoogleAuthRequestDTO.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -41,6 +41,12 @@
 		2C801D7E2B04B65400A7ABAE /* DefaultTimerUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C801D7D2B04B65400A7ABAE /* DefaultTimerUseCase.swift */; };
 		2C801D802B04B68900A7ABAE /* TimerUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C801D7F2B04B68900A7ABAE /* TimerUseCase.swift */; };
 		2C801D832B04C64F00A7ABAE /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C801D822B04C64F00A7ABAE /* TimerManager.swift */; };
+		2C88DCF22B124238000B4686 /* AppFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCF12B124238000B4686 /* AppFlowCoordinator.swift */; };
+		2C88DCF42B124272000B4686 /* AppDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCF32B124272000B4686 /* AppDIContainer.swift */; };
+		2C88DCF62B124292000B4686 /* TimerSceneDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCF52B124292000B4686 /* TimerSceneDIContainer.swift */; };
+		2C88DCF92B1242DA000B4686 /* TimerFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCF82B1242DA000B4686 /* TimerFlowCoordinator.swift */; };
+		2C88DCFB2B124451000B4686 /* LoginDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCFA2B124451000B4686 /* LoginDIContainer.swift */; };
+		2C88DCFE2B1244A6000B4686 /* LoginFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCFD2B1244A6000B4686 /* LoginFlowCoordinator.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -152,6 +158,12 @@
 		2C801D7D2B04B65400A7ABAE /* DefaultTimerUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTimerUseCase.swift; sourceTree = "<group>"; };
 		2C801D7F2B04B68900A7ABAE /* TimerUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerUseCase.swift; sourceTree = "<group>"; };
 		2C801D822B04C64F00A7ABAE /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
+		2C88DCF12B124238000B4686 /* AppFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlowCoordinator.swift; sourceTree = "<group>"; };
+		2C88DCF32B124272000B4686 /* AppDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainer.swift; sourceTree = "<group>"; };
+		2C88DCF52B124292000B4686 /* TimerSceneDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerSceneDIContainer.swift; sourceTree = "<group>"; };
+		2C88DCF82B1242DA000B4686 /* TimerFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFlowCoordinator.swift; sourceTree = "<group>"; };
+		2C88DCFA2B124451000B4686 /* LoginDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginDIContainer.swift; sourceTree = "<group>"; };
+		2C88DCFD2B1244A6000B4686 /* LoginFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFlowCoordinator.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -398,6 +410,22 @@
 			path = TimerManager;
 			sourceTree = "<group>";
 		};
+		2C88DCF72B1242C7000B4686 /* Flows */ = {
+			isa = PBXGroup;
+			children = (
+				2C88DCF82B1242DA000B4686 /* TimerFlowCoordinator.swift */,
+			);
+			path = Flows;
+			sourceTree = "<group>";
+		};
+		2C88DCFC2B124498000B4686 /* Flows */ = {
+			isa = PBXGroup;
+			children = (
+				2C88DCFD2B1244A6000B4686 /* LoginFlowCoordinator.swift */,
+			);
+			path = Flows;
+			sourceTree = "<group>";
+		};
 		48114A3517087E7FD0C9546F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -471,6 +499,7 @@
 		600908ED2AFCDB6E0065DFFB /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				2C88DCF12B124238000B4686 /* AppFlowCoordinator.swift */,
 				600908BD2AFCD7DF0065DFFB /* AppDelegate.swift */,
 				600908BF2AFCD7DF0065DFFB /* SceneDelegate.swift */,
 				600909042AFCE0AB0065DFFB /* DIContainer */,
@@ -507,6 +536,7 @@
 		600908F12AFCDCD80065DFFB /* TimerScene */ = {
 			isa = PBXGroup;
 			children = (
+				2C88DCF72B1242C7000B4686 /* Flows */,
 				2C4D55B12B035476006D7C26 /* Model */,
 				EDC851D02B04EE74009031EA /* View */,
 				2C4D55AC2B0348D1006D7C26 /* ViewModel */,
@@ -534,6 +564,7 @@
 		600908F42AFCDCFA0065DFFB /* LoginScene */ = {
 			isa = PBXGroup;
 			children = (
+				2C88DCFC2B124498000B4686 /* Flows */,
 				2C5CDA492B0252C1007AFC57 /* Model */,
 				ED38422A2B0F451F001E2803 /* ViewModel */,
 				2C5CDA462B0252B2007AFC57 /* ViewController */,
@@ -675,6 +706,9 @@
 		600909042AFCE0AB0065DFFB /* DIContainer */ = {
 			isa = PBXGroup;
 			children = (
+				2C88DCF32B124272000B4686 /* AppDIContainer.swift */,
+				2C88DCF52B124292000B4686 /* TimerSceneDIContainer.swift */,
+				2C88DCFA2B124451000B4686 /* LoginDIContainer.swift */,
 			);
 			path = DIContainer;
 			sourceTree = "<group>";
@@ -1062,6 +1096,7 @@
 				2C4D55B02B0348FB006D7C26 /* TimerViewModel.swift in Sources */,
 				ED3842252B0F1DDA001E2803 /* DefaultGoogleAuthUseCase.swift in Sources */,
 				2C801D7E2B04B65400A7ABAE /* DefaultTimerUseCase.swift in Sources */,
+				2C88DCFB2B124451000B4686 /* LoginDIContainer.swift in Sources */,
 				2C4D55AB2B033029006D7C26 /* UIView++Extension.swift in Sources */,
 				60F67C6A2B0E1868002C8BF3 /* DefaultCategoryUseCase.swift in Sources */,
 				2C5CDA4B2B0252C1007AFC57 /* LoginType.swift in Sources */,
@@ -1075,11 +1110,14 @@
 				ED3595B22B0C83D700558FAA /* TimerStartResponseDTO.swift in Sources */,
 				2C5CDA582B025426007AFC57 /* FlipMateFont.swift in Sources */,
 				60DE493D2B05DEA400ACE6DD /* FlipMateLogger.swift in Sources */,
+				2C88DCF62B124292000B4686 /* TimerSceneDIContainer.swift in Sources */,
 				2C2F21802B0F4DA600B45BA8 /* MockURLSession.swift in Sources */,
 				2C801D802B04B68900A7ABAE /* TimerUseCase.swift in Sources */,
 				6086464E2B0DDA1300B0C1BC /* CategoryRepository.swift in Sources */,
 				2C2F21782B0F4CCC00B45BA8 /* StudyLog.swift in Sources */,
+				2C88DCFE2B1244A6000B4686 /* LoginFlowCoordinator.swift in Sources */,
 				601773E42B021E6000D175D9 /* TimerViewController.swift in Sources */,
+				2C88DCF92B1242DA000B4686 /* TimerFlowCoordinator.swift in Sources */,
 				600908C22AFCD7DF0065DFFB /* ViewController.swift in Sources */,
 				2C3430AB2B0DDB8D008CBC85 /* TimerEndpoints.swift in Sources */,
 				ED3842212B0F1CF9001E2803 /* User.swift in Sources */,
@@ -1087,6 +1125,7 @@
 				2C3430A12B0DA4E6008CBC85 /* BaseComponents.swift in Sources */,
 				2C2F21832B0F53B500B45BA8 /* StduyLogMock.swift in Sources */,
 				60F67C682B0E1785002C8BF3 /* CategoryUseCase.swift in Sources */,
+				2C88DCF42B124272000B4686 /* AppDIContainer.swift in Sources */,
 				2C5CDA5B2B025440007AFC57 /* ChartViewController.swift in Sources */,
 				6057A58D2B0C7F0F00EE58E8 /* Requestable.swift in Sources */,
 				2C3430A72B0DD0F6008CBC85 /* TimerRepsoitory.swift in Sources */,
@@ -1118,6 +1157,7 @@
 				2C2F21762B0F440D00B45BA8 /* StudyLogEndpoints.swift in Sources */,
 				2C4D55B32B035484006D7C26 /* DeviceOrientation.swift in Sources */,
 				ED3842272B0F1E0C001E2803 /* GoogleAuthUseCase.swift in Sources */,
+				2C88DCF22B124238000B4686 /* AppFlowCoordinator.swift in Sources */,
 				EDC851C72B021492009031EA /* TabBarViewController.swift in Sources */,
 				2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */,
 				2C5CDA572B025426007AFC57 /* FlipMateColor.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Application/AppFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Application/AppFlowCoordinator.swift
@@ -27,7 +27,7 @@ final class AppFlowCoordinator: Coordinator {
     
     func start() {
         if isLogginIn {
-            showTimerViewController()
+            showTabBarViewController()
         } else {
             showLoginViewController()
         }
@@ -40,9 +40,9 @@ final class AppFlowCoordinator: Coordinator {
         childCoordinators.append(coordinator)
     }
     
-    private func showTimerViewController() {
-        let timerSceneDIContainer = appDIContainer.makeTimerSceneDIContainer()
-        let coordinator = timerSceneDIContainer.makeTimerFlowCoordinator(navigationController: navigationController)
+    private func showTabBarViewController() {
+        let tabBarDIContainer = appDIContainer.makeTabBarDIContainer()
+        let coordinator = tabBarDIContainer.makeTabBarFlowCoordinator(navigationController: navigationController)
         coordinator.start()
         childCoordinators.append(coordinator)
     }

--- a/iOS/FlipMate/FlipMate/Application/AppFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Application/AppFlowCoordinator.swift
@@ -41,12 +41,13 @@ final class AppFlowCoordinator: Coordinator {
             showTabBarViewController()
         } else {
             showLoginViewController()
-        }
+        }        
     }
 
     private func showLoginViewController() {
         let loginDIContainer = appDIContainer.makeLoginDiContainer()
-        let coordinator = loginDIContainer.makeLoginFlowCoordinator(navigationController: navigationController)
+        let coordinator = loginDIContainer.makeLoginFlowCoordinator(
+            navigationController: navigationController)
         coordinator.start()
         coordinator.parentCoordinator = self
         childCoordinators.append(coordinator)
@@ -54,7 +55,8 @@ final class AppFlowCoordinator: Coordinator {
     
     private func showTabBarViewController() {
         let tabBarDIContainer = appDIContainer.makeTabBarDIContainer()
-        let coordinator = tabBarDIContainer.makeTabBarFlowCoordinator(navigationController: navigationController)
+        let coordinator = tabBarDIContainer.makeTabBarFlowCoordinator(
+            navigationController: navigationController)
         coordinator.start()
         coordinator.parentCoordinator = self
         childCoordinators.append(coordinator)

--- a/iOS/FlipMate/FlipMate/Application/AppFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Application/AppFlowCoordinator.swift
@@ -7,9 +7,20 @@
 
 import UIKit
 
-protocol Coordinator {
+protocol Coordinator: AnyObject {
     var childCoordinators: [Coordinator] { get set }
     func start()
+}
+
+extension Coordinator {
+    func childDidFinish(_ child: Coordinator?) {
+        for (index, coordinator) in childCoordinators.enumerated() {
+            if coordinator === child {
+                childCoordinators.remove(at: index)
+                break
+            }
+        }
+    }
 }
 
 final class AppFlowCoordinator: Coordinator {
@@ -37,6 +48,7 @@ final class AppFlowCoordinator: Coordinator {
         let loginDIContainer = appDIContainer.makeLoginDiContainer()
         let coordinator = loginDIContainer.makeLoginFlowCoordinator(navigationController: navigationController)
         coordinator.start()
+        coordinator.parentCoordinator = self
         childCoordinators.append(coordinator)
     }
     
@@ -44,6 +56,7 @@ final class AppFlowCoordinator: Coordinator {
         let tabBarDIContainer = appDIContainer.makeTabBarDIContainer()
         let coordinator = tabBarDIContainer.makeTabBarFlowCoordinator(navigationController: navigationController)
         coordinator.start()
+        coordinator.parentCoordinator = self
         childCoordinators.append(coordinator)
     }
 }

--- a/iOS/FlipMate/FlipMate/Application/AppFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Application/AppFlowCoordinator.swift
@@ -1,0 +1,49 @@
+//
+//  AppFlowCoordinator.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/25.
+//
+
+import UIKit
+
+protocol Coordinator {
+    var childCoordinators: [Coordinator] { get set }
+    func start()
+}
+
+final class AppFlowCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+    private var navigationController: UINavigationController
+    private let appDIContainer: AppDIContainer
+    
+    // TODO: 추후 자동 로그인 로직 추가
+    var isLogginIn: Bool = false
+    
+    init(navigationController: UINavigationController, appDIContainer: AppDIContainer) {
+        self.navigationController = navigationController
+        self.appDIContainer = appDIContainer
+    }
+    
+    func start() {
+        if isLogginIn {
+            showTimerViewController()
+        } else {
+            showLoginViewController()
+        }
+    }
+
+    private func showLoginViewController() {
+        let loginDIContainer = appDIContainer.makeLoginDiContainer()
+        let coordinator = loginDIContainer.makeLoginFlowCoordinator(navigationController: navigationController)
+        coordinator.start()
+        childCoordinators.append(coordinator)
+    }
+    
+    private func showTimerViewController() {
+        let timerSceneDIContainer = appDIContainer.makeTimerSceneDIContainer()
+        let coordinator = timerSceneDIContainer.makeTimerFlowCoordinator(navigationController: navigationController)
+        coordinator.start()
+        childCoordinators.append(coordinator)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/AppDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/AppDIContainer.swift
@@ -11,16 +11,16 @@ final class AppDIContainer {
     lazy var provider: Provider = Provider(urlSession: URLSession.shared)
     lazy var categoryManager: CategoryManager = CategoryManager()
     
-    func makeTimerSceneDIContainer() -> TimerSceneDIContainer {
-        let dependencies = TimerSceneDIContainer.Dependencies(
+    func makeTabBarDIContainer() -> TabBarDIContainer {
+        let dependencies = TabBarDIContainer.Dependencies(
             provider: provider,
             categoryManager: categoryManager)
         
-        return TimerSceneDIContainer(dependencies: dependencies)
+        return TabBarDIContainer(dependencies: dependencies)
     }
     
     func makeLoginDiContainer() -> LoginDIContainer {
-        let dependencies = LoginDIContainer.Dependencies(provider: provider)
+        let dependencies = LoginDIContainer.Dependencies(provider: provider, categoryManager: categoryManager)
         
         return LoginDIContainer(dependencies: dependencies)
     }

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/AppDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/AppDIContainer.swift
@@ -1,0 +1,27 @@
+//
+//  AppDIContainer.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/25.
+//
+
+import UIKit
+
+final class AppDIContainer {
+    lazy var provider: Provider = Provider(urlSession: URLSession.shared)
+    lazy var categoryManager: CategoryManager = CategoryManager()
+    
+    func makeTimerSceneDIContainer() -> TimerSceneDIContainer {
+        let dependencies = TimerSceneDIContainer.Dependencies(
+            provider: provider,
+            categoryManager: categoryManager)
+        
+        return TimerSceneDIContainer(dependencies: dependencies)
+    }
+    
+    func makeLoginDiContainer() -> LoginDIContainer {
+        let dependencies = LoginDIContainer.Dependencies(provider: provider)
+        
+        return LoginDIContainer(dependencies: dependencies)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/CategoryDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/CategoryDIContainer.swift
@@ -33,14 +33,19 @@ final class CategoryDIContainer: CategoryFlowCoordinatorDependencies {
         return CategorySettingViewController(viewModel: makeCategoryViewModel(actions: actions))
     }
     
-    func makeCategoryModifyViewController(purpose: CategoryPurpose, category: Category? = nil) -> UIViewController {
+    func makeCategoryModifyViewController(
+        purpose: CategoryPurpose,
+        category: Category? = nil
+    ) -> UIViewController {
         return CategoryModifyViewController(
             viewModel: makeCategoryViewModel(),
             purpose: purpose,
             category: category)
     }
     
-    func makeCategoryFlowCoordinator(navigationController: UINavigationController) -> CategoryFlowCoordinator {
+    func makeCategoryFlowCoordinator(
+        navigationController: UINavigationController
+    ) -> CategoryFlowCoordinator {
         return CategoryFlowCoordinator(
             navigationController: navigationController,
             dependencies: self)

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/CategoryDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/CategoryDIContainer.swift
@@ -19,12 +19,25 @@ final class CategoryDIContainer: CategoryFlowCoordinatorDependencies {
         self.dependencies = dependencies
     }
     
-    func makeCategorySettingViewController() -> UIViewController {
-        return CategorySettingViewController(
-            viewModel: CategoryViewModel(
-                useCase: DefaultCategoryUseCase(
-                    repository: DefaultCategoryRepository(
-                        provider: dependencies.provider))))
+    func makeCategoryViewModel(actions: CategoryViewModelActions? = nil) -> CategoryViewModelProtocol {
+        return CategoryViewModel(
+            useCase: DefaultCategoryUseCase(
+                repository: DefaultCategoryRepository(
+                    provider: dependencies.provider)),
+            categoryManager: dependencies.categoryManager,
+            actions: actions
+        )
+    }
+    
+    func makeCategorySettingViewController(actions: CategoryViewModelActions) -> UIViewController {
+        return CategorySettingViewController(viewModel: makeCategoryViewModel(actions: actions))
+    }
+    
+    func makeCategoryModifyViewController(purpose: CategoryPurpose, category: Category? = nil) -> UIViewController {
+        return CategoryModifyViewController(
+            viewModel: makeCategoryViewModel(),
+            purpose: purpose,
+            category: category)
     }
     
     func makeCategoryFlowCoordinator(navigationController: UINavigationController) -> CategoryFlowCoordinator {

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/CategoryDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/CategoryDIContainer.swift
@@ -1,0 +1,35 @@
+//
+//  CategoryDIContainer.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/26.
+//
+
+import UIKit
+
+final class CategoryDIContainer: CategoryFlowCoordinatorDependencies {
+    struct Dependencies {
+        let provider: Providable
+        let categoryManager: CategoryManager
+    }
+    
+    private let dependencies: Dependencies
+    
+    init(dependencies: Dependencies) {
+        self.dependencies = dependencies
+    }
+    
+    func makeCategorySettingViewController() -> UIViewController {
+        return CategorySettingViewController(
+            viewModel: CategoryViewModel(
+                useCase: DefaultCategoryUseCase(
+                    repository: DefaultCategoryRepository(
+                        provider: dependencies.provider))))
+    }
+    
+    func makeCategoryFlowCoordinator(navigationController: UINavigationController) -> CategoryFlowCoordinator {
+        return CategoryFlowCoordinator(
+            navigationController: navigationController,
+            dependencies: self)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/LoginDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/LoginDIContainer.swift
@@ -1,0 +1,39 @@
+//
+//  LoginDIContainer.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/26.
+//
+
+import UIKit
+
+final class LoginDIContainer: LoginFlowCoordinatorDependencies {
+
+    struct Dependencies {
+        let provider: Providable
+    }
+    
+    private let dependencies: Dependencies
+    
+    init(dependencies: Dependencies) {
+        self.dependencies = dependencies
+    }
+    
+    func makeLoginViewController() -> LoginViewController {
+        return LoginViewController(
+            loginViewModel: LoginViewModel(
+                googleAuthUseCase: DefaultGoogleAuthUseCase(
+                    repository: DefaultGoogleAuthRepository(
+                        provider: dependencies.provider)
+                )
+            )
+        )
+    }
+    
+    func makeLoginFlowCoordinator(navigationController: UINavigationController) -> LoginFlowCoordinator {
+        return LoginFlowCoordinator(
+            navigationViewController: navigationController,
+            dependencies: self
+        )
+    }
+}

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/LoginDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/LoginDIContainer.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 final class LoginDIContainer: LoginFlowCoordinatorDependencies {
-
     struct Dependencies {
         let provider: Providable
+        let categoryManager: CategoryManager
     }
     
     private let dependencies: Dependencies
@@ -19,15 +19,24 @@ final class LoginDIContainer: LoginFlowCoordinatorDependencies {
         self.dependencies = dependencies
     }
     
-    func makeLoginViewController() -> LoginViewController {
+    func makeLoginViewController(actions: LoginViewModelActions) -> UIViewController {
         return LoginViewController(
             loginViewModel: LoginViewModel(
                 googleAuthUseCase: DefaultGoogleAuthUseCase(
                     repository: DefaultGoogleAuthRepository(
                         provider: dependencies.provider)
-                )
+                ),
+                actions: actions
             )
         )
+    }
+    
+    func makeTabBarDIContainer() -> TabBarDIContainer {
+        let dependencies = TabBarDIContainer.Dependencies(
+            provider: dependencies.provider,
+            categoryManager: dependencies.categoryManager)
+        
+        return TabBarDIContainer(dependencies: dependencies)
     }
     
     func makeLoginFlowCoordinator(navigationController: UINavigationController) -> LoginFlowCoordinator {

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TabBarDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TabBarDIContainer.swift
@@ -33,7 +33,6 @@ final class TabBarDIContainer: TabBarFlowCoordinatorDependencies {
         return TimerSceneDIContainer(dependencies: dependencies)
     }
     
-    
     func makeTimerViewController() -> UIViewController {
         return UIViewController()
     }

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TabBarDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TabBarDIContainer.swift
@@ -1,0 +1,47 @@
+//
+//  TabBarDIContainer.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/26.
+//
+
+import UIKit
+
+final class TabBarDIContainer: TabBarFlowCoordinatorDependencies {
+    
+    struct Dependencies {
+        let provider: Providable
+        let categoryManager: CategoryManager
+    }
+    
+    private let dependencies: Dependencies
+    
+    init(dependencies: Dependencies) {
+        self.dependencies = dependencies
+    }
+    
+    func makeTabBarController() -> UITabBarController {
+        return TabBarViewController()
+    }
+    
+    func makeTimerDIContainer() -> TimerSceneDIContainer {
+        let dependencies = TimerSceneDIContainer.Dependencies(
+            provider: dependencies.provider,
+            categoryManager: dependencies.categoryManager
+        )
+        
+        return TimerSceneDIContainer(dependencies: dependencies)
+    }
+    
+    
+    func makeTimerViewController() -> UIViewController {
+        return UIViewController()
+    }
+    
+    func makeTabBarFlowCoordinator(navigationController: UINavigationController) -> TabBarFlowCoordinator {
+        return TabBarFlowCoordinator(
+            navigationController: navigationController,
+            dependencies: self
+        )
+    }
+}

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
@@ -1,0 +1,54 @@
+//
+//  TimerSceneDIContainer.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/25.
+//
+
+import UIKit
+
+final class TimerSceneDIContainer: TimerFlowCoordinatorDependencies {
+    struct Dependencies {
+        let provider: Providable
+        let categoryManager: CategoryManager
+    }
+    
+    private let dependencies: Dependencies
+    
+    init(dependencies: Dependencies) {
+        self.dependencies = dependencies
+    }
+    
+    func makeTimerViewController() -> TimerViewController {
+        return TimerViewController(
+            timerViewModel: makeTimerViewModel())
+    }
+    
+    func makeTimerViewModel() -> TimerViewModelProtocol {
+        return TimerViewModel(
+            timerUseCase: makeTimerUseCase(),
+            userInfoUserCase: makeUserInfoUseCase())
+    }
+    
+    func makeTimerUseCase() -> TimerUseCase {
+        return DefaultTimerUseCase(timerRepository: makeTimerRepository())
+    }
+    
+    func makeUserInfoUseCase() -> StudyLogUseCase {
+        return DefaultStudyLogUseCase(userInfoRepository: makeUserInfoRespository())
+    }
+    
+    func makeTimerRepository() -> TimerRepsoitory {
+        return DefaultTimerRepository(provider: dependencies.provider)
+    }
+    
+    func makeUserInfoRespository() -> StudyLogRepository {
+        return DefaultStudyLogRepository(provider: dependencies.provider)
+    }
+    
+    func makeTimerFlowCoordinator(navigationController: UINavigationController) -> TimerFlowCoordinator {
+        return TimerFlowCoordinator(
+            navigationController: navigationController,
+            dependencies: self)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
@@ -19,15 +19,16 @@ final class TimerSceneDIContainer: TimerFlowCoordinatorDependencies {
         self.dependencies = dependencies
     }
     
-    func makeTimerViewController() -> TimerViewController {
+    func makeTimerViewController(actions: TimerViewModelActions) -> TimerViewController {
         return TimerViewController(
-            timerViewModel: makeTimerViewModel())
+            timerViewModel: makeTimerViewModel(actions: actions))
     }
     
-    func makeTimerViewModel() -> TimerViewModelProtocol {
+    func makeTimerViewModel(actions: TimerViewModelActions) -> TimerViewModelProtocol {
         return TimerViewModel(
             timerUseCase: makeTimerUseCase(),
-            userInfoUserCase: makeUserInfoUseCase())
+            userInfoUserCase: makeUserInfoUseCase(),
+            actions: actions)
     }
     
     func makeTimerUseCase() -> TimerUseCase {
@@ -50,5 +51,13 @@ final class TimerSceneDIContainer: TimerFlowCoordinatorDependencies {
         return TimerFlowCoordinator(
             navigationController: navigationController,
             dependencies: self)
+    }
+    
+    // MARK: - Category Setting
+    func makeCategoryDIContainer() -> CategoryDIContainer {
+        let dependencies = CategoryDIContainer.Dependencies(
+            provider: dependencies.provider,
+            categoryManager: dependencies.categoryManager)
+        return CategoryDIContainer(dependencies: dependencies)
     }
 }

--- a/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
+++ b/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
@@ -8,8 +8,11 @@
 import UIKit
 import GoogleSignIn
 
+final class CategoryManager { }
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    
+    let appDIContainer = AppDIContainer()
+    var appFlowCoordinator: AppFlowCoordinator?
     var window: UIWindow?
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
@@ -18,11 +21,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = LoginViewController(loginViewModel: LoginViewModel(googleAuthUseCase: DefaultGoogleAuthUseCase(repository: DefaultGoogleAuthRepository(provider: Provider(urlSession: URLSession.shared)))))
+        self.window = window
+
+        let navigationController = UINavigationController()
+        window.rootViewController = navigationController
+        
+        appFlowCoordinator = AppFlowCoordinator(
+            navigationController: navigationController,
+            appDIContainer: appDIContainer
+        )
+        
+        appFlowCoordinator?.start()
         window.makeKeyAndVisible()
         try? KeychainManager.deleteAccessToken()
-        
-        self.window = window
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
+++ b/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
@@ -15,7 +15,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var appFlowCoordinator: AppFlowCoordinator?
     var window: UIWindow?
     
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
         guard let windowScene = (scene as? UIWindowScene) else {
             return
         }

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultCategoryRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultCategoryRepository.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 final class DefaultCategoryRepository: CategoryRepository {
-    private let provider: Provider
+    private let provider: Providable
     
-    init(provider: Provider) {
+    init(provider: Providable) {
         self.provider = provider
     }
     

--- a/iOS/FlipMate/FlipMate/Data/Repositories/Utils/DefaultGoogleAuthRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/Utils/DefaultGoogleAuthRepository.swift
@@ -16,9 +16,9 @@ final class DefaultGoogleAuthRepository: GoogleAuthRepository {
         return responseDTO
     }
     
-    private let provider: Provider
+    private let provider: Providable
     
-    init(provider: Provider) {
+    init(provider: Providable) {
         self.provider = provider
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
@@ -35,7 +35,8 @@ final class LoginFlowCoordinator: Coordinator {
     
     private func showTabBarController() {
         let tabBarDIContainer = dependencies.makeTabBarDIContainer()
-        let coordinator = tabBarDIContainer.makeTabBarFlowCoordinator(navigationController: navigationViewController)
+        let coordinator = tabBarDIContainer.makeTabBarFlowCoordinator(
+            navigationController: navigationViewController)
         coordinator.parentCoordinator = self
         childCoordinators.append(coordinator)
         coordinator.start()
@@ -45,4 +46,3 @@ final class LoginFlowCoordinator: Coordinator {
         parentCoordinator?.childDidFinish(self)
     }
 }
-

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
@@ -1,0 +1,31 @@
+//
+//  LoginFlowCoordinator.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/26.
+//
+
+import UIKit
+
+protocol LoginFlowCoordinatorDependencies {
+    func makeLoginViewController() -> LoginViewController
+}
+
+final class LoginFlowCoordinator {
+    private weak var navigationViewController: UINavigationController?
+    private let dependencies: LoginFlowCoordinatorDependencies
+    
+    private weak var loginViewController: LoginViewController?
+    
+    init(navigationViewController: UINavigationController? = nil, dependencies: LoginFlowCoordinatorDependencies) {
+        self.navigationViewController = navigationViewController
+        self.dependencies = dependencies
+    }
+    
+    func start() {
+        let viewController = dependencies.makeLoginViewController()
+        navigationViewController?.pushViewController(viewController, animated: true)
+        loginViewController = viewController
+    }
+}
+

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
@@ -11,7 +11,8 @@ protocol LoginFlowCoordinatorDependencies {
     func makeLoginViewController() -> LoginViewController
 }
 
-final class LoginFlowCoordinator {
+final class LoginFlowCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
     private weak var navigationViewController: UINavigationController?
     private let dependencies: LoginFlowCoordinatorDependencies
     
@@ -24,7 +25,7 @@ final class LoginFlowCoordinator {
     
     func start() {
         let viewController = dependencies.makeLoginViewController()
-        navigationViewController?.pushViewController(viewController, animated: true)
+        navigationViewController?.viewControllers = [viewController]
         loginViewController = viewController
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
@@ -14,6 +14,8 @@ protocol LoginFlowCoordinatorDependencies {
 
 final class LoginFlowCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
+    weak var parentCoordinator: Coordinator?
+    
     private var navigationViewController: UINavigationController
     private let dependencies: LoginFlowCoordinatorDependencies
         
@@ -23,16 +25,24 @@ final class LoginFlowCoordinator: Coordinator {
     }
     
     func start() {
-        let actions = LoginViewModelActions(showTabBarController: showTabBarController)
+        let actions = LoginViewModelActions(
+            showTabBarController: showTabBarController,
+            didFinishLogin: didFinishLogin
+        )
         let viewController = dependencies.makeLoginViewController(actions: actions)
-//        navigationViewController.view.window?.rootViewController = viewController
         navigationViewController.viewControllers = [viewController]
     }
     
     private func showTabBarController() {
         let tabBarDIContainer = dependencies.makeTabBarDIContainer()
         let coordinator = tabBarDIContainer.makeTabBarFlowCoordinator(navigationController: navigationViewController)
+        coordinator.parentCoordinator = self
+        childCoordinators.append(coordinator)
         coordinator.start()
+    }
+    
+    func didFinishLogin() {
+        parentCoordinator?.childDidFinish(self)
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
@@ -8,25 +8,31 @@
 import UIKit
 
 protocol LoginFlowCoordinatorDependencies {
-    func makeLoginViewController() -> LoginViewController
+    func makeLoginViewController(actions: LoginViewModelActions) -> UIViewController
+    func makeTabBarDIContainer() -> TabBarDIContainer
 }
 
 final class LoginFlowCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
-    private weak var navigationViewController: UINavigationController?
+    private var navigationViewController: UINavigationController
     private let dependencies: LoginFlowCoordinatorDependencies
-    
-    private weak var loginViewController: LoginViewController?
-    
-    init(navigationViewController: UINavigationController? = nil, dependencies: LoginFlowCoordinatorDependencies) {
+        
+    init(navigationViewController: UINavigationController, dependencies: LoginFlowCoordinatorDependencies) {
         self.navigationViewController = navigationViewController
         self.dependencies = dependencies
     }
     
     func start() {
-        let viewController = dependencies.makeLoginViewController()
-        navigationViewController?.viewControllers = [viewController]
-        loginViewController = viewController
+        let actions = LoginViewModelActions(showTabBarController: showTabBarController)
+        let viewController = dependencies.makeLoginViewController(actions: actions)
+//        navigationViewController.view.window?.rootViewController = viewController
+        navigationViewController.viewControllers = [viewController]
+    }
+    
+    private func showTabBarController() {
+        let tabBarDIContainer = dependencies.makeTabBarDIContainer()
+        let coordinator = tabBarDIContainer.makeTabBarFlowCoordinator(navigationController: navigationViewController)
+        coordinator.start()
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -12,7 +12,7 @@ import GoogleSignIn
 final class LoginViewController: BaseViewController {
     
     // MARK: - Properties
-    private let loginViewModel: LoginViewModel
+    private let loginViewModel: LoginViewModelProtocol
     private var cancellables: Set<AnyCancellable> = []
     
     // MARK: - Constant
@@ -23,7 +23,7 @@ final class LoginViewController: BaseViewController {
     }
     
     // MARK: - Init
-    init(loginViewModel: LoginViewModel){
+    init(loginViewModel: LoginViewModelProtocol){
         self.loginViewModel = loginViewModel
         super.init(nibName: nil, bundle: nil)
     }
@@ -128,16 +128,13 @@ final class LoginViewController: BaseViewController {
     
     override func bind() {
         loginViewModel.isMemberPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] isMember in
                 guard let self = self else { return }
                 if let isMember = isMember {
                     if isMember {
                         FMLogger.device.log("타이머 창으로 이동합니다")
-                        DispatchQueue.main.async {
-                            let tabBarViewController = TabBarViewController()
-                            tabBarViewController.modalPresentationStyle = .fullScreen
-                            self.view.window?.rootViewController = tabBarViewController
-                        }
+                        loginViewModel.didLogin()
                     } else {
                         FMLogger.device.log("회원가입 창으로 이동합니다")
                     }
@@ -149,11 +146,8 @@ final class LoginViewController: BaseViewController {
 
 // MARK: - Objc func
 private extension LoginViewController {
-    // TODO: Condinator 패턴 도입 !?
     @objc func loginSkipButtonDidTapped() {
-        let tabBarViewController = TabBarViewController()
-        tabBarViewController.modalPresentationStyle = .fullScreen
-        view.window?.rootViewController = tabBarViewController
+        loginViewModel.didLogin()
     }
     
     @objc func handleGoogleLoginButton() {
@@ -170,7 +164,6 @@ private extension LoginViewController {
         }
     }
 }
-
 
 // MARK: - UIButton extension
 fileprivate extension UIButton {

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -32,6 +32,10 @@ final class LoginViewController: BaseViewController {
         fatalError("Don't use storyboard")
     }
     
+    deinit {
+        loginViewModel.didFinishLogin()
+    }
+    
     // MARK: - UI Components
     private var logoImageView: UIImageView = {
         let imageView = UIImageView()

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/LoginViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/LoginViewModel.swift
@@ -8,10 +8,26 @@
 import Foundation
 import Combine
 
-final class LoginViewModel {
+struct LoginViewModelActions {
+    let showTabBarController: () -> Void
+}
+
+protocol LoginViewModelInput {
+    func didLogin()
+    func requestLogin(accessToken: String)
+}
+
+protocol LoginViewModelOutput { 
+    var isMemberPublisher: AnyPublisher<Bool?, Never> { get }
+}
+
+typealias LoginViewModelProtocol = LoginViewModelInput & LoginViewModelOutput
+
+final class LoginViewModel: LoginViewModelProtocol {
     // MARK: properties
     private let googleAuthUseCase: GoogleAuthUseCase
     private let cancellables: Set<AnyCancellable> = []
+    private let actions: LoginViewModelActions?
     
     private let isMemberSubject = CurrentValueSubject<Bool?, Never>(nil)
     
@@ -19,8 +35,14 @@ final class LoginViewModel {
         return isMemberSubject.eraseToAnyPublisher()
     }
     
-    init(googleAuthUseCase: GoogleAuthUseCase) {
+    init(googleAuthUseCase: GoogleAuthUseCase, actions: LoginViewModelActions? = nil) {
         self.googleAuthUseCase = googleAuthUseCase
+        self.actions = actions
+    }
+    
+    // MARK: - input
+    func didLogin() {
+        actions?.showTabBarController()
     }
     
     func requestLogin(accessToken: String) {

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/LoginViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/LoginViewModel.swift
@@ -10,10 +10,12 @@ import Combine
 
 struct LoginViewModelActions {
     let showTabBarController: () -> Void
+    let didFinishLogin: () -> Void
 }
 
 protocol LoginViewModelInput {
     func didLogin()
+    func didFinishLogin()
     func requestLogin(accessToken: String)
 }
 
@@ -43,6 +45,10 @@ final class LoginViewModel: LoginViewModelProtocol {
     // MARK: - input
     func didLogin() {
         actions?.showTabBarController()
+    }
+    
+    func didFinishLogin() {
+        actions?.didFinishLogin()
     }
     
     func requestLogin(accessToken: String) {

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -28,7 +28,10 @@ final class TabBarFlowCoordinator: Coordinator {
     
     func start() {
         let tabBarController = dependencies.makeTabBarController()
-        tabBarController.setViewControllers([makeSocialViewController(), makeTimerViewContorller(), makeChartViewController()], animated: false)
+        tabBarController.setViewControllers(
+            [makeSocialViewController(), makeTimerViewContorller(), makeChartViewController()],
+            animated: false
+        )
         navigationController.view.window?.rootViewController = tabBarController
         navigationController.viewControllers = []
         tabBarController.selectedIndex = 1
@@ -38,22 +41,27 @@ final class TabBarFlowCoordinator: Coordinator {
     private func makeTimerViewContorller() -> UINavigationController {
         let navigationViewController = UINavigationController()
         let timerSceneDIContainer = dependencies.makeTimerDIContainer()
-        let coordinator = timerSceneDIContainer.makeTimerFlowCoordinator(navigationController: navigationViewController)
+        let coordinator = timerSceneDIContainer.makeTimerFlowCoordinator(
+            navigationController: navigationViewController)
         coordinator.start()
         return navigationViewController
     }
     
     private func makeSocialViewController() -> UINavigationController {
         let navigationViewController = UINavigationController()
-        navigationViewController.tabBarItem.image = UIImage(systemName: Constant.socialNomalImageName)
-        navigationViewController.tabBarItem.selectedImage = UIImage(systemName: Constant.socialSelectedImageName)
+        navigationViewController.tabBarItem.image = UIImage(
+            systemName: Constant.socialNomalImageName)
+        navigationViewController.tabBarItem.selectedImage = UIImage(
+            systemName: Constant.socialSelectedImageName)
         return navigationViewController
     }
 
     private func makeChartViewController() -> UINavigationController {
         let navigationViewController = UINavigationController()
-        navigationViewController.tabBarItem.image = UIImage(systemName: Constant.chartNomalImageName)
-        navigationViewController.tabBarItem.selectedImage = UIImage(systemName: Constant.socialSelectedImageName)
+        navigationViewController.tabBarItem.image = UIImage(
+            systemName: Constant.chartNomalImageName)
+        navigationViewController.tabBarItem.selectedImage = UIImage(
+            systemName: Constant.socialSelectedImageName)
         return navigationViewController
     }
     

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -15,6 +15,8 @@ protocol TabBarFlowCoordinatorDependencies {
 
 final class TabBarFlowCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
+    weak var parentCoordinator: Coordinator?
+    
     private var navigationController: UINavigationController
     private weak var tabBarViewController: UITabBarController?
     private let dependencies: TabBarFlowCoordinatorDependencies
@@ -26,8 +28,9 @@ final class TabBarFlowCoordinator: Coordinator {
     
     func start() {
         let tabBarController = dependencies.makeTabBarController()
-        tabBarController.setViewControllers([makeSocialViewController(), makeTimerViewContorller(), makeChartViewController()], animated: true)
+        tabBarController.setViewControllers([makeSocialViewController(), makeTimerViewContorller(), makeChartViewController()], animated: false)
         navigationController.view.window?.rootViewController = tabBarController
+        navigationController.viewControllers = []
         tabBarController.selectedIndex = 1
         tabBarViewController = tabBarController
     }

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -1,0 +1,63 @@
+//
+//  TabBarFlowCoordinator.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/26.
+//
+
+import UIKit
+
+protocol TabBarFlowCoordinatorDependencies {
+    func makeTabBarController() -> UITabBarController
+    func makeTimerViewController() -> UIViewController
+    func makeTimerDIContainer() -> TimerSceneDIContainer
+}
+
+final class TabBarFlowCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+    private var navigationController: UINavigationController
+    private weak var tabBarViewController: UITabBarController?
+    private let dependencies: TabBarFlowCoordinatorDependencies
+    
+    init(navigationController: UINavigationController, dependencies: TabBarFlowCoordinatorDependencies) {
+        self.navigationController = navigationController
+        self.dependencies = dependencies
+    }
+    
+    func start() {
+        let tabBarController = dependencies.makeTabBarController()
+        tabBarController.setViewControllers([makeSocialViewController(), makeTimerViewContorller(), makeChartViewController()], animated: true)
+        navigationController.view.window?.rootViewController = tabBarController
+        tabBarController.selectedIndex = 1
+        tabBarViewController = tabBarController
+    }
+    
+    private func makeTimerViewContorller() -> UINavigationController {
+        let navigationViewController = UINavigationController()
+        let timerSceneDIContainer = dependencies.makeTimerDIContainer()
+        let coordinator = timerSceneDIContainer.makeTimerFlowCoordinator(navigationController: navigationViewController)
+        coordinator.start()
+        return navigationViewController
+    }
+    
+    private func makeSocialViewController() -> UINavigationController {
+        let navigationViewController = UINavigationController()
+        navigationViewController.tabBarItem.image = UIImage(systemName: Constant.socialNomalImageName)
+        navigationViewController.tabBarItem.selectedImage = UIImage(systemName: Constant.socialSelectedImageName)
+        return navigationViewController
+    }
+
+    private func makeChartViewController() -> UINavigationController {
+        let navigationViewController = UINavigationController()
+        navigationViewController.tabBarItem.image = UIImage(systemName: Constant.chartNomalImageName)
+        navigationViewController.tabBarItem.selectedImage = UIImage(systemName: Constant.socialSelectedImageName)
+        return navigationViewController
+    }
+    
+    private enum Constant {
+        static let socialNomalImageName = "person.3"
+        static let socialSelectedImageName = "person.3.fill"
+        static let chartNomalImageName = "chart.bar"
+        static let chartSelectedImageName = "chart.bar.fill"
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/ViewController/TabBarViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/ViewController/TabBarViewController.swift
@@ -11,10 +11,6 @@ final class TabBarViewController: UITabBarController {
 
     private enum Constant {
         static let timerImageName = "timer"
-        static let socialNomalImageName = "person.3"
-        static let socialSelectedImageName = "person.3.fill"
-        static let chartNomalImageName = "chart.bar"
-        static let chartSelectedImageName = "chart.bar.fill"
         static let borderWidth: CGFloat = 1.0
         static let timerImageSize: CGFloat = 40
     }
@@ -36,7 +32,6 @@ final class TabBarViewController: UITabBarController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
         configureTabBar()
     }
 
@@ -55,29 +50,6 @@ final class TabBarViewController: UITabBarController {
 
 // MARK: - UI Setting
 private extension TabBarViewController {
-
-    func configureUI() {
-        let timerViewController = TimerViewController(timerViewModel: TimerViewModel(
-            timerUseCase: DefaultTimerUseCase(timerRepository: DefaultTimerRepository(provider: Provider(urlSession: URLSession.shared))),
-            userInfoUserCase: DefaultStudyLogUseCase(userInfoRepository: DefaultStudyLogRepository(provider: Provider(urlSession: URLSession.shared)))))
-        let socialViewController = SocialViewController()
-        let chartViewController = ChartViewController()
-
-        socialViewController.tabBarItem.image = UIImage(systemName: Constant.socialNomalImageName)
-        socialViewController.tabBarItem.selectedImage = UIImage(systemName: Constant.socialSelectedImageName)
-
-        chartViewController.tabBarItem.image = UIImage(systemName: Constant.chartNomalImageName)
-        chartViewController.tabBarItem.selectedImage = UIImage(systemName: Constant.chartSelectedImageName)
-
-        let navigationTimer = UINavigationController(rootViewController: timerViewController)
-        let navigationSocial = UINavigationController(rootViewController: socialViewController)
-        let navigationChart = UINavigationController(rootViewController: chartViewController)
-
-        setViewControllers([navigationSocial, navigationTimer, navigationChart], animated: false)
-
-        selectedIndex = 1
-    }
-
     func setupFrame() {
         var tabFrame = tabBar.frame
         tabFrame.size.height += 10

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
@@ -1,0 +1,32 @@
+//
+//  CategorySettingCoordinator.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/26.
+//
+
+import UIKit
+
+protocol CategoryFlowCoordinatorDependencies {
+    func makeCategorySettingViewController() -> UIViewController
+}
+
+final class CategoryFlowCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+    private var navigationController: UINavigationController
+    private let dependencies: CategoryFlowCoordinatorDependencies
+    
+    init(navigationController: UINavigationController, dependencies: CategoryFlowCoordinatorDependencies) {
+        self.navigationController = navigationController
+        self.dependencies = dependencies
+    }
+    
+    func start() {
+        let viewController = dependencies.makeCategorySettingViewController()
+        navigationController.pushViewController(viewController, animated: true)
+    }
+    
+    func showCategoryModifyVieWController() {
+        
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 protocol CategoryFlowCoordinatorDependencies {
-    func makeCategorySettingViewController() -> UIViewController
+    func makeCategorySettingViewController(actions: CategoryViewModelActions) -> UIViewController
+    func makeCategoryModifyViewController(purpose: CategoryPurpose, category: Category?) -> UIViewController
 }
 
 final class CategoryFlowCoordinator: Coordinator {
@@ -22,11 +23,15 @@ final class CategoryFlowCoordinator: Coordinator {
     }
     
     func start() {
-        let viewController = dependencies.makeCategorySettingViewController()
+        let actions = CategoryViewModelActions(
+            showModifyCategory: showCategoryModifyVieWController
+        )
+        let viewController = dependencies.makeCategorySettingViewController(actions: actions)
         navigationController.pushViewController(viewController, animated: true)
     }
     
-    func showCategoryModifyVieWController() {
-        
+    private func showCategoryModifyVieWController(purpose: CategoryPurpose, category: Category? = nil) {
+        let categoryModifyViewController = dependencies.makeCategoryModifyViewController(purpose: purpose, category: category)
+        navigationController.pushViewController(categoryModifyViewController, animated: true)
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
@@ -14,6 +14,7 @@ protocol CategoryFlowCoordinatorDependencies {
 
 final class CategoryFlowCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
+    weak var parentCoordinator: Coordinator?
     private var navigationController: UINavigationController
     private let dependencies: CategoryFlowCoordinatorDependencies
     
@@ -24,7 +25,8 @@ final class CategoryFlowCoordinator: Coordinator {
     
     func start() {
         let actions = CategoryViewModelActions(
-            showModifyCategory: showCategoryModifyVieWController
+            showModifyCategory: showCategoryModifyVieWController,
+            didFinishCategorySetting: didFinishCategorySetting
         )
         let viewController = dependencies.makeCategorySettingViewController(actions: actions)
         navigationController.pushViewController(viewController, animated: true)
@@ -33,5 +35,9 @@ final class CategoryFlowCoordinator: Coordinator {
     private func showCategoryModifyVieWController(purpose: CategoryPurpose, category: Category? = nil) {
         let categoryModifyViewController = dependencies.makeCategoryModifyViewController(purpose: purpose, category: category)
         navigationController.pushViewController(categoryModifyViewController, animated: true)
+    }
+    
+    func didFinishCategorySetting() {
+        parentCoordinator?.childDidFinish(self)
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
@@ -33,8 +33,10 @@ final class CategoryFlowCoordinator: Coordinator {
     }
     
     private func showCategoryModifyVieWController(purpose: CategoryPurpose, category: Category? = nil) {
-        let categoryModifyViewController = dependencies.makeCategoryModifyViewController(purpose: purpose, category: category)
-        navigationController.pushViewController(categoryModifyViewController, animated: true)
+        let categoryModifyViewController = dependencies.makeCategoryModifyViewController(
+            purpose: purpose,
+            category: category)
+        navigationController.present(categoryModifyViewController, animated: true)
     }
     
     func didFinishCategorySetting() {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
@@ -1,0 +1,31 @@
+//
+//  TimerFlowCoordinator.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/25.
+//
+
+import UIKit
+
+protocol TimerFlowCoordinatorDependencies {
+    func makeTimerViewController() -> TimerViewController
+}
+
+final class TimerFlowCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+    private weak var navigationController: UINavigationController?
+    private let dependencies: TimerFlowCoordinatorDependencies
+    
+    private weak var timerViewController: TimerViewController?
+    
+    init(navigationController: UINavigationController? = nil, dependencies: TimerFlowCoordinatorDependencies) {
+        self.navigationController = navigationController
+        self.dependencies = dependencies
+    }
+    
+    func start() {
+        let viewController = dependencies.makeTimerViewController()
+        navigationController?.viewControllers = [viewController]
+        timerViewController = viewController
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
@@ -8,24 +8,30 @@
 import UIKit
 
 protocol TimerFlowCoordinatorDependencies {
-    func makeTimerViewController() -> TimerViewController
+    func makeTimerViewController(actions: TimerViewModelActions) -> TimerViewController
+    func makeCategoryDIContainer() -> CategoryDIContainer
 }
 
 final class TimerFlowCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
-    private weak var navigationController: UINavigationController?
+    private var navigationController: UINavigationController
     private let dependencies: TimerFlowCoordinatorDependencies
-    
-    private weak var timerViewController: TimerViewController?
-    
-    init(navigationController: UINavigationController? = nil, dependencies: TimerFlowCoordinatorDependencies) {
+        
+    init(navigationController: UINavigationController, dependencies: TimerFlowCoordinatorDependencies) {
         self.navigationController = navigationController
         self.dependencies = dependencies
     }
     
     func start() {
-        let viewController = dependencies.makeTimerViewController()
-        navigationController?.viewControllers = [viewController]
-        timerViewController = viewController
+        let actions = TimerViewModelActions(showCategorySettingViewController: showCategorySettingViewController)
+        let viewController = dependencies.makeTimerViewController(actions: actions)
+        navigationController.viewControllers = [viewController]
+    }
+    
+    private func showCategorySettingViewController() {
+        let categoryDIContainer = dependencies.makeCategoryDIContainer()
+        let coordinator = categoryDIContainer.makeCategoryFlowCoordinator(navigationController: navigationController)
+        coordinator.start()
+        childCoordinators.append(coordinator)
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
@@ -23,14 +23,16 @@ final class TimerFlowCoordinator: Coordinator {
     }
     
     func start() {
-        let actions = TimerViewModelActions(showCategorySettingViewController: showCategorySettingViewController)
+        let actions = TimerViewModelActions(
+            showCategorySettingViewController: showCategorySettingViewController)
         let viewController = dependencies.makeTimerViewController(actions: actions)
         navigationController.viewControllers = [viewController]
     }
     
     private func showCategorySettingViewController() {
         let categoryDIContainer = dependencies.makeCategoryDIContainer()
-        let coordinator = categoryDIContainer.makeCategoryFlowCoordinator(navigationController: navigationController)
+        let coordinator = categoryDIContainer.makeCategoryFlowCoordinator(
+            navigationController: navigationController)
         coordinator.parentCoordinator = self
         coordinator.start()
         childCoordinators.append(coordinator)

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
@@ -31,6 +31,7 @@ final class TimerFlowCoordinator: Coordinator {
     private func showCategorySettingViewController() {
         let categoryDIContainer = dependencies.makeCategoryDIContainer()
         let coordinator = categoryDIContainer.makeCategoryFlowCoordinator(navigationController: navigationController)
+        coordinator.parentCoordinator = self
         coordinator.start()
         childCoordinators.append(coordinator)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
@@ -71,7 +71,6 @@ private extension CategorySettingFooterView {
 
 private extension CategorySettingFooterView {
     func configureGestureRecognizers() {
-        print("tapgesture added")
         tapGestureRecognizer.cancelsTouchesInView = false
         self.addGestureRecognizer(tapGestureRecognizer)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
@@ -182,7 +182,7 @@ private extension CategoryModifyViewController {
 // MARK: objc function
 private extension CategoryModifyViewController {
     @objc func closeButtonTapped(_ sender: UIBarButtonItem) {
-        dismiss(animated: true)
+        self.navigationController?.popViewController(animated: true)
     }
     
     @objc func doneButtonTapped(_ sender: UIBarButtonItem) {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -49,6 +49,10 @@ final class CategorySettingViewController: BaseViewController {
         }
     }
     
+    deinit {
+        viewModel.didFinishCategorySetting()
+    }
+    
     // MARK: - Configure UI
     override func configureUI() {
         view.addSubview(collectionView)

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -62,20 +62,6 @@ final class CategorySettingViewController: BaseViewController {
     }
     
     override func bind() {
-        viewModel.presentingCategoryModifyViewControllerPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.createCategoryButtonTapped()
-            }
-            .store(in: &cancellables)
-        
-        viewModel.tappedCategoryDataPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] category in
-                self?.updateCategoryTapped(with: category)
-            }
-            .store(in: &cancellables)
-        
         viewModel.categoriesPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] categories in
@@ -104,7 +90,10 @@ private extension CategorySettingViewController {
 // MARK: - CollectionViewDelegate
 extension CategorySettingViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        viewModel.categoryTapped(at: indexPath.row)
+//        viewModel.categoryTapped(at: indexPath.row)
+        // 임시로 카테고리 클릭 시 수정화면으로 이동
+        guard let item = dataSource?.itemIdentifier(for: indexPath) else { return }
+        viewModel.updateCategoryTapped(category: item.category)
     }
 }
 
@@ -147,18 +136,8 @@ private extension CategorySettingViewController {
         dataSource?.apply(snapshot)
     }
     
-    func createCategoryButtonTapped() {
-        let presentingViewController = CategoryModifyViewController(
-            viewModel: self.viewModel, purpose: .create)
-        let navController = UINavigationController(rootViewController: presentingViewController)
-        present(navController, animated: true)
-    }
-    
     func updateCategoryTapped(with category: Category) {
-        let presentingViewController = CategoryModifyViewController(
-            viewModel: self.viewModel, purpose: .update, category: category)
-        let navController = UINavigationController(rootViewController: presentingViewController)
-        present(navController, animated: true)
+        viewModel.updateCategoryTapped(category: category)
     }
 }
 
@@ -187,11 +166,11 @@ private extension CategorySettingViewController {
     }
 }
 
-@available(iOS 17.0, *)
-#Preview {
-    CategorySettingViewController(
-        viewModel: CategoryViewModel(
-            useCase: DefaultCategoryUseCase(
-                repository: DefaultCategoryRepository(
-                    provider: Provider(urlSession: URLSession.shared)))))
-}
+//@available(iOS 17.0, *)
+//#Preview {
+//    CategorySettingViewController(
+//        viewModel: CategoryViewModel(
+//            useCase: DefaultCategoryUseCase(
+//                repository: DefaultCategoryRepository(
+//                    provider: Provider(urlSession: URLSession.shared)))))
+//}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -160,14 +160,6 @@ final class TimerViewController: BaseViewController {
             }
             .store(in: &cancellables)
         
-        timerViewModel.isPresentingCategoryPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                guard let self = self else { return }
-                self.pushtCategorySettingViewController()
-            }
-            .store(in: &cancellables)
-        
         deviceMotionManager.orientationDidChangePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newOrientation in
@@ -218,15 +210,6 @@ private extension TimerViewController {
         } else {
             feedbackManager.startFaceupFeedback()
         }
-    }
-    
-    func pushtCategorySettingViewController() {
-        let categorySettingViewController = CategorySettingViewController(
-            viewModel: CategoryViewModel(
-                useCase: DefaultCategoryUseCase(
-                    repository: DefaultCategoryRepository(
-                        provider: Provider(urlSession: URLSession.shared)))))
-        navigationController?.pushViewController(categorySettingViewController, animated: true)
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/CategoryViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/CategoryViewModel.swift
@@ -8,9 +8,13 @@
 import Foundation
 import Combine
 
+struct CategoryViewModelActions {
+    let showModifyCategory: (CategoryPurpose, Category?) -> Void
+}
+
 protocol CategoryViewModelInput {
     func createCategoryTapped()
-    func categoryTapped(at index: Int)
+    func updateCategoryTapped(category: Category)
     func createCategory(name: String, colorCode: String) async throws
     func readCategories() async throws
     func updateCategory(of id: Int, newName: String, newColorCode: String) async throws
@@ -18,8 +22,6 @@ protocol CategoryViewModelInput {
 }
 
 protocol CategoryViewModelOutput {
-    var presentingCategoryModifyViewControllerPublisher: AnyPublisher<Void, Never> { get }
-    var tappedCategoryDataPublisher: AnyPublisher<Category, Never> { get }
     var categoriesPublisher: AnyPublisher<[Category], Never> { get }
 }
 
@@ -27,39 +29,31 @@ typealias CategoryViewModelProtocol = CategoryViewModelInput & CategoryViewModel
 
 final class CategoryViewModel: CategoryViewModelProtocol {
     // MARK: properties
-    private var presentingCategoryModifyViewControllerSubject = PassthroughSubject<Void, Never>()
-    private var tappedCategoryDataSubject = PassthroughSubject<Category, Never>()
     private var categoriesSubject = CurrentValueSubject<[Category], Never>([])
     
     var categories = [Category]()
-    
+    private var categoryMananger: CategoryManager
     private let useCase: CategoryUseCase
+    private let actions: CategoryViewModelActions?
     
-    init(useCase: CategoryUseCase) {
+    init(useCase: CategoryUseCase, categoryManager: CategoryManager, actions: CategoryViewModelActions? = nil) {
         self.useCase = useCase
+        self.categoryMananger = categoryManager
+        self.actions = actions
     }
     
     // MARK: Output
-    var presentingCategoryModifyViewControllerPublisher: AnyPublisher<Void, Never> {
-        return presentingCategoryModifyViewControllerSubject
-            .eraseToAnyPublisher()
-    }
-    var tappedCategoryDataPublisher: AnyPublisher<Category, Never> {
-        return tappedCategoryDataSubject
-            .eraseToAnyPublisher()
-    }
-    
     var categoriesPublisher: AnyPublisher<[Category], Never> {
         return categoriesSubject.eraseToAnyPublisher()
     }
     
     // MARK: Input
     func createCategoryTapped() {
-        presentingCategoryModifyViewControllerSubject.send()
+        actions?.showModifyCategory(.create, nil)
     }
     
-    func categoryTapped(at index: Int) {
-        tappedCategoryDataSubject.send(categories[index])
+    func updateCategoryTapped(category: Category) {
+        actions?.showModifyCategory(.update, category)
     }
     
     func createCategory(name: String, colorCode: String) async throws {
@@ -81,7 +75,6 @@ final class CategoryViewModel: CategoryViewModelProtocol {
         }
         
         categories[index] = Category(id: id, color: newColorCode, subject: newName)
-        print(categories)
         categoriesSubject.send(categories)
     }
     

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/CategoryViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/CategoryViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 
 struct CategoryViewModelActions {
     let showModifyCategory: (CategoryPurpose, Category?) -> Void
+    let didFinishCategorySetting: () -> Void
 }
 
 protocol CategoryViewModelInput {
@@ -19,6 +20,7 @@ protocol CategoryViewModelInput {
     func readCategories() async throws
     func updateCategory(of id: Int, newName: String, newColorCode: String) async throws
     func deleteCategory(of id: Int) async throws
+    func didFinishCategorySetting()
 }
 
 protocol CategoryViewModelOutput {
@@ -54,6 +56,10 @@ final class CategoryViewModel: CategoryViewModelProtocol {
     
     func updateCategoryTapped(category: Category) {
         actions?.showModifyCategory(.update, category)
+    }
+    
+    func didFinishCategorySetting() {
+        actions?.didFinishCategorySetting()
     }
     
     func createCategory(name: String, colorCode: String) async throws {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
@@ -9,6 +9,11 @@ import Foundation
 import Combine
 import OSLog
 
+
+struct TimerViewModelActions {
+    let showCategorySettingViewController: () -> Void
+}
+
 protocol TimerViewModelInput {
     func viewDidLoad()
     func deviceOrientationDidChange(_ sender: DeviceOrientation)
@@ -19,7 +24,6 @@ protocol TimerViewModelInput {
 
 protocol TimerViewModelOutput {
     var isDeviceFaceDownPublisher: AnyPublisher<Bool, Never> { get }
-    var isPresentingCategoryPublisher: AnyPublisher<Void, Never> { get }
     var totalTimePublisher: AnyPublisher<Int, Never> { get }
     var categoryChangePublisher: AnyPublisher<[Category], Never> { get }
     var categoriesPublisher: AnyPublisher<[Category], Never> { get }
@@ -47,11 +51,13 @@ final class TimerViewModel: TimerViewModelProtocol {
     private var totalTime: Int = 0 // 총 공부 시간
     private var categories = [Category]()
     private var selectedCategory: Category?
+    private let actions: TimerViewModelActions?
     
     // MARK: - init
-    init(timerUseCase: TimerUseCase, userInfoUserCase: StudyLogUseCase) {
+    init(timerUseCase: TimerUseCase, userInfoUserCase: StudyLogUseCase, actions: TimerViewModelActions? = nil) {
         self.timerUseCase = timerUseCase
         self.userInfoUserCase = userInfoUserCase
+        self.actions = actions
     }
     
     // MARK: Output
@@ -87,7 +93,7 @@ final class TimerViewModel: TimerViewModelProtocol {
     }
     
     func categorySettingButtoneDidTapped() {
-        isPresentingCategorySubject.send(())
+        actions?.showCategorySettingViewController()
     }
     
     func viewDidLoad() {


### PR DESCRIPTION
## 완료된 기능
- AppDIContainer 구현
- AppFlowCoordinator 구현
- 각각 화면에 필요한 DIContainer와 FlowCoordinator 구현
- 로그인 화면에서 탭바컨트롤러로 전환 시 로그인 VC 및 관련 객체 매모리 해제되도록 수정

## 고민과 해결과정
### Coordinator 패턴과 DI Container 적용
Coordinator 패턴에 대해서는 어느정도 이해가 되었는데 어떤식으로 적용을 해야할지 상당히 해맸습니다.
일단 기초를 MVVM + Clean Archiecture 예제 코드를 참고해서 구현했습니다. 

각각의 화면 전환이 필요한 ViewController인 경우 FlowCoordinator가 화면 전환을 담당해주고
해당 FlowCoordinator에서 ViewController에 의존성을 주입하는 부분은 DI Container가 담당하고 있습니다.

먼저, 기초가 되는 AppFlowCoordinator와 AppDIContainer을 구현하고 AppFlowCoordinator와 AppDIContainer을 SceneDelegate에서 사용하여 로그인 여부에 따라 LoginViewController와 TabBarController을 보여주도록 했습니다.

화면 전환이 필요한 ViewController마다 FlowCoordinator을 생성하였고, 해당 FlowCoordinator의 start() 메소드를 통해 해당 ViewController을 띄우고, 화면 전환이 필요한 경우에는 DI Container에서 화면을 전환하고 싶은 ViewController의 DI Container와 FlowCoordinator을 생성하고 해당 FlowCoordinator을 통해 화면을 전환하는 방식으로 구현했습니다.
그리고 각 ViewController마다 DI Container는 ViewController을 생성하고, 해당 ViewController 생성에 필요한 의존성을 주입해주고 있습니다.

예를 들어 TimerSceneDIContainer는 TimerViewController생성시 의존성 주입에 필요한 ViewModel, UseCase, Repository을 전달받은 dependencies을 통해 생성하고 TimerViewController을 생성하고 있습니다.

ex) LoginViewController에서 TabBarController로 화면을 전환해야되는 경우
- LoginDIContainer
    - LoginFlowCoordinatorDependencies 채택 (Coordinator에서 의존성 주입에 필요한 메소드 추상화)
    - LoginViewController 생성 메소드 구현
        - 해당 메소드에서 ViewController 생성에 필요한 의존성 주입 (viewModel, UseCase, ...)
    - LoginFlowCoordinator 생성 메소드 구현
        - LoginViewController로 화면을 전환하기 위한 FlowCoordinator
    - TabBarDIContainer 생성 메소드 구현
        - 해당 메소드에서 TabBarDIContainer 생성에 필요한 의존성과 navigationController 주입
        - LoginFlowCoordinator에서 사용할 TabBarDIContainer

- LoginFlowCoordinator
    - LoginViewController로 화면을 전환할 메소드 구현 -> `start()`
        - LoginViewModelActions로 각각 Action에 맞는 함수 전달
    - TabBarController의 FlowCoordinator를 통해 화면 전환
        - LoginDIContainer을 통해 TabBarDIContainer을 생성
        - 해당 TabBarDIContainer을 통해 TabBarCoordinator 생성
        - TabBarCoordinator의 start 메소드를 통해 화면 전환

아직 제대로 이해한건지 몰라서 좀 더 학습해보고 더 좋은 방법이 있는지 확인해봐야될 것 같습니다.
현재로서는 화면 전환은 Coordinator을 통해서 하고 의존성 주입은 DI Container을 각각 필요한 ViewModel, UseCase, Repository을 생성해서 주입하고 있긴한데 결과적으로 Dependencies는  AppDIContainer에서 생성한 Provider와 CategoryManager에 의존하고 있습니다. 

### 화면 전환 시 이전 Coordinator, DI Container 메모리 누수
Timer 화면에서 CategorySetting 화면으로 이동할때마다 TimerFlowCoordinator에서 CategoryCoordinator가 계속 생성되어 메모리 누수가 있었습니다.

각각의 FlowCoordinator가 childCoordinator와 parentCoordinator을 가지게 구현하였고
이 과정에서 parentCoordinator가 강한 참조이기 때문에 weak 키워드를 통해 약한 참조로 만들었습니다.

FlowCoordinator을 생성하고 화면을 전환할 때 parentCoordinator을 이전 FlowCoordinator로 설정하고 ViewController가 deinit될 때 해당 parentCoordinator에서 coordinator을 삭제해줘서 메모리에서 해제되도록 했습니다.

`Coordinator로 화면 전환할 때 사용된 Coordinator을 사용한 뒤에 parentCoordinator에서 삭제하는 거 까먹으시면 안됩니다.....!!!`


해결 전

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/1877968a-0bc0-4013-a133-6e3a7d780651

해결 후

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/8f10ed5d-3d85-483f-b342-d0d6df5ce0e0

잘 해제되는 걸 볼 수 있음니다.

### 로그인 화면 관련 객체 메모리 해제
로그인이 진행되거나 로그인을 사용하지 않고 이용하기를 클릭해서 TabBarController로 화면 전환을 하게 되면 이전의 LoginViewController, LoginViewModel, LoginUseCase, LoginRepository, LoginDiContainer, LoginFlowCoordinator가 메모리에서 해제되지 않는 문제가 있었습니다.

navigationController의 rootViewController을 tabBarController로 설정하고 이전의 navigation Stack에 쌓인 LoginViewController가 그대로 쌓여있던 것을 확인하고 navigation 스택에 쌓여있는 ViewController을 초기화하여 해당 메모리 문제를 해결하였습니다.

해결 전

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/0ca8e67e-f8de-46ae-a5f2-408b5d2106af


해결 후 

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/e7567b61-c6c4-4b86-bff4-56e6096bd67b



