### PR TITLE
[iOS/#139] 회원가입 뷰 UI 개선

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -9,21 +9,27 @@ import UIKit
 
 final class SignUpViewController: BaseViewController {
     
-    private lazy var profileImage: UIImageView = {
+    // MARK: - View Properties
+    private lazy var profileImageView: UIImageView = {
         let imageView = UIImageView()
-        let cameraView = UIImageView()
+        let cameraButtonView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
         imageView.image = UIImage(systemName: Constant.profileImageName)
         imageView.tintColor = FlipMateColor.darkBlue.color
-        cameraView.image = UIImage(systemName: Constant.cameraImageName)
-        cameraView.tintColor = FlipMateColor.gray1.color
-        cameraView.backgroundColor = FlipMateColor.gray3.color
-        cameraView.clipsToBounds = true
-        cameraView.layer.cornerRadius = cameraView.bounds.height / 2
-        imageView.addSubview(cameraView)
-        cameraView.translatesAutoresizingMaskIntoConstraints = false
+        cameraButtonView.contentMode = .center
+        cameraButtonView.image = UIImage(systemName: Constant.cameraImageName)
+        cameraButtonView.tintColor = FlipMateColor.gray1.color
+        cameraButtonView.backgroundColor = FlipMateColor.gray3.color
+        cameraButtonView.clipsToBounds = true
+        cameraButtonView.frame = CGRect(x: 0, y: 0, width: 33, height: 33)
+        cameraButtonView.layer.cornerRadius = cameraButtonView.frame.height / 2
+        imageView.addSubview(cameraButtonView)
+        cameraButtonView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            cameraView.bottomAnchor.constraint(equalTo: imageView.bottomAnchor),
-            cameraView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 0)
+            cameraButtonView.bottomAnchor.constraint(equalTo: imageView.bottomAnchor),
+            cameraButtonView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: -30),
+            cameraButtonView.widthAnchor.constraint(equalToConstant: 33),
+            cameraButtonView.heightAnchor.constraint(equalToConstant: 33)
         ])
         return imageView
     }()
@@ -70,7 +76,7 @@ final class SignUpViewController: BaseViewController {
         self.title = "회원가입"
         
         let subViews = [
-            profileImage,
+            profileImageView,
             nickNameTextField,
             signUpButton
         ]
@@ -81,12 +87,12 @@ final class SignUpViewController: BaseViewController {
         }
         
         NSLayoutConstraint.activate([
-            profileImage.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 64),
-            profileImage.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            profileImage.widthAnchor.constraint(equalToConstant: 100),
-            profileImage.heightAnchor.constraint(equalToConstant: 100),
+            profileImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 64),
+            profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            profileImageView.widthAnchor.constraint(equalToConstant: 100),
+            profileImageView.heightAnchor.constraint(equalToConstant: 100),
             
-            nickNameTextField.topAnchor.constraint(equalTo: profileImage.bottomAnchor, constant: 16),
+            nickNameTextField.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: 16),
             nickNameTextField.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             nickNameTextField.widthAnchor.constraint(equalToConstant: 220),
             

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -81,10 +81,12 @@ final class SignUpViewController: BaseViewController {
         return button
     }()
     
+    // MARK: - View Life Cycles
     override func viewDidLayoutSubviews() {
         drawTextFieldUnderline()
     }
     
+    // MARK: - Configure UI
     override func configureUI() {
         self.title = "회원가입"
         
@@ -128,6 +130,7 @@ final class SignUpViewController: BaseViewController {
     }
 }
 
+// MARK: - Constants
 private extension SignUpViewController {
     enum Constant {
         static let profileImageName = "person.crop.circle.fill"

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -77,6 +77,7 @@ final class SignUpViewController: BaseViewController {
         }
         button.clipsToBounds = true
         button.layer.cornerRadius = 15
+        button.isEnabled = false
         return button
     }()
     

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -61,7 +61,11 @@ final class SignUpViewController: BaseViewController {
             var titleContainer = AttributeContainer()
             titleContainer.font = FlipMateFont.mediumBold.font
             configuration.baseBackgroundColor = FlipMateColor.darkBlue.color
-            configuration.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 32, bottom: 16, trailing: 32)
+            configuration.contentInsets = NSDirectionalEdgeInsets(
+                top: 16,
+                leading: 32,
+                bottom: 16,
+                trailing: 32)
             configuration.attributedTitle = AttributedString("회원가입", attributes: titleContainer)
             button.configuration = configuration
         } else {
@@ -104,10 +108,13 @@ final class SignUpViewController: BaseViewController {
             nickNameTextField.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             nickNameTextField.widthAnchor.constraint(equalToConstant: 220),
             
-            signUpButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32),
+            signUpButton.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32),
             signUpButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            signUpButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 32),
-            signUpButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -32)
+            signUpButton.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 32),
+            signUpButton.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -32)
         ])
     }
     

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -121,6 +121,10 @@ final class SignUpViewController: BaseViewController {
     func drawTextFieldUnderline() {
         self.nickNameTextField.addSubview(textFieldUnderline)
     }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
 }
 
 private extension SignUpViewController {

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -43,6 +43,17 @@ final class SignUpViewController: BaseViewController {
         return textField
     }()
     
+    private lazy var textFieldUnderline: UIView = {
+        let underline = UIView()
+        underline.frame = CGRect(
+            x: 0,
+            y: Double(nickNameTextField.frame.height) + 2,
+            width: Double(nickNameTextField.frame.width),
+            height: 1.5)
+        underline.backgroundColor = FlipMateColor.gray1.color
+        return underline
+    }()
+    
     private lazy var signUpButton: UIButton = {
         let button = UIButton()
         if #available(iOS 15.0, *) {
@@ -66,10 +77,7 @@ final class SignUpViewController: BaseViewController {
     }()
     
     override func viewDidLayoutSubviews() {
-        let underLine = UIView()
-        underLine.frame = CGRect(x: 0, y: Double(nickNameTextField.frame.height) + 2, width: Double(nickNameTextField.frame.width), height: 1.5)
-        underLine.backgroundColor = FlipMateColor.gray1.color
-        self.nickNameTextField.addSubview(underLine)
+        drawTextFieldUnderline()
     }
     
     override func configureUI() {
@@ -101,6 +109,10 @@ final class SignUpViewController: BaseViewController {
             signUpButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 32),
             signUpButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -32)
         ])
