### PR TITLE
[iOS] 공부 저장 화면 UI 및 로직 구현

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		2C88DD072B125781000B4686 /* TabBarDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD062B125781000B4686 /* TabBarDIContainer.swift */; };
 		2C88DD092B1274FA000B4686 /* CategorySettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD082B1274FA000B4686 /* CategorySettingCoordinator.swift */; };
 		2C88DD0B2B1340E4000B4686 /* CategoryDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD0A2B1340E4000B4686 /* CategoryDIContainer.swift */; };
+		2C88DD0D2B148E9B000B4686 /* TimerFinishViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD0C2B148E9B000B4686 /* TimerFinishViewController.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -173,6 +174,7 @@
 		2C88DD062B125781000B4686 /* TabBarDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarDIContainer.swift; sourceTree = "<group>"; };
 		2C88DD082B1274FA000B4686 /* CategorySettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingCoordinator.swift; sourceTree = "<group>"; };
 		2C88DD0A2B1340E4000B4686 /* CategoryDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDIContainer.swift; sourceTree = "<group>"; };
+		2C88DD0C2B148E9B000B4686 /* TimerFinishViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishViewController.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -344,6 +346,7 @@
 				601773E32B021E6000D175D9 /* TimerViewController.swift */,
 				2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */,
 				ED3595BC2B0DB29F00558FAA /* CategoryModifyViewController.swift */,
+				2C88DD0C2B148E9B000B4686 /* TimerFinishViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1164,6 +1167,7 @@
 				2C3430AB2B0DDB8D008CBC85 /* TimerEndpoints.swift in Sources */,
 				ED3842212B0F1CF9001E2803 /* User.swift in Sources */,
 				2C3430A12B0DA4E6008CBC85 /* BaseComponents.swift in Sources */,
+				2C88DD0D2B148E9B000B4686 /* TimerFinishViewController.swift in Sources */,
 				2C3430A12B0DA4E6008CBC85 /* BaseComponents.swift in Sources */,
 				2C2F21832B0F53B500B45BA8 /* StduyLogMock.swift in Sources */,
 				60F67C682B0E1785002C8BF3 /* CategoryUseCase.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		2C88DD0F2B14C22C000B4686 /* TimerFinishViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD0E2B14C22C000B4686 /* TimerFinishViewModel.swift */; };
 		2C88DD112B14C50F000B4686 /* DefaultTimerFinishUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD102B14C50F000B4686 /* DefaultTimerFinishUseCase.swift */; };
 		2C88DD132B14C51B000B4686 /* TimerFinishUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD122B14C51B000B4686 /* TimerFinishUseCase.swift */; };
+		2C9F61F72B14EFA200AE63F9 /* CategoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F61F62B14EFA200AE63F9 /* CategoryManager.swift */; };
+		2C9F61F92B14F33600AE63F9 /* CategoryManagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F61F82B14F33600AE63F9 /* CategoryManagable.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -181,6 +183,8 @@
 		2C88DD0E2B14C22C000B4686 /* TimerFinishViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishViewModel.swift; sourceTree = "<group>"; };
 		2C88DD102B14C50F000B4686 /* DefaultTimerFinishUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTimerFinishUseCase.swift; sourceTree = "<group>"; };
 		2C88DD122B14C51B000B4686 /* TimerFinishUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishUseCase.swift; sourceTree = "<group>"; };
+		2C9F61F62B14EFA200AE63F9 /* CategoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryManager.swift; sourceTree = "<group>"; };
+		2C9F61F82B14F33600AE63F9 /* CategoryManagable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryManagable.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -474,6 +478,14 @@
 			path = Flows;
 			sourceTree = "<group>";
 		};
+		2C9F61F52B14EA9800AE63F9 /* CategoryManager */ = {
+			isa = PBXGroup;
+			children = (
+				2C9F61F62B14EFA200AE63F9 /* CategoryManager.swift */,
+			);
+			path = CategoryManager;
+			sourceTree = "<group>";
+		};
 		48114A3517087E7FD0C9546F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -703,6 +715,7 @@
 		600908FE2AFCDF8D0065DFFB /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				2C9F61F52B14EA9800AE63F9 /* CategoryManager */,
 				2C801D812B04C62900A7ABAE /* TimerManager */,
 				EDC851D72B05C357009031EA /* DeviceMotionManager */,
 				2C43A0D62B037BA50005596A /* FeedbackManager */,
