### PR TITLE
[iOS#217] 카테고리 색상 연결 및 삭제, 수정 화면 

### DIFF
--- a/iOS/FlipMate/FlipMate/Data/Extension/UIColor++Extension.swift
+++ b/iOS/FlipMate/FlipMate/Data/Extension/UIColor++Extension.swift
@@ -8,6 +8,22 @@
 import UIKit
 
 extension UIColor {
+    convenience init?(hexString: String) {
+        var hexSanitized = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
+        var rgb: UInt64 = 0
+        
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else {
+            return nil
+        }
+        
+        let red = CGFloat((rgb & 0xFF000000) >> 24) / 255.0
+        let green = CGFloat((rgb & 0x00FF0000) >> 16) / 255.0
+        let blue = CGFloat((rgb & 0x0000FF00) >> 8) / 255.0
+        let alpha = CGFloat(rgb & 0x000000FF) / 255.0
+        
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+    
     func toHexString() -> String {
         guard let components = cgColor.components, components.count >= 3 else {
             return "FFFFFFFF"

--- a/iOS/FlipMate/FlipMate/Data/Extension/UIColor++Extension.swift
+++ b/iOS/FlipMate/FlipMate/Data/Extension/UIColor++Extension.swift
@@ -9,13 +9,19 @@ import UIKit
 
 extension UIColor {
     func toHexString() -> String {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
-        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-        let rgb: Int = (Int)(red*255) << 16 | (Int)(green*255) << 8 | (Int)(blue*255) << 0
+        guard let components = cgColor.components, components.count >= 3 else {
+            return "FFFFFFFF"
+        }
         
-        return String(format: "#%06x", rgb)
+        var red = components[0]
+        var green = components[1]
+        var blue = components[2]
+        var alpha = components[3]
+        
+        let hexString = String(format: "%02lX%02lX%02lX%02lX", lroundf(Float(red * 255)),
+                               lroundf(Float(green * 255)), lroundf(Float(blue * 255)),
+                               lroundf(Float(alpha * 255)))
+        
+        return hexString
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
@@ -36,7 +36,7 @@ final class CategoryFlowCoordinator: Coordinator {
         let categoryModifyViewController = dependencies.makeCategoryModifyViewController(
             purpose: purpose,
             category: category)
-        navigationController.present(categoryModifyViewController, animated: true)
+        navigationController.pushViewController(categoryModifyViewController, animated: true)
     }
     
     func didFinishCategorySetting() {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryColorSelectView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryColorSelectView.swift
@@ -22,6 +22,8 @@ final class CategoryColorSelectView: UIView {
         let colorWell = UIColorWell()
         colorWell.translatesAutoresizingMaskIntoConstraints = false
         colorWell.addTarget(self, action: #selector(colorWellChanged(_:)), for: .valueChanged)
+        colorWell.selectedColor = .black
+        
         return colorWell
     }()
     
@@ -39,7 +41,6 @@ private extension CategoryColorSelectView {
     func configureUI() {
         addSubview(colorLabel)
         addSubview(colorWell)
-        colorWell.selectedColor = .black
         self.backgroundColor = .systemBackground
         NSLayoutConstraint.activate([
             colorWell.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -24.0),

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryColorSelectView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryColorSelectView.swift
@@ -8,12 +8,12 @@
 import UIKit
 
 final class CategoryColorSelectView: UIView {
-    private var colorLabel: UILabel = {
+    var colorLabel: UILabel = {
         let colorLabel = UILabel()
         colorLabel.translatesAutoresizingMaskIntoConstraints = false
         colorLabel.textColor = .label
         colorLabel.font = FlipMateFont.mediumRegular.font
-        colorLabel.text = "색상을 선택하세요"
+        colorLabel.text = "000000FF"
         
         return colorLabel
     }()
@@ -39,6 +39,7 @@ private extension CategoryColorSelectView {
     func configureUI() {
         addSubview(colorLabel)
         addSubview(colorWell)
+        colorWell.selectedColor = .black
         self.backgroundColor = .systemBackground
         NSLayoutConstraint.activate([
             colorWell.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -24.0),
@@ -57,8 +58,7 @@ private extension CategoryColorSelectView {
 // MARK: - objc function
 private extension CategoryColorSelectView {
     @objc func colorWellChanged(_ sender: Any) {
-        colorLabel.text = colorWell.selectedColor?.toHexString()
-    }
+        colorLabel.text = colorWell.selectedColor?.toHexString() }
 }
 @available(iOS 17.0, *)
 #Preview {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryListCollectionViewCell.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategoryListCollectionViewCell.swift
@@ -46,6 +46,7 @@ final class CategoryListCollectionViewCell: UICollectionViewCell {
     
     func updateUI(category: Category) {
         subjectLabel.text = category.subject
+        colorCircle.tintColor = UIColor(hexString: category.color)
         timeLabel.text = category.studyTime?.secondsToStringTime()
     }
     

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
@@ -29,7 +29,8 @@ final class CategorySettingFooterView: UICollectionReusableView {
         return button
     }()
     
-    private lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(footerViewSelected))
+    private lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, 
+                                                                   action: #selector(footerViewSelected))
     private var subject = PassthroughSubject<Void, Never>()
     var cancellable: AnyCancellable?
     

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
@@ -197,7 +197,6 @@ private extension CategoryModifyViewController {
     }
     
     @objc func doneButtonTapped(_ sender: UIBarButtonItem) {
-        // TODO: 색깔 선택 기능 미구현
         if purpose == .create {
             Task {
                 do {
@@ -236,4 +235,3 @@ private extension CategoryModifyViewController {
         self.navigationController?.popViewController(animated: true)
     }
 }
-

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategoryModifyViewController.swift
@@ -205,8 +205,9 @@ private extension CategoryModifyViewController {
                         FMLogger.general.error("빈 제목, 추가할 수 없음")
                         return
                     }
-                    try await viewModel.createCategory(name: categoryTitle, colorCode: "FFFFFFFF")
-                    dismiss(animated: true)
+                    try await viewModel.createCategory(name: categoryTitle,
+                                                       colorCode: categoryColorSelectView.colorLabel.text 
+                                                       ?? "000000FF")
                 } catch let error {
                     FMLogger.general.error("카테고리 추가 중 에러 \(error)")
                 }
@@ -222,16 +223,17 @@ private extension CategoryModifyViewController {
                         FMLogger.general.error("가져온 카테고리 없음 에러")
                         return
                     }
-                    try await viewModel.updateCategory(of: category.id, newName: categoryTitle, newColorCode: "FFFFFFFF")
-                    dismiss(animated: true)
+                    try await viewModel.updateCategory(of: category.id, 
+                                                       newName: categoryTitle,
+                                                       newColorCode: categoryColorSelectView.colorLabel.text 
+                                                       ?? "000000FF")
                 } catch let error {
                     FMLogger.general.error("카테고리 추가 중 에러 \(error)")
                 }
             }
         }
+        
+        self.navigationController?.popViewController(animated: true)
     }
 }
-//@available(iOS 17.0, *)
-//#Preview {
-//    CategoryModifyViewController(viewModel: CategoryViewModel(useCase: DefaultCategoryUseCase(repository: DefaultCategoryRepository(provider: Provider(urlSession: URLSession.shared)))), purpose: .create)
-//}
+

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -111,25 +111,11 @@ private extension CategorySettingViewController {
     @objc func showActionSheet() {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
-        let modifyAction = UIAlertAction(title: "카테고리 수정", style: .default) { [weak self] _ in
-            guard let self = self,
-                  let indexPath = self.collectionView.indexPathsForSelectedItems?.first else { return }
-            guard let item = self.dataSource?.itemIdentifier(for: indexPath) else { return }
-            self.viewModel.updateCategoryTapped(category: item.category)
-        }
+        let actions = createActionSheet()
         
-        let deleteAction = UIAlertAction(title: "카테고리 삭제", style: .destructive) { [weak self] _ in
-            guard let self = self,
-                  let indexPath = self.collectionView.indexPathsForSelectedItems?.first else { return }
-            guard let item = self.dataSource?.itemIdentifier(for: indexPath) else { return }
-            showDeleteAlert()
-        }
-        
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-        
-        actionSheet.addAction(modifyAction)
-        actionSheet.addAction(deleteAction)
-        actionSheet.addAction(cancelAction)
+        for action in actions {
+                actionSheet.addAction(action)
+            }
         
         self.present(actionSheet, animated: true)
     }
@@ -141,17 +127,11 @@ private extension CategorySettingViewController {
                                       message: "\(item.category.subject)을(를) 정말 삭제하시겠습니까?",
                                       preferredStyle: .alert)
         
-        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
-            guard let self = self else { return }
-            Task {
-                await self.deleteCategory(id: item.category.id)
+        let actions = createDeleteAlert()
+        
+        for action in actions {
+                alert.addAction(action)
             }
-        }
-        
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-        
-        alert.addAction(deleteAction)
-        alert.addAction(cancelAction)
         
         self.present(alert, animated: true)
     }
@@ -223,5 +203,44 @@ private extension CategorySettingViewController {
                 .sectionIdentifiers[sectionIndex] else { return nil }
             return self?.makeLayoutSection(sectionType: sectionType)
         }
+    }
+}
+
+// MARK: - Alert function
+
+private extension CategorySettingViewController {
+    func createActionSheet() -> [UIAlertAction] {
+        let modifyAction = UIAlertAction(title: "카테고리 수정", style: .default) { [weak self] _ in
+            guard let self = self,
+                  let indexPath = self.collectionView.indexPathsForSelectedItems?.first else { return }
+            guard let item = self.dataSource?.itemIdentifier(for: indexPath) else { return }
+            self.viewModel.updateCategoryTapped(category: item.category)
+        }
+        
+        let deleteAction = UIAlertAction(title: "카테고리 삭제", style: .destructive) { [weak self] _ in
+            guard let self = self,
+                  let indexPath = self.collectionView.indexPathsForSelectedItems?.first else { return }
+            guard let item = self.dataSource?.itemIdentifier(for: indexPath) else { return }
+            showDeleteAlert()
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        return [modifyAction, deleteAction, cancelAction]
+    }
+    
+    func createDeleteAlert() -> [UIAlertAction] {
+        guard let indexPath = self.collectionView.indexPathsForSelectedItems?.first else { return [] }
+        guard let item = self.dataSource?.itemIdentifier(for: indexPath) else { return [] }
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+            guard let self = self else { return }
+            Task {
+                await self.deleteCategory(id: item.category.id)
+            }
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        return [deleteAction, cancelAction]
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -122,9 +122,7 @@ private extension CategorySettingViewController {
             guard let self = self,
                   let indexPath = self.collectionView.indexPathsForSelectedItems?.first else { return }
             guard let item = self.dataSource?.itemIdentifier(for: indexPath) else { return }
-            Task {
-                await self.deleteCategory(id: item.category.id)
-            }
+            showDeleteAlert()
         }
         
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
@@ -135,7 +133,30 @@ private extension CategorySettingViewController {
         
         self.present(actionSheet, animated: true)
     }
+    
+    @objc func showDeleteAlert() {
+        guard let indexPath = self.collectionView.indexPathsForSelectedItems?.first else { return }
+        guard let item = self.dataSource?.itemIdentifier(for: indexPath) else { return }
+        let alert = UIAlertController(title: "카테고리 삭제", 
+                                      message: "\(item.category.subject)을(를) 정말 삭제하시겠습니까?",
+                                      preferredStyle: .alert)
+        
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+            guard let self = self else { return }
+            Task {
+                await self.deleteCategory(id: item.category.id)
+            }
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(deleteAction)
+        alert.addAction(cancelAction)
+        
+        self.present(alert, animated: true)
+    }
 }
+
 // MARK: - DiffableDataSource
 private extension CategorySettingViewController {
     func setDataSource() {


### PR DESCRIPTION
close #217 

## 완료된 기능

- 카테고리 수정 부분 present -> Push
- 액션 시트, Alert를 통한 삭제 및 수정 접근
- 카테고리 색상 호환

## 고민과 해결과정

1. 기존 UIColor Extension 부분 특정 조건 시 8자리 String이 아니고 10자리 String이 나오는 오류가 종종 발견 되었습니다. 원인을 찾지는 못했지만 비트마스킹 중 오류로 예상됩니다. 따라서 로직 일부 수정하였습니다.
2. Action Sheet, Alert를 UIAlertController를 통해 구현하였습니다. 해당 부분은 뷰 전환으로 볼 수 없기 때문에 Coordinator 패턴 적용조차 고려하지 않았습니다. HIG의 언급되어 있는 삭제를 쉽게 할 수 없게 하라는 인용을 바탕으로 삭제 시도 시 2중 Alert (Action Sheet 선택 -> 경고 Alert)로 구현했습니다.
3. 카테고리 색상은 카테고리 Color String Property로 다루었습니다. 앞의 6자 String은 색상, 뒤의 2자 String은 alpha값을 0~255로 확장한 것입니다. color를 string으로 의존성을 관리하는 것이 조금 의아하긴 하지만 가장 좋은 방법이기도 한 것 같습니다.

++) 시뮬레이터 동작 중 발견한 버그 
1. DiffableDataSource & CollectionView 오류 
2. 카테고리 선택 후 타이머 실행 후 FaceUp 시 가끔 중단되지 않는 오류
3. Proximity Sensor 오류 (Found no UIEvent for backing event of type: 14; contextId: 0x0 발생 후 일정시간 화면 멈춤)