### PR TITLE
[BE#209] 친구 조회 추가 삭제

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -14,6 +14,7 @@ import { PassportModule } from '@nestjs/passport';
 import { AuthModule } from './auth/auth.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
+import { Mates } from './mates/mates.entity';
 
 @Module({
   imports: [
@@ -33,7 +34,7 @@ import { join } from 'path';
         username: config.get<string>('DATABASE_USERNAME'),
         password: config.get<string>('DATABASE_PASSWORD'),
         database: config.get<string>('DATABASE_NAME'),
-        entities: [StudyLogs, Categories, UsersModel],
+        entities: [StudyLogs, Categories, UsersModel, Mates],
         synchronize: true,
       }),
       inject: [ConfigService],

--- a/BE/src/mates/dto/response/mates.dto.ts
+++ b/BE/src/mates/dto/response/mates.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MatesDto {
+  @ApiProperty({
+    type: 'number',
+    example: '1',
+    description: '친구 관계 id',
+  })
+  id: number;
+
+  @ApiProperty({
+    type: 'number',
+    example: 1,
+    description: '구독의 주체 id (1이 2를 구독중)',
+  })
+  follower_id: number;
+
+  @ApiProperty({
+    type: 'number',
+    example: 2,
+    description: '구독 중인 친구 id',
+  })
+  following_id: number;
+}

--- a/BE/src/mates/dto/response/status-message.dto.ts
+++ b/BE/src/mates/dto/response/status-message.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class StatusMessageDto {
+  @ApiProperty({
+    type: 'number',
+    example: 200,
+    description: '상태 코드',
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: 'string',
+    example: '성공적으로 삭제되었습니다.',
+    description: '메시지',
+  })
+  message: string;
+}

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -18,6 +18,7 @@ import { MatesService } from './mates.service';
 import { MatesDto } from './dto/response/mates.dto';
 import { StatusMessageDto } from './dto/response/status-message.dto';
 import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
+import { UsersModel } from 'src/users/entity/users.entity';
 
 @Controller('mates')
 @ApiTags('소셜 페이지')
@@ -47,10 +48,10 @@ export class MatesController {
   })
   @ApiOperation({ summary: '친구 구독하기 (완)' })
   createMate(
-    @User('id') user_id: number,
+    @User() user: UsersModel,
     @Body('following_nickname') following_nickname: string,
   ): Promise<MatesDto> {
-    return this.matesService.addMate(user_id, following_nickname);
+    return this.matesService.addMate(user, following_nickname);
   }
 
   @Delete('')
@@ -58,10 +59,10 @@ export class MatesController {
   @ApiBearerAuth()
   @ApiOperation({ summary: '구독한 친구 구독 취소하기 (완)' })
   async deleteMate(
-    @User('id') user_id: number,
-    @Body('following_id') following_id: string,
+    @User() user: UsersModel,
+    @Body('following_id') following_id: number,
   ): Promise<StatusMessageDto> {
-    await this.matesService.deleteMate(user_id, following_id);
+    await this.matesService.deleteMate(user, following_id);
 
     return {
       statusCode: 200,

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -1,29 +1,71 @@
-import { Controller, Delete, Get, Param, Post } from '@nestjs/common';
-import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Body,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { User } from 'src/users/decorator/user.decorator';
+import { MatesService } from './mates.service';
+import { MatesDto } from './dto/response/mates.dto';
+import { StatusMessageDto } from './dto/response/status-message.dto';
+import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
 
 @Controller('mates')
 @ApiTags('소셜 페이지')
 export class MatesController {
+  constructor(private readonly matesService: MatesService) {}
   @Get()
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '모든 친구들 조회하기' })
-  getMates() {}
+  getMates(@User('id') user_id: number): Promise<MatesDto[]> {
+    return this.matesService.getMates(user_id);
+  }
 
   @Get('/:mate_id/stats')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '특정 친구의 통계 조회하기' })
   getMateStats(@Param('mate_id') id: string) {
     id;
   }
 
   @Post()
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth()
   @ApiCreatedResponse({
     description: '친구가 성공적으로 구독되었습니다.',
   })
   @ApiOperation({ summary: '친구 구독하기' })
-  crateMate() {}
+  createMate(
+    @User('id') user_id: number,
+    @Body('following_nickname') following_nickname: string,
+  ): Promise<MatesDto> {
+    return this.matesService.addMate(user_id, following_nickname);
+  }
 
-  @Delete('/:mate_id')
+  @Delete('')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '구독한 친구 구독 취소하기' })
-  deleteMate(@Param('mate_id') id: string) {
-    id;
+  async deleteMate(
+    @User('id') user_id: number,
+    @Body('following_id') following_id: string,
+  ): Promise<StatusMessageDto> {
+    await this.matesService.deleteMate(user_id, following_id);
+
+    return {
+      statusCode: 200,
+      message: '성공적으로 삭제되었습니다.',
+    };
   }
 }

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -26,7 +26,7 @@ export class MatesController {
   @Get()
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: '모든 친구들 조회하기' })
+  @ApiOperation({ summary: '모든 친구들 조회하기 (완)' })
   getMates(@User('id') user_id: number): Promise<MatesDto[]> {
     return this.matesService.getMates(user_id);
   }