@@ -727,6 +740,7 @@
 			isa = PBXGroup;
 			children = (
 				2C6717F72B0535A8004D118D /* Int++Extension.swift */,
+				2C9F61F82B14F33600AE63F9 /* CategoryManagable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1163,6 +1177,7 @@
 				ED3595B22B0C83D700558FAA /* TimerStartResponseDTO.swift in Sources */,
 				2C5CDA582B025426007AFC57 /* FlipMateFont.swift in Sources */,
 				60DE493D2B05DEA400ACE6DD /* FlipMateLogger.swift in Sources */,
+				2C9F61F72B14EFA200AE63F9 /* CategoryManager.swift in Sources */,
 				2C88DCF62B124292000B4686 /* TimerSceneDIContainer.swift in Sources */,
 				2C2F21802B0F4DA600B45BA8 /* MockURLSession.swift in Sources */,
 				2C801D802B04B68900A7ABAE /* TimerUseCase.swift in Sources */,
@@ -1202,6 +1217,7 @@
 				2CE84EF72B0B7F3C00E2FB71 /* CategorySettingSection.swift in Sources */,
 				2C88DD112B14C50F000B4686 /* DefaultTimerFinishUseCase.swift in Sources */,
 				2C3430AD2B0DDF25008CBC85 /* DefaultTimerRepository.swift in Sources */,
+				2C9F61F92B14F33600AE63F9 /* CategoryManagable.swift in Sources */,
 				2C6717F82B0535A8004D118D /* Int++Extension.swift in Sources */,
 				ED3595B92B0C88A300558FAA /* TimerFinishResponseDTO.swift in Sources */,
 				608646552B0DDC3900B0C1BC /* CategoryRequestDTO.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -52,6 +52,9 @@
 		2C88DD092B1274FA000B4686 /* CategorySettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD082B1274FA000B4686 /* CategorySettingCoordinator.swift */; };
 		2C88DD0B2B1340E4000B4686 /* CategoryDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD0A2B1340E4000B4686 /* CategoryDIContainer.swift */; };
 		2C88DD0D2B148E9B000B4686 /* TimerFinishViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD0C2B148E9B000B4686 /* TimerFinishViewController.swift */; };
+		2C88DD0F2B14C22C000B4686 /* TimerFinishViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD0E2B14C22C000B4686 /* TimerFinishViewModel.swift */; };
+		2C88DD112B14C50F000B4686 /* DefaultTimerFinishUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD102B14C50F000B4686 /* DefaultTimerFinishUseCase.swift */; };
+		2C88DD132B14C51B000B4686 /* TimerFinishUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DD122B14C51B000B4686 /* TimerFinishUseCase.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -175,6 +178,9 @@
 		2C88DD082B1274FA000B4686 /* CategorySettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingCoordinator.swift; sourceTree = "<group>"; };
 		2C88DD0A2B1340E4000B4686 /* CategoryDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDIContainer.swift; sourceTree = "<group>"; };
 		2C88DD0C2B148E9B000B4686 /* TimerFinishViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishViewController.swift; sourceTree = "<group>"; };
+		2C88DD0E2B14C22C000B4686 /* TimerFinishViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishViewModel.swift; sourceTree = "<group>"; };
+		2C88DD102B14C50F000B4686 /* DefaultTimerFinishUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTimerFinishUseCase.swift; sourceTree = "<group>"; };
+		2C88DD122B14C51B000B4686 /* TimerFinishUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFinishUseCase.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -336,6 +342,7 @@
 			children = (
 				2C4D55AF2B0348FB006D7C26 /* TimerViewModel.swift */,
 				ED9B2A802B06048D008FE1C5 /* CategoryViewModel.swift */,
+				2C88DD0E2B14C22C000B4686 /* TimerFinishViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -774,6 +781,7 @@
 				60F67C692B0E1868002C8BF3 /* DefaultCategoryUseCase.swift */,
 				2C2F216D2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift */,
 				ED3842242B0F1DDA001E2803 /* DefaultGoogleAuthUseCase.swift */,
+				2C88DD102B14C50F000B4686 /* DefaultTimerFinishUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -785,6 +793,7 @@
 				60F67C672B0E1785002C8BF3 /* CategoryUseCase.swift */,
 				2C2F21792B0F4CF900B45BA8 /* StudyLogUseCase.swift */,
 				ED3842262B0F1E0C001E2803 /* GoogleAuthUseCase.swift */,
+				2C88DD122B14C51B000B4686 /* TimerFinishUseCase.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1160,6 +1169,7 @@
 				6086464E2B0DDA1300B0C1BC /* CategoryRepository.swift in Sources */,
 				2C2F21782B0F4CCC00B45BA8 /* StudyLog.swift in Sources */,
 				ED82F00B2B128C4D005BB32D /* UIColor++Extension.swift in Sources */,
+				2C88DD132B14C51B000B4686 /* TimerFinishUseCase.swift in Sources */,
 				2C88DCFE2B1244A6000B4686 /* LoginFlowCoordinator.swift in Sources */,
 				601773E42B021E6000D175D9 /* TimerViewController.swift in Sources */,
 				2C88DCF92B1242DA000B4686 /* TimerFlowCoordinator.swift in Sources */,
@@ -1190,6 +1200,7 @@
 				2C2F21702B0F429800B45BA8 /* StudyLogResponseDTO.swift in Sources */,
 				2C2F216E2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift in Sources */,
 				2CE84EF72B0B7F3C00E2FB71 /* CategorySettingSection.swift in Sources */,
+				2C88DD112B14C50F000B4686 /* DefaultTimerFinishUseCase.swift in Sources */,
 				2C3430AD2B0DDF25008CBC85 /* DefaultTimerRepository.swift in Sources */,
 				2C6717F82B0535A8004D118D /* Int++Extension.swift in Sources */,
 				ED3595B92B0C88A300558FAA /* TimerFinishResponseDTO.swift in Sources */,
@@ -1201,6 +1212,7 @@
 				2C3430972B0C7ED8008CBC85 /* EndPoint.swift in Sources */,
 				608646592B0DE61200B0C1BC /* CategoryEndpoints.swift in Sources */,
 				2C2F21762B0F440D00B45BA8 /* StudyLogEndpoints.swift in Sources */,
+				2C88DD0F2B14C22C000B4686 /* TimerFinishViewModel.swift in Sources */,
 				2C4D55B32B035484006D7C26 /* DeviceOrientation.swift in Sources */,
 				ED3842272B0F1E0C001E2803 /* GoogleAuthUseCase.swift in Sources */,
 				2C88DCF22B124238000B4686 /* AppFlowCoordinator.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/AppDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/AppDIContainer.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class AppDIContainer {
     lazy var provider: Provider = Provider(urlSession: URLSession.shared)
-    lazy var categoryManager: CategoryManager = CategoryManager(categories: [])
+    lazy var categoryManager: CategoryManageable = CategoryManager(categories: [])
     
     func makeTabBarDIContainer() -> TabBarDIContainer {
         let dependencies = TabBarDIContainer.Dependencies(

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/AppDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/AppDIContainer.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class AppDIContainer {
     lazy var provider: Provider = Provider(urlSession: URLSession.shared)
-    lazy var categoryManager: CategoryManager = CategoryManager()
+    lazy var categoryManager: CategoryManager = CategoryManager(categories: [])
     
     func makeTabBarDIContainer() -> TabBarDIContainer {
         let dependencies = TabBarDIContainer.Dependencies(

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/CategoryDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/CategoryDIContainer.swift
@@ -10,7 +10,7 @@ import UIKit
 final class CategoryDIContainer: CategoryFlowCoordinatorDependencies {
     struct Dependencies {
         let provider: Providable
-        let categoryManager: CategoryManager
+        let categoryManager: CategoryManageable
     }
     
     private let dependencies: Dependencies

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/LoginDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/LoginDIContainer.swift
@@ -10,7 +10,7 @@ import UIKit
 final class LoginDIContainer: LoginFlowCoordinatorDependencies {
     struct Dependencies {
         let provider: Providable
-        let categoryManager: CategoryManager
+        let categoryManager: CategoryManageable
     }
     
     private let dependencies: Dependencies

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TabBarDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TabBarDIContainer.swift
@@ -11,7 +11,7 @@ final class TabBarDIContainer: TabBarFlowCoordinatorDependencies {
     
     struct Dependencies {
         let provider: Providable
-        let categoryManager: CategoryManager
+        let categoryManager: CategoryManageable
     }
     
     private let dependencies: Dependencies

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
@@ -10,7 +10,7 @@ import UIKit
 final class TimerSceneDIContainer: TimerFlowCoordinatorDependencies {
     struct Dependencies {
         let provider: Providable
-        let categoryManager: CategoryManager
+        let categoryManager: CategoryManageable
     }
     
     private let dependencies: Dependencies

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
@@ -24,6 +24,18 @@ final class TimerSceneDIContainer: TimerFlowCoordinatorDependencies {
             timerViewModel: makeTimerViewModel(actions: actions))
     }
     
+    func makeTimerFinishViewController(actions: TimerFinishViewModelActions, studyEndLog: StudyEndLog) -> UIViewController {
+        return TimerFinishViewController(
+            viewModel: makeTimerFinishViewModel(studyEndLog: studyEndLog, actions: actions))
+    }
+    
+    func makeTimerFinishViewModel(studyEndLog: StudyEndLog, actions: TimerFinishViewModelActions) -> TimerFinishViewModel {
+        return TimerFinishViewModel(
+            studyEndLog: studyEndLog,
+            timerFinishUseCase: DefaultTimerFinishUseCase(timerRepository: makeTimerRepository()),
+            actions: actions)
+    }
+    
     func makeTimerViewModel(actions: TimerViewModelActions) -> TimerViewModelProtocol {
         return TimerViewModel(
             timerUseCase: makeTimerUseCase(),

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
@@ -40,7 +40,8 @@ final class TimerSceneDIContainer: TimerFlowCoordinatorDependencies {
         return TimerViewModel(
             timerUseCase: makeTimerUseCase(),
             userInfoUserCase: makeUserInfoUseCase(),
-            actions: actions)
+            actions: actions,
+            categoryManager: dependencies.categoryManager)
     }
     
     func makeTimerUseCase() -> TimerUseCase {

--- a/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
+++ b/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
@@ -8,8 +8,6 @@
 import UIKit
 import GoogleSignIn
 
-final class CategoryManager { }
-
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let appDIContainer = AppDIContainer()
     var appFlowCoordinator: AppFlowCoordinator?

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultTimerFinishUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultTimerFinishUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  DefaultTimerFinishUseCase.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/27.
+//
+
+import Foundation
+import Combine
+
+final class DefaultTimerFinishUseCase: TimerFinishUseCase {
+    private let timerRepository: TimerRepsoitory
+    
+    init(timerRepository: TimerRepsoitory) {
+        self.timerRepository = timerRepository
+    }
+    
+    func finishTimer(endTime: Date, learningTime: Int, categoryId: Int?) -> AnyPublisher<Void, NetworkError> {
+        return timerRepository.finishTimer(
+            endTime: endTime,
+            learningTime: learningTime,
+            categoryId: categoryId)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultTimerUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultTimerUseCase.swift
@@ -27,14 +27,10 @@ class DefaultTimerUseCase: TimerUseCase {
         return timerRepository.startTimer(startTime: resumeTime, categoryId: categoryId)
     }
 
-    func suspendTimer(suspendTime: Date, categoryId: Int?) -> AnyPublisher<Int, NetworkError> {
+    func suspendTimer(suspendTime: Date) -> Int {
         let totalTime = timerManager.totalTime
         timerManager.suspend()
-        return timerRepository.finishTimer(endTime: suspendTime, learningTime: totalTime, categoryId: categoryId)
-            .map { response -> Int in
-                return totalTime
-            }
-            .eraseToAnyPublisher()
+        return totalTime
     }
 
     func stopTimer() {

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/TimerFinishUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/TimerFinishUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  TimerFinishUseCase.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/27.
+//
+
+import Foundation
+import Combine
+
+protocol TimerFinishUseCase {
+    func finishTimer(endTime: Date, learningTime: Int, categoryId: Int?) -> AnyPublisher<Void, NetworkError>
+}

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/TimerUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/TimerUseCase.swift
@@ -15,7 +15,7 @@ protocol TimerUseCase {
     /// 타이머 재개
     func resumeTimer(resumeTime: Date, categoryId: Int?) -> AnyPublisher<Void, NetworkError>
     /// 타이머 일시정지
-    func suspendTimer(suspendTime: Date, categoryId: Int?) -> AnyPublisher<Int, NetworkError>
+    func suspendTimer(suspendTime: Date) -> Int
     /// 타이머 종료
     func stopTimer()
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
@@ -10,13 +10,15 @@ import UIKit
 protocol TimerFlowCoordinatorDependencies {
     func makeTimerViewController(actions: TimerViewModelActions) -> TimerViewController
     func makeCategoryDIContainer() -> CategoryDIContainer
+    func makeTimerFinishViewController(actions: TimerFinishViewModelActions, studyEndLog: StudyEndLog) -> UIViewController
 }
 
 final class TimerFlowCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
     private var navigationController: UINavigationController
+    private var timerViewController: TimerViewController?
     private let dependencies: TimerFlowCoordinatorDependencies
-        
+    
     init(navigationController: UINavigationController, dependencies: TimerFlowCoordinatorDependencies) {
         self.navigationController = navigationController
         self.dependencies = dependencies
@@ -24,8 +26,10 @@ final class TimerFlowCoordinator: Coordinator {
     
     func start() {
         let actions = TimerViewModelActions(
-            showCategorySettingViewController: showCategorySettingViewController)
+            showCategorySettingViewController: showCategorySettingViewController,
+            showTimerFinishViewController: showTimerFinishViewController)
         let viewController = dependencies.makeTimerViewController(actions: actions)
+        timerViewController = viewController
         navigationController.viewControllers = [viewController]
     }
     
@@ -36,5 +40,24 @@ final class TimerFlowCoordinator: Coordinator {
         coordinator.parentCoordinator = self
         coordinator.start()
         childCoordinators.append(coordinator)
+    }
+    
+    private func showTimerFinishViewController(studyEndLog: StudyEndLog) -> Void {
+        let actions = TimerFinishViewModelActions(
+            didSaveStudyEndLog: didSaveStudyEndLog,
+            didCancleStudyEndLog: didCancleStudyEndLog)
+        let timerFinishViewController = dependencies.makeTimerFinishViewController(actions: actions, studyEndLog: studyEndLog)
+        timerFinishViewController.modalPresentationStyle = .overFullScreen
+        timerFinishViewController.modalTransitionStyle = .crossDissolve
+        navigationController.present(timerFinishViewController, animated: true)
+    }
+    
+    private func didSaveStudyEndLog(studyEndLog: StudyEndLog) {
+        navigationController.dismiss(animated: true)
+        timerViewController?.appendStudyEndLog(studyEndLog: studyEndLog)
+    }
+    
+    private func didCancleStudyEndLog() {
+        navigationController.dismiss(animated: true)
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
@@ -1,0 +1,130 @@
+//
+//  TimerFinishViewController.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/27.
+//
+
+import UIKit
+
+final class TimerFinishViewController: BaseViewController {
+    private enum Constant {
+        static let save = "예"
+        static let cancle = "아니요"
+        static let title = "타이머 종료"
+        static let learningTitle = "공부한 시간을 저장하시겠습니까?"
+        static let learningTime = "00:00:00"
+    }
+    
+    private lazy var backgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = FlipMateColor.gray2.color
+        view.layer.opacity = 0.4
+        view.isUserInteractionEnabled = true
+        return view
+    }()
+    
+    private lazy var finishView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemBackground
+        return view
+    }()
+    
+    private lazy var saveButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(Constant.save, for: .normal)
+        button.backgroundColor = FlipMateColor.darkBlue.color
+        button.titleLabel?.font = FlipMateFont.mediumBold.font
+        button.setTitleColor(.white, for: .normal)
+        button.layer.borderColor = FlipMateColor.gray2.color?.cgColor
+        button.layer.borderWidth = 1
+        return button
+    }()
+    
+    private lazy var cancleButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(Constant.cancle, for: .normal)
+        button.backgroundColor = FlipMateColor.darkBlue.color
+        button.titleLabel?.font = FlipMateFont.mediumBold.font
+        button.setTitleColor(.white, for: .normal)
+        button.layer.borderColor = FlipMateColor.gray2.color?.cgColor
+        button.layer.borderWidth = 1
+        return button
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = Constant.title
+        label.font = FlipMateFont.smallBold.font
+        label.textColor = FlipMateColor.gray2.color
+        return label
+    }()
+    
+    private let learningTimeTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = Constant.learningTitle
+        label.font = FlipMateFont.mediumBold.font
+        label.textColor = .label
+        return label
+    }()
+    
+    private let learningTimeContentLabel: UILabel = {
+        let label = UILabel()
+        label.text = Constant.learningTime
+        label.font = FlipMateFont.largeBold.font
+        label.textColor = .label
+        return label
+    }()
+    
+    // MARK: - Life Cycle
+    override func configureUI() {
+        [backgroundView, finishView].forEach {
+            view.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        [saveButton, cancleButton, titleLabel, learningTimeTitleLabel, learningTimeContentLabel].forEach {
+            finishView.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            backgroundView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            backgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            backgroundView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            
+            finishView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            finishView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            finishView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            finishView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            finishView.heightAnchor.constraint(equalToConstant: 200),
+            
+            titleLabel.centerXAnchor.constraint(equalTo: finishView.centerXAnchor),
+            titleLabel.topAnchor.constraint(equalTo: finishView.topAnchor, constant: 10),
+            
+            learningTimeTitleLabel.centerXAnchor.constraint(equalTo: finishView.centerXAnchor),
+            learningTimeTitleLabel.bottomAnchor.constraint(
+                equalTo: learningTimeContentLabel.topAnchor,
+                constant: -5),
+            
+            learningTimeContentLabel.centerXAnchor.constraint(equalTo: finishView.centerXAnchor),
+            learningTimeContentLabel.centerYAnchor.constraint(equalTo: finishView.centerYAnchor),
+            
+            saveButton.bottomAnchor.constraint(equalTo: finishView.bottomAnchor),
+            saveButton.leadingAnchor.constraint(equalTo: finishView.leadingAnchor),
+            saveButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
+            saveButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2),
+            
+            cancleButton.bottomAnchor.constraint(equalTo: finishView.bottomAnchor),
+            cancleButton.trailingAnchor.constraint(equalTo: finishView.trailingAnchor),
+            cancleButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
+            cancleButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2)
+        ])
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    TimerFinishViewController()
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
@@ -18,7 +18,7 @@ final class TimerFinishViewController: BaseViewController {
     
     private lazy var backgroundView: UIView = {
         let view = UIView()
-        view.backgroundColor = FlipMateColor.gray2.color
+        view.backgroundColor = FlipMateColor.gray1.color
         view.layer.opacity = 0.4
         view.isUserInteractionEnabled = true
         return view
@@ -27,6 +27,8 @@ final class TimerFinishViewController: BaseViewController {
     private lazy var finishView: UIView = {
         let view = UIView()
         view.backgroundColor = .systemBackground
+        view.layer.borderColor = FlipMateColor.gray2.color?.cgColor
+        view.layer.borderWidth = 1
         return view
     }()
     
@@ -78,6 +80,8 @@ final class TimerFinishViewController: BaseViewController {
     
     // MARK: - Life Cycle
     override func configureUI() {
+        view.backgroundColor = .clear
+
         [backgroundView, finishView].forEach {
             view.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -89,10 +93,10 @@ final class TimerFinishViewController: BaseViewController {
         }
         
         NSLayoutConstraint.activate([
-            backgroundView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            backgroundView.topAnchor.constraint(equalTo: view.topAnchor),
             backgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             backgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            backgroundView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            backgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             
             finishView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             finishView.centerYAnchor.constraint(equalTo: view.centerYAnchor),

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -20,7 +20,7 @@ final class TimerViewController: BaseViewController {
     private var cancellables = Set<AnyCancellable>()
     private var userScreenBrightness: CGFloat = UIScreen.main.brightness
     private var dataSource: CateogoryDataSource?
-
+    
     // MARK: - init
     init(timerViewModel: TimerViewModelProtocol) {
         self.timerViewModel = timerViewModel
@@ -83,7 +83,6 @@ final class TimerViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         configureNotification()
         UIDevice.current.isProximityMonitoringEnabled = true
-        timerViewModel.viewDidLoad()
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -190,6 +189,10 @@ final class TimerViewController: BaseViewController {
                 self.dataSource?.apply(snapShot)
             }
             .store(in: &cancellables)
+    }
+    
+    func appendStudyEndLog(studyEndLog: StudyEndLog) {
+        timerViewModel.appendStudyEndLog(studyEndLog: studyEndLog)
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -172,16 +172,6 @@ final class TimerViewController: BaseViewController {
             .sink { [weak self] categories in
                 guard let self = self else { return }
                 guard var snapShot = self.dataSource?.snapshot() else { return }
-                snapShot.appendItems(categories.map { CategorySettingItem.categoryCell($0) })
-                self.dataSource?.apply(snapShot)
-            }
-            .store(in: &cancellables)
-        
-        timerViewModel.categoryChangePublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] categories in
-                guard let self = self else { return }
-                guard var snapShot = self.dataSource?.snapshot() else { return }
                 let sections: [CategorySettingSection] = [.categorySection([])]
                 snapShot.deleteAllItems()
                 snapShot.appendSections(sections)
@@ -189,6 +179,10 @@ final class TimerViewController: BaseViewController {
                 self.dataSource?.apply(snapShot)
             }
             .store(in: &cancellables)
+        
+        // TODO: 특정 카테고리만 업데이트 구현
+//        timerViewModel.categoryChangePublisher
+            
     }
     
     func appendStudyEndLog(studyEndLog: StudyEndLog) {
@@ -250,6 +244,8 @@ private extension TimerViewController {
             case .categoryCell(let category):
                 let cell: CategoryListCollectionViewCell = collectionView.dequeueReusableCell(for: indexPath)
                 cell.updateUI(category: category)
+                cell.updateShadow()
+                cell.setTimeLabelHidden(isHidden: false)
                 return cell
             }
         })

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerFinishViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerFinishViewModel.swift
@@ -1,0 +1,75 @@
+//
+//  TimerFinishViewModel.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/27.
+//
+
+import Foundation
+import Combine
+
+struct TimerFinishViewModelActions {
+    let didSaveStudyEndLog: (StudyEndLog) -> Void
+    let didCancleStudyEndLog: () -> Void
+}
+
+protocol TimerFinishViewModelInput {
+    func saveButtonDidTapped()
+    func cancleButtonDidTapped()
+}
+
+protocol TimerFinishViewModelOutput {
+    var learningTimePublisher: AnyPublisher<Int, Never> { get }
+}
+
+typealias TimerFinishViewModelProtocol = TimerFinishViewModelInput & TimerFinishViewModelOutput
+
+struct StudyEndLog {
+    let learningTime: Int
+    let endDate: Date
+    let categoryId: Int?
+}
+
+final class TimerFinishViewModel: TimerFinishViewModelProtocol {
+    
+    private let studyEndLog: StudyEndLog
+    private let timerFinishUseCase: TimerFinishUseCase
+    private let actions: TimerFinishViewModelActions?
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - Subject
+    private lazy var learningTimeSubject = CurrentValueSubject<Int, Never>(studyEndLog.learningTime)
+    
+    init(studyEndLog: StudyEndLog, timerFinishUseCase: TimerFinishUseCase, actions: TimerFinishViewModelActions? = nil) {
+        self.studyEndLog = studyEndLog
+        self.timerFinishUseCase = timerFinishUseCase
+        self.actions = actions
+    }
+    
+    // MARK: - output
+    var learningTimePublisher: AnyPublisher<Int, Never> {
+        return learningTimeSubject.eraseToAnyPublisher()
+    }
+    
+    // MARK: - input
+    func saveButtonDidTapped() {
+        timerFinishUseCase.finishTimer(endTime: studyEndLog.endDate, learningTime: studyEndLog.learningTime, categoryId: studyEndLog.categoryId)
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    FMLogger.timer.debug("공부 종료 API 요청 성공")
+                case .failure(let error):
+                    FMLogger.timer.error("\(error.localizedDescription)")
+                }
+            } receiveValue: { [weak self] _ in
+                guard let self = self else { return }
+                self.actions?.didSaveStudyEndLog(studyEndLog)
+            }
+            .store(in: &cancellables)
+    }
+    
+    func cancleButtonDidTapped() {
+        actions?.didCancleStudyEndLog()
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
@@ -52,10 +52,10 @@ final class TimerViewModel: TimerViewModelProtocol {
     private var totalTime: Int = 0 // 총 공부 시간
     private var selectedCategory: Category?
     private let actions: TimerViewModelActions?
-    private let categoryManager: CategoryManager
+    private let categoryManager: CategoryManageable
     
     // MARK: - init
-    init(timerUseCase: TimerUseCase, userInfoUserCase: StudyLogUseCase, actions: TimerViewModelActions? = nil, categoryManager: CategoryManager) {
+    init(timerUseCase: TimerUseCase, userInfoUserCase: StudyLogUseCase, actions: TimerViewModelActions? = nil, categoryManager: CategoryManageable) {
         self.timerUseCase = timerUseCase
         self.userInfoUserCase = userInfoUserCase
         self.actions = actions

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/CategoryManager/CategoryManager.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/CategoryManager/CategoryManager.swift
@@ -1,0 +1,55 @@
+//
+//  CategoryManager.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/28.
+//
+
+import Foundation
+import Combine
+
+final class CategoryManager: CategoryManageable {
+    // MARK: - Properties
+    private lazy var categoryDidChangeSubject = CurrentValueSubject<[Category], Never>(categories)
+    private var categories: [Category] = []
+
+    var categoryDidChangePublisher: AnyPublisher<[Category], Never> {
+        return categoryDidChangeSubject.eraseToAnyPublisher()
+    }
+    
+    // MARK: - init
+    init(categories: [Category]) {
+        self.categories = categories
+    }
+    
+    // MARK: - Methods
+    func replace(categories: [Category]) {
+        self.categories = categories
+        categoryDidChangeSubject.send(self.categories)
+    }
+    
+    func change(category: Category) {
+        guard let targetCategory = categories.filter { $0.id == category.id }.first else { return }
+        guard let targetIndex = categories.firstIndex(of: targetCategory) else { return }
+        categories[targetIndex] = category
+        categoryDidChangeSubject.send(categories)
+    }
+    
+    func removeCategory(categoryId: Int) {
+        guard let targetCategory = categories.filter { $0.id == categoryId }.first else { return }
+        guard let targetIndex = categories.firstIndex(of: targetCategory) else { return }
+        categories.remove(at: targetIndex)
+        categoryDidChangeSubject.send(categories)
+    }
+    
+    func append(category: Category) {
+        categories.append(category)
+        categoryDidChangeSubject.send(categories)
+    }
+    
+    func findCategory(categoryId: Int) -> Category? {
+        guard let targetCategory = categories.filter { $0.id == categoryId }.first else { return nil }
+        guard let targetIndex = categories.firstIndex(of: targetCategory) else { return nil }
+        return categories[targetIndex]
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/Protocols/CategoryManagable.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/Protocols/CategoryManagable.swift
@@ -1,0 +1,18 @@
+//
+//  CategoryManagable.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/28.
+//
+
+import Foundation
+import Combine
+
+protocol CategoryManageable {
+    var categoryDidChangePublisher: AnyPublisher<[Category], Never> { get }
+    func replace(categories: [Category])
+    func change(category: Category)
+    func removeCategory(categoryId: Int)
+    func append(category: Category)
+    func findCategory(categoryId: Int) -> Category?
+}


### PR DESCRIPTION
closed #221 

## 완료된 기능
- Face Down -> Face Up 될 때 저장 화면 UI 및 로직 구현
- CategoryManager 구현 (해당 Manager을 통해 여러 화면에서 카테고리 데이터 관리)
- 총 공부 시간 중복 누적 이슈 수정
- 다중 Cell 선택 이슈 수정
- 카테고리 cell 선택 후 공부 완료시 반영안되던 이슈 수정

## 실행 결과

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/34525963-5f9d-4a7a-8d78-58921960c23c

## 고민과 해결과정
### FlowCoordinator을 통한 화면 간의 데이터 전달 
기록 저장 화면에서 저장 여부 선택에 따라 타이머 화면으로 다시 dismiss될 때 데이터를 전달하기 위하여 TimerFlowCoordinator을 통해 데이터를 전달하였습니다.

기록 저장 화면에서 저장을 하게 되면 이전 화면으로 돌아오게 될 때 데이터를 전달해주기 위해 해당아래 코드와 같이 구현하였습니다.
 
``` swift
// TimerFlowCoordinator
    private func didSaveStudyEndLog(studyEndLog: StudyEndLog) {
        navigationController.dismiss(animated: true)
        timerViewController?.appendStudyEndLog(studyEndLog: studyEndLog)
    }
```
때문에 TimerFlowCoordinator가 timerViewController에 직접 접근하여 관련된 메소드를 실행시켜주고 있어서 은닉화에 어늣나는 것이 아닌가 싶기도 합니다........

결국에 Coordinator로 화면 전환을 관리하고 두 ViewController가 서로에 대해서 아예 알지 못하다보니 위의 방식으로밖에 해답이 안나왔는데 더 좋은 방법이 있으면 알려주시면 감사하겠습니다!

### CategoryManager을 통한 카테고리 관리
이전 로직의 문제점이 카테고리 데이터를 일관성 있게 관리해주지 못하고 화면 전환시에 API을 지속적으로 호출해야되는 문제점이 있었습니다.
결국에 하나의 카테고리 데이터를 통해서 여러 ViewModel에서 위의 데이터를 사용하여 데이터를 일관성있게 관리해주는게 맞다고 판단하여 CategoryManager을 드디어 구현하게 되었습니다.

이전에는 Input, Output 패턴을 통해서 ViewModel을 추상화해주다보니 CategoryManager을 화면을 전환해야하는 ViewModel에 전달해주기가 곤란했었었는데
Coordinator와 DI Container을 통해 각각의 ViewModel에 의존성을 주입해주다보니 문제가 해결되었습니다.