+    }
+    
+    func drawTextFieldUnderline() {
+        self.nickNameTextField.addSubview(textFieldUnderline)
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -10,27 +10,32 @@ import UIKit
 final class SignUpViewController: BaseViewController {
     
     // MARK: - View Properties
+    /// 프로필 이미지 뷰
     private lazy var profileImageView: UIImageView = {
         let imageView = UIImageView()
-        let cameraButtonView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
+        imageView.contentMode = .scaleAspectFill
         imageView.image = UIImage(systemName: Constant.profileImageName)
         imageView.tintColor = FlipMateColor.darkBlue.color
-        cameraButtonView.contentMode = .center
-        cameraButtonView.image = UIImage(systemName: Constant.cameraImageName)
-        cameraButtonView.tintColor = FlipMateColor.gray1.color
-        cameraButtonView.backgroundColor = FlipMateColor.gray3.color
-        cameraButtonView.clipsToBounds = true
-        cameraButtonView.frame = CGRect(x: 0, y: 0, width: 33, height: 33)
-        cameraButtonView.layer.cornerRadius = cameraButtonView.frame.height / 2
-        imageView.addSubview(cameraButtonView)
-        cameraButtonView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            cameraButtonView.bottomAnchor.constraint(equalTo: imageView.bottomAnchor),
-            cameraButtonView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: -30),
-            cameraButtonView.widthAnchor.constraint(equalToConstant: 33),
-            cameraButtonView.heightAnchor.constraint(equalToConstant: 33)
-        ])
+        imageView.clipsToBounds = true
+        imageView.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+        imageView.layer.cornerRadius = imageView.bounds.height / 2
+        let tapGestureRecognizer = UITapGestureRecognizer(
+            target: self, action: #selector(profileImageViewTapped))
+        imageView.isUserInteractionEnabled = true
+        imageView.addGestureRecognizer(tapGestureRecognizer)
+        return imageView
+    }()
+    
+    private lazy var cameraButton: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: Constant.cameraImageName)
+        imageView.tintColor = FlipMateColor.gray1.color
+        imageView.backgroundColor = FlipMateColor.gray3.color
+        imageView.contentMode = .center
+        imageView.layoutMargins = .init(top: 8, left: 16, bottom: 8, right: 16)
+        imageView.clipsToBounds = true
+        imageView.bounds = CGRect(x: 0, y: 0, width: 33, height: 33)
+        imageView.layer.cornerRadius = imageView.bounds.height / 2
         return imageView
     }()
     
@@ -92,6 +97,7 @@ final class SignUpViewController: BaseViewController {
         
         let subViews = [
             profileImageView,
+            cameraButton,
             nickNameTextField,
             signUpButton
         ]
@@ -106,6 +112,11 @@ final class SignUpViewController: BaseViewController {
             profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             profileImageView.widthAnchor.constraint(equalToConstant: 100),
             profileImageView.heightAnchor.constraint(equalToConstant: 100),
+            
+            cameraButton.widthAnchor.constraint(equalToConstant: 33),
+            cameraButton.heightAnchor.constraint(equalToConstant: 33),
+            cameraButton.trailingAnchor.constraint(equalTo: profileImageView.trailingAnchor),
+            cameraButton.bottomAnchor.constraint(equalTo: profileImageView.bottomAnchor),
             
             nickNameTextField.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: 16),
             nickNameTextField.centerXAnchor.constraint(equalTo: view.centerXAnchor),


### PR DESCRIPTION
close #139 

## 완료된 기능
- 카메라 버튼 위치 및 모양 조정
- 프로필 사진을 탭 하여 사진첩에서 사진 선택하기 기능 구현
- 화면 터치 시 키보드 내리기 구현

| 동작 화면 |
| -- |
| <img src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/22342277/38b293eb-d79c-4708-9a36-6765164abfea" width=200> |

## 고민과 해결과정
### UIButton의 이미지 크기 변경하기
- 프로필 설정 및 닉네임 변경 뷰에서는 카메라 버튼을 통해 프로필 사진 변경 기능을 알린다.
- iOS 15 이상에서부터 적용되는 UIButton.Configuration 방식은 native한 이미지 크기 변경을 지원하지 않아서, 원본 이미지 크기가 사용하고자 하는 이미지보다 크다면 그것을 줄여서 사용하기 쉽지 않다.
- contentInset이나 layoutMargin을 주어도 원본 이미지 사이즈 이하로 변하지 않아서 카메라 이미지의 크기가 더 이상 작아지지 않는 것을 확인할 수 있었다.
- UIGraphicsImageRenderer를 사용해서 새로운 크기로 다시 이미지를 그리는 방법이 있었지만, UIImageView로 변경해서 사용하는 것이 간단하고 좋은 방법이라고 생각되었다.
- 왜냐하면 사진 변경을 위한 카메라 버튼은 highlighted 또는 터치 기능 등 버튼의 필수적인 기능을 가져야 할 필요는 없다고 생각했기 때문이다.