@@ -45,7 +45,7 @@ export class MatesController {
   @ApiCreatedResponse({
     description: '친구가 성공적으로 구독되었습니다.',
   })
-  @ApiOperation({ summary: '친구 구독하기' })
+  @ApiOperation({ summary: '친구 구독하기 (완)' })
   createMate(
     @User('id') user_id: number,
     @Body('following_nickname') following_nickname: string,
@@ -56,7 +56,7 @@ export class MatesController {
   @Delete('')
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: '구독한 친구 구독 취소하기' })
+  @ApiOperation({ summary: '구독한 친구 구독 취소하기 (완)' })
   async deleteMate(
     @User('id') user_id: number,
     @Body('following_id') following_id: string,

--- a/BE/src/mates/mates.entity.ts
+++ b/BE/src/mates/mates.entity.ts
@@ -12,11 +12,17 @@ export class Mates {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => UsersModel, (user) => user.follower, { eager: true })
+  @ManyToOne(() => UsersModel, (user) => user.follower, {
+    eager: true,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'follower_id' })
   follower_id: UsersModel;
 
-  @ManyToOne(() => UsersModel, (user) => user.following, { eager: true })
+  @ManyToOne(() => UsersModel, (user) => user.following, {
+    eager: true,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'following_id' })
   following_id: UsersModel;
 }

--- a/BE/src/mates/mates.entity.ts
+++ b/BE/src/mates/mates.entity.ts
@@ -1,0 +1,22 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { UsersModel } from 'src/users/entity/users.entity';
+
+@Entity()
+export class Mates {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => UsersModel, (user) => user.follower, { eager: true })
+  @JoinColumn({ name: 'follower_id' })
+  follower_id: UsersModel;
+
+  @ManyToOne(() => UsersModel, (user) => user.following, { eager: true })
+  @JoinColumn({ name: 'following_id' })
+  following_id: UsersModel;
+}

--- a/BE/src/mates/mates.module.ts
+++ b/BE/src/mates/mates.module.ts
@@ -1,7 +1,14 @@
 import { Module } from '@nestjs/common';
 import { MatesController } from './mates.controller';
+import { MatesService } from './mates.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Mates } from './mates.entity';
+import { AuthModule } from 'src/auth/auth.module';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Mates]), AuthModule, UsersModule],
   controllers: [MatesController],
+  providers: [MatesService],
 })
 export class MatesModule {}

--- a/BE/src/mates/mates.service.spec.ts
+++ b/BE/src/mates/mates.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MatesService } from './mates.service';
+
+describe('MatesService', () => {
+  let service: MatesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MatesService],
+    }).compile();
+
+    service = module.get<MatesService>(MatesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -52,9 +52,10 @@ export class MatesService {
       throw new BadRequestException('이미 친구 관계입니다.');
     }
 
-    const mate = new Mates();
-    mate.follower_id = user;
-    mate.following_id = following;
+    const mate = this.matesRepository.create({
+      follower_id: user,
+      following_id: following,
+    });
 
     const result = await this.matesRepository.save(mate);
     return this.entityToDto(result);

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -26,17 +26,14 @@ export class MatesService {
   }
 
   async addMate(
-    user_id: number,
+    user: UsersModel,
     following_nickname: string,
   ): Promise<MatesDto> {
-    const user = await this.userRepository.findOne({
-      where: { id: user_id },
-    });
     const following = await this.userRepository.findOne({
       where: { nickname: following_nickname },
     });
 
-    if (user_id === following.id) {
+    if (user.id === following.id) {
       throw new BadRequestException('자신을 친구 추가 할 수 없습니다.');
     }
 
@@ -61,10 +58,13 @@ export class MatesService {
     return this.entityToDto(result);
   }
 
-  async deleteMate(user_id, following_id): Promise<void> {
+  async deleteMate(user: UsersModel, following_id: number): Promise<void> {
+    const following = await this.userRepository.findOne({
+      where: { id: following_id },
+    });
     const result = await this.matesRepository.delete({
-      follower_id: user_id,
-      following_id: following_id,
+      follower_id: user,
+      following_id: following,
     });
 
     if (result.affected === 0) {

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -1,0 +1,83 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Mates } from './mates.entity';
+import { Repository } from 'typeorm';
+import { MatesDto } from './dto/response/mates.dto';
+import { UsersModel } from 'src/users/entity/users.entity';
+
+@Injectable()
+export class MatesService {
+  constructor(
+    @InjectRepository(Mates)
+    private matesRepository: Repository<Mates>,
+    @InjectRepository(UsersModel)
+    private userRepository: Repository<UsersModel>,
+  ) {}
+
+  async getMates(user_id: number): Promise<MatesDto[]> {
+    const result = await this.matesRepository.find({
+      where: { follower_id: { id: user_id } },
+    });
+    return result.map((mate) => this.entityToDto(mate));
+  }
+
+  async addMate(
+    user_id: number,
+    following_nickname: string,
+  ): Promise<MatesDto> {
+    const user = await this.userRepository.findOne({
+      where: { id: user_id },
+    });
+    const following = await this.userRepository.findOne({
+      where: { nickname: following_nickname },
+    });
+
+    if (user_id === following.id) {
+      throw new BadRequestException('자신을 친구 추가 할 수 없습니다.');
+    }
+
+    if (!user || !following) {
+      throw new NotFoundException('해당 유저는 존재하지 않습니다.');
+    }
+
+    const isExist = await this.matesRepository.findOne({
+      where: { follower_id: user, following_id: following },
+    });
+
+    if (isExist) {
+      throw new BadRequestException('이미 친구 관계입니다.');
+    }
+
+    const mate = new Mates();
+    mate.follower_id = user;
+    mate.following_id = following;
+
+    const result = await this.matesRepository.save(mate);
+    return this.entityToDto(result);
+  }
+
+  async deleteMate(user_id, following_id): Promise<void> {
+    const result = await this.matesRepository.delete({
+      follower_id: user_id,
+      following_id: following_id,
+    });
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 친구 관계는 존재하지 않습니다.');
+    }
+  }
+
+  entityToDto(mate: Mates): MatesDto {
+    const { id, follower_id, following_id } = mate;
+    const mateDto = {
+      id: id,
+      follower_id: follower_id.id,
+      following_id: following_id.id,
+    };
+    return mateDto;
+  }
+}

--- a/BE/src/users/entity/users.entity.ts
+++ b/BE/src/users/entity/users.entity.ts
@@ -4,6 +4,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { StudyLogs } from 'src/study-logs/study-logs.entity';
 import { Categories } from 'src/categories/categories.entity';
 import { AuthTypeEnum } from '../const/auth-type.const';
+import { Mates } from 'src/mates/mates.entity';
 
 @Entity()
 export class UsersModel {
@@ -57,4 +58,10 @@ export class UsersModel {
 
   @OneToMany(() => Categories, (category) => category.user_id)
   categories: Categories[];
+
+  @OneToMany(() => Mates, (mate) => mate.follower_id)
+  follower: Mates[];
+
+  @OneToMany(() => Mates, (mate) => mate.following_id)
+  following: Mates[];
 }


### PR DESCRIPTION
# 이슈번호-작업이름
close #209 
## 완료된 기능
- 친구 추가 기능
- 내 친구 목록 불러오기 기능
- 친구 삭제 기능

## 고민과 해결과정
```ts
    const user = await this.userRepository.findOne({
      where: { id: user_id },
    });
    const following = await this.userRepository.findOne({
      where: { nickname: following_nickname },
    });

    const mate = this.matesRepository.create({
      follower_id: user,
      following_id: following,
    });

    const result = await this.matesRepository.save(mate);
```
친구 추가하는 방법을 위 코드처럼 내 id로 user 객체 찾고, 등록 할 친구 닉네임으로 user 객체 찾고, 이 객체를 활용해서 mate 테이블에 넣어줬습니다. DB에 조회가 2번 발생하는데 다른 방법이 없는 것 같더라구요. 직접 SQL문을 넣으면 될 것 같긴 한데 일단 이렇게 처리해둔 상태입니다

