### PR TITLE
[BE#200]이미지 유해성 검사 기능 추가

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -28,6 +28,7 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.17",
+        "uuid": "^9.0.1",
         "winston": "^3.11.0"
       },
       "devDependencies": {
@@ -1660,6 +1661,14 @@
         "reflect-metadata": "^0.1.13"
       }
     },
+    "node_modules/@nestjs/config/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.2.8",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.2.8.tgz",
@@ -1894,18 +1903,6 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.0"
-      }
-    },
-    "node_modules/@nestjs/typeorm/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9462,9 +9459,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/BE/package.json
+++ b/BE/package.json
@@ -39,6 +39,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",
+    "uuid": "^9.0.1",
     "winston": "^3.11.0"
   },
   "devDependencies": {

--- a/BE/src/users/interface/greeneye.interface.ts
+++ b/BE/src/users/interface/greeneye.interface.ts
@@ -1,0 +1,19 @@
+export interface GreenEyeResponse {
+  version: string;
+  requestId: string;
+  timestamp: number;
+  images: [
+    {
+      message: string;
+      name: string;
+      result: {
+        adult: { confidence: number };
+        normal: { confidence: number };
+        porn: { confidence: number };
+        sexy: { confidence: number };
+      };
+      latency: number;
+      confidence: number;
+    },
+  ];
+}

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -4,12 +4,16 @@ import { Repository } from 'typeorm';
 import { UsersModel } from './entity/users.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { ConfigService } from '@nestjs/config';
+import { v4 } from 'uuid';
+import { GreenEyeResponse } from './interface/greeneye.interface';
 
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(UsersModel)
     private usersRepository: Repository<UsersModel>,
+    private config: ConfigService,
   ) {}
 
   async createUser(user: CreateUserDto): Promise<UsersModel> {
@@ -61,5 +65,49 @@ export class UsersService {
     });
 
     return selectedUser;
+  }
+
+  async isNormalImage(image_url: string): Promise<boolean> {
+    const THRESHOLD = 0.5;
+    const response = await this.requestClovaGreenEye(image_url);
+    const result = response.images[0].result;
+    const message = response.images[0].message;
+    if (message !== 'SUCCESS') {
+      throw new BadRequestException('이미지 인식 실패');
+    }
+    const normalScore = result.normal.confidence;
+    const isNormal = normalScore > THRESHOLD ? true : false;
+
+    return isNormal;
+  }
+
+  async requestClovaGreenEye(image_url: string): Promise<GreenEyeResponse> {
+    const APIURL = this.config.get<string>('GREENEYE_URL');
+    const CLIENT_SECRET = this.config.get<string>('GREENEYE_SECRET');
+    const UUID = v4();
+    try {
+      const response = await fetch(APIURL, {
+        method: 'POST',
+        headers: {
+          'X-GREEN-EYE-SECRET': CLIENT_SECRET,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          version: 'V1',
+          requestId: UUID,
+          timestamp: Date.now(),
+          images: [
+            {
+              name: `${UUID}_profile`,
+              url: image_url,
+            },
+          ],
+        }),
+      });
+
+      return response.json();
+    } catch (error) {
+      throw new BadRequestException('이미지 검사 요청 실패');
+    }
   }
 }


### PR DESCRIPTION
close #200 

## 완료된 기능
- clova greeneye api를 활용한 이미지 유해성 검사

## 고민과 해결과정
 - 현재 이미지의 url을 이용해 검사 요청 api를 활용하도록 구현했는데, base64 인코딩 이미지 바이트로도 활용할 수 있습니다.
 - api 요청을 보내면 각 label 별로(normal, adult, sexy, porn) score를 리턴해주는데, 일단 normal이 0.5보다 크면 정상 이미지로 처리하도록 했습니다.
 
## Reference
[api 공식 문서](https://api.ncloud-docs.com/docs/ai-application-service-greeneye-custom-api)