### PR TITLE
[iOS#238] 친구 추가하기 화면 UI 구현

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -59,6 +59,9 @@
 		2C9F61F92B14F33600AE63F9 /* CategoryManagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F61F82B14F33600AE63F9 /* CategoryManagable.swift */; };
 		2C9F61FB2B15C96100AE63F9 /* CategoryModifyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F61FA2B15C96100AE63F9 /* CategoryModifyViewModel.swift */; };
 		2C9F61FE2B15F48600AE63F9 /* FriendAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F61FD2B15F48600AE63F9 /* FriendAddViewController.swift */; };
+		2C9F62012B1601F200AE63F9 /* MyNickNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62002B1601F200AE63F9 /* MyNickNameView.swift */; };
+		2C9F62032B16021E00AE63F9 /* FriendSearchResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62022B16021E00AE63F9 /* FriendSearchResultView.swift */; };
+		2C9F62052B160B3900AE63F9 /* NoResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62042B160B3900AE63F9 /* NoResultView.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -189,6 +192,9 @@
 		2C9F61F82B14F33600AE63F9 /* CategoryManagable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryManagable.swift; sourceTree = "<group>"; };
 		2C9F61FA2B15C96100AE63F9 /* CategoryModifyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModifyViewModel.swift; sourceTree = "<group>"; };
 		2C9F61FD2B15F48600AE63F9 /* FriendAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendAddViewController.swift; sourceTree = "<group>"; };
+		2C9F62002B1601F200AE63F9 /* MyNickNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNickNameView.swift; sourceTree = "<group>"; };
+		2C9F62022B16021E00AE63F9 /* FriendSearchResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSearchResultView.swift; sourceTree = "<group>"; };
+		2C9F62042B160B3900AE63F9 /* NoResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoResultView.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -492,6 +498,16 @@
 			path = CategoryManager;
 			sourceTree = "<group>";
 		};
+		2C9F61FF2B1601E800AE63F9 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				2C9F62002B1601F200AE63F9 /* MyNickNameView.swift */,
+				2C9F62022B16021E00AE63F9 /* FriendSearchResultView.swift */,
+				2C9F62042B160B3900AE63F9 /* NoResultView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		48114A3517087E7FD0C9546F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -614,6 +630,7 @@
 		600908F22AFCDCE10065DFFB /* SocialScene */ = {
 			isa = PBXGroup;
 			children = (
+				2C9F61FF2B1601E800AE63F9 /* View */,
 				2C5CDA4D2B0253F5007AFC57 /* ViewController */,
 			);
 			path = SocialScene;
@@ -1196,6 +1213,7 @@
 				601773E42B021E6000D175D9 /* TimerViewController.swift in Sources */,
 				2C88DCF92B1242DA000B4686 /* TimerFlowCoordinator.swift in Sources */,
 				600908C22AFCD7DF0065DFFB /* ViewController.swift in Sources */,
+				2C9F62032B16021E00AE63F9 /* FriendSearchResultView.swift in Sources */,
 				2C3430AB2B0DDB8D008CBC85 /* TimerEndpoints.swift in Sources */,
 				ED3842212B0F1CF9001E2803 /* User.swift in Sources */,
 				2C3430A12B0DA4E6008CBC85 /* BaseComponents.swift in Sources */,
@@ -1205,6 +1223,7 @@
 				60F67C682B0E1785002C8BF3 /* CategoryUseCase.swift in Sources */,
 				2C88DCF42B124272000B4686 /* AppDIContainer.swift in Sources */,
 				2C5CDA5B2B025440007AFC57 /* ChartViewController.swift in Sources */,
+				2C9F62012B1601F200AE63F9 /* MyNickNameView.swift in Sources */,
 				6057A58D2B0C7F0F00EE58E8 /* Requestable.swift in Sources */,
 				2C3430A72B0DD0F6008CBC85 /* TimerRepsoitory.swift in Sources */,
 				6057A58F2B0C801300EE58E8 /* NetworkError.swift in Sources */,
@@ -1215,6 +1234,7 @@
 				ED3595B72B0C887C00558FAA /* TimerFinishRequestDTO.swift in Sources */,
 				2C2F217A2B0F4CF900B45BA8 /* StudyLogUseCase.swift in Sources */,
 				ED3595A92B0C7F3500558FAA /* HTTPMethod.swift in Sources */,
+				2C9F62052B160B3900AE63F9 /* NoResultView.swift in Sources */,
 				ED38421D2B0F1BE9001E2803 /* GoogleAuthEndpoints.swift in Sources */,
 				2C5CDA562B025426007AFC57 /* BaseViewController.swift in Sources */,
 				2C9F61FB2B15C96100AE63F9 /* CategoryModifyViewModel.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		2C9F62012B1601F200AE63F9 /* MyNickNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62002B1601F200AE63F9 /* MyNickNameView.swift */; };
 		2C9F62032B16021E00AE63F9 /* FriendSearchResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62022B16021E00AE63F9 /* FriendSearchResultView.swift */; };
 		2C9F62052B160B3900AE63F9 /* NoResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62042B160B3900AE63F9 /* NoResultView.swift */; };
+		2C9F62082B16398D00AE63F9 /* FreindAddResultViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62072B16398D00AE63F9 /* FreindAddResultViewProtocol.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -195,6 +196,7 @@
 		2C9F62002B1601F200AE63F9 /* MyNickNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNickNameView.swift; sourceTree = "<group>"; };
 		2C9F62022B16021E00AE63F9 /* FriendSearchResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSearchResultView.swift; sourceTree = "<group>"; };
 		2C9F62042B160B3900AE63F9 /* NoResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoResultView.swift; sourceTree = "<group>"; };
+		2C9F62072B16398D00AE63F9 /* FreindAddResultViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreindAddResultViewProtocol.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -508,6 +510,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		2C9F62062B16397400AE63F9 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				2C9F62072B16398D00AE63F9 /* FreindAddResultViewProtocol.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		48114A3517087E7FD0C9546F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -630,6 +640,7 @@
 		600908F22AFCDCE10065DFFB /* SocialScene */ = {
 			isa = PBXGroup;
 			children = (
+				2C9F62062B16397400AE63F9 /* Protocol */,
 				2C9F61FF2B1601E800AE63F9 /* View */,
 				2C5CDA4D2B0253F5007AFC57 /* ViewController */,
 			);
@@ -1275,6 +1286,7 @@
 				2C801D832B04C64F00A7ABAE /* TimerManager.swift in Sources */,
 				2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */,
 				2C88DD0B2B1340E4000B4686 /* CategoryDIContainer.swift in Sources */,
+				2C9F62082B16398D00AE63F9 /* FreindAddResultViewProtocol.swift in Sources */,
 				ED3842312B0F94E6001E2803 /* DefaultCategoryRepository.swift in Sources */,
 				ED3595C12B0DC2F100558FAA /* CategoryColorSelectView.swift in Sources */,
 				ED38421B2B0F1B7E001E2803 /* GoogleAuthRequestDTO.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		2C9F61F72B14EFA200AE63F9 /* CategoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F61F62B14EFA200AE63F9 /* CategoryManager.swift */; };
 		2C9F61F92B14F33600AE63F9 /* CategoryManagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F61F82B14F33600AE63F9 /* CategoryManagable.swift */; };
 		2C9F61FB2B15C96100AE63F9 /* CategoryModifyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F61FA2B15C96100AE63F9 /* CategoryModifyViewModel.swift */; };
+		2C9F61FE2B15F48600AE63F9 /* FriendAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F61FD2B15F48600AE63F9 /* FriendAddViewController.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -187,6 +188,7 @@
 		2C9F61F62B14EFA200AE63F9 /* CategoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryManager.swift; sourceTree = "<group>"; };
 		2C9F61F82B14F33600AE63F9 /* CategoryManagable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryManagable.swift; sourceTree = "<group>"; };
 		2C9F61FA2B15C96100AE63F9 /* CategoryModifyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModifyViewModel.swift; sourceTree = "<group>"; };
+		2C9F61FD2B15F48600AE63F9 /* FriendAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendAddViewController.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -395,6 +397,7 @@
 			isa = PBXGroup;
 			children = (
 				2C5CDA4E2B025403007AFC57 /* SocialViewController.swift */,
+				2C9F61FD2B15F48600AE63F9 /* FriendAddViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1188,6 +1191,7 @@
 				2C2F21782B0F4CCC00B45BA8 /* StudyLog.swift in Sources */,
 				ED82F00B2B128C4D005BB32D /* UIColor++Extension.swift in Sources */,
 				2C88DD132B14C51B000B4686 /* TimerFinishUseCase.swift in Sources */,
+				2C9F61FE2B15F48600AE63F9 /* FriendAddViewController.swift in Sources */,
 				2C88DCFE2B1244A6000B4686 /* LoginFlowCoordinator.swift in Sources */,
 				601773E42B021E6000D175D9 /* TimerViewController.swift in Sources */,
 				2C88DCF92B1242DA000B4686 /* TimerFlowCoordinator.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Common/Color/FlipMateColor.swift
+++ b/iOS/FlipMate/FlipMate/Common/Color/FlipMateColor.swift
@@ -13,6 +13,7 @@ enum FlipMateColor {
     case gray2
     case gray3
     case gray4
+    case gray5
     case tabBarColor
     case tabBarLayerColor
 
@@ -28,6 +29,8 @@ enum FlipMateColor {
             return UIColor(named: "Gray3")
         case .gray4:
             return UIColor(named: "Gray4")
+        case .gray5:
+            return UIColor(named: "Gray5")
         case .tabBarColor:
             return UIColor(named: "TabBarColor")
         case .tabBarLayerColor:

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/Protocol/FreindAddResultViewProtocol.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/Protocol/FreindAddResultViewProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  FreindAddResultViewProtocol.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import UIKit
+
+protocol FreindAddResultViewProtocol: UIView {
+    func height() -> CGFloat
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
@@ -16,7 +16,7 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
     
     private enum ProfileImageConstant {
         static let cornerRadius: CGFloat = 50
-        static let top: CGFloat = 20
+        static let top: CGFloat = 30
         static let width: CGFloat = 100
         static let height: CGFloat = 100
     }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
@@ -1,0 +1,108 @@
+//
+//  FriendSearchResultView.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/28.
+//
+
+import UIKit
+
+final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
+    // MARK: - Costants
+    private enum Constant {
+        static let height: CGFloat = 250
+        static let cornerRadius: CGFloat = 5
+    }
+    
+    private enum ProfileImageConstant {
+        static let cornerRadius: CGFloat = 50
+        static let top: CGFloat = 20
+        static let width: CGFloat = 100
+        static let height: CGFloat = 100
+    }
+    
+    private enum NickNameLabelConstant {
+        static let name = "임현규"
+        static let top: CGFloat = 15
+    }
+    
+    private enum FlowButtonConstant {
+        static let title = "친구추가"
+        static let top: CGFloat = 15
+        static let width: CGFloat = 90
+        static let cornerRadius: CGFloat = 10
+    }
+    
+    // MARK: - UI Components
+    private lazy var profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.backgroundColor = FlipMateColor.gray2.color
+        imageView.layer.cornerRadius = ProfileImageConstant.cornerRadius
+        return imageView
+    }()
+    
+    private lazy var nickNameLabel: UILabel = {
+        let label = UILabel()
+        label.text = NickNameLabelConstant.name
+        label.textColor = .label
+        return label
+    }()
+    
+    private lazy var flowButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(FlowButtonConstant.title, for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.backgroundColor = FlipMateColor.darkBlue.color
+        button.layer.cornerRadius = FlowButtonConstant.cornerRadius
+        return button
+    }()
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func height() -> CGFloat {
+        return Constant.height
+    }
+}
+
+// MARK: - Private Methods
+private extension FriendSearchResultView {
+    // MARK: - Configure UI
+    func configureUI() {
+        backgroundColor = FlipMateColor.gray3.color
+        layer.cornerRadius = Constant.cornerRadius
+
+        [profileImageView, nickNameLabel, flowButton].forEach {
+            addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            profileImageView.topAnchor.constraint(equalTo: topAnchor, constant: ProfileImageConstant.top),
+            profileImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            profileImageView.widthAnchor.constraint(equalToConstant: ProfileImageConstant.width),
+            profileImageView.heightAnchor.constraint(equalToConstant: ProfileImageConstant.height),
+            
+            nickNameLabel.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: NickNameLabelConstant.top),
+            nickNameLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            
+            flowButton.topAnchor.constraint(equalTo: nickNameLabel.bottomAnchor, constant: FlowButtonConstant.top),
+            flowButton.widthAnchor.constraint(equalToConstant: FlowButtonConstant.width),
+            flowButton.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
+    }
+}
+
+
+@available(iOS 17.0, *)
+#Preview {
+    FriendAddViewController()
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/MyNickNameView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/MyNickNameView.swift
@@ -1,0 +1,70 @@
+//
+//  MyNickNameView.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/28.
+//
+
+import UIKit
+
+final class MyNickNameView: UIView, FreindAddResultViewProtocol {
+    private enum Constant {
+        static let nameTitle = "내 닉네임"
+        static let nameContent = "사용자닉네임"
+        static let height: CGFloat = 30
+        static let leading: CGFloat = 10
+        static let trailing: CGFloat = -10
+        static let cornerRadius: CGFloat = 5
+    }
+    
+    // MARK: - UI Components
+    private let nickNameTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = Constant.nameTitle
+        label.textColor = .label
+        return label
+    }()
+    
+    private let nickNameContentLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .label
+        label.text = Constant.nameContent
+        return label
+    }()
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Don't use storyboard")
+    }
+    
+    func height() -> CGFloat {
+        return Constant.height
+    }
+}
+
+// MARK: - Private Method
+private extension MyNickNameView {
+    // MARK: - Configure UI
+    func configureUI() {
+        backgroundColor = FlipMateColor.gray3.color
+        layer.cornerRadius = Constant.cornerRadius
+        
+        [nickNameTitleLabel, nickNameContentLabel].forEach {
+            addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            nickNameTitleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            nickNameTitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constant.leading),
+            
+            nickNameContentLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            nickNameContentLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constant.trailing)
+        ])
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/NoResultView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/NoResultView.swift
@@ -1,0 +1,51 @@
+//
+//  NoResultView.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/28.
+//
+
+import UIKit
+
+final class NoResultView: UIView, FreindAddResultViewProtocol {
+    private enum Constant {
+        static let title = "검색 결과가 없습니다."
+        static let height: CGFloat = 100
+    }
+    
+    // MARK: - UI Components
+    private let noResultLabel: UILabel = {
+        let label = UILabel()
+        label.text = Constant.title
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Don't use storyboard")
+    }
+    
+    func height() -> CGFloat {
+        return Constant.height
+    }
+}
+
+// MARK: - Private Method
+private extension NoResultView {
+    // MARK: - Configure UI
+    func configureUI() {
+        addSubview(noResultLabel)
+        
+        NSLayoutConstraint.activate([
+            noResultLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            noResultLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class FirendAddViewController: BaseViewController {
+final class FriendAddViewController: BaseViewController {
     // MARK: - Constant
     private enum NameTextFieldConstant {
         static let top: CGFloat = 20
@@ -28,10 +28,17 @@ final class FirendAddViewController: BaseViewController {
         static let height: CGFloat = 1
     }
     
+    private enum containerViewConstant {
+        static let top: CGFloat = 15
+        static let leading: CGFloat = 40
+        static let trailing: CGFloat = -40
+    }
+
     // MARK: - UI Components
     private lazy var nickNameTextField: UITextField = {
         let textField = UITextField()
         textField.placeholder = NameTextFieldConstant.placeholder
+        textField.becomeFirstResponder()
         return textField
     }()
     
@@ -48,14 +55,20 @@ final class FirendAddViewController: BaseViewController {
         return view
     }()
     
+    private let containerView = UIView()
+    private let myNickNameView = MyNickNameView()
+    private let noResultView = NoResultView()
+    private let friendSearchResultView = FriendSearchResultView()
+    
     // MARK: - Life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        updateResultView(myNickNameView)
     }
     
     // MARK: - Configure UI
     override func configureUI() {
-        [nickNameTextField, nickNameCountLabel, separatorLineView].forEach {
+        [nickNameTextField, nickNameCountLabel, separatorLineView, containerView].forEach {
             view.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
@@ -72,13 +85,33 @@ final class FirendAddViewController: BaseViewController {
             separatorLineView.topAnchor.constraint(equalTo: nickNameTextField.bottomAnchor, constant: SeparatorLineConstant.top),
             separatorLineView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: SeparatorLineConstant.leading),
             separatorLineView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: SeparatorLineConstant.trailing),
-            separatorLineView.heightAnchor.constraint(equalToConstant: SeparatorLineConstant.height)
+            separatorLineView.heightAnchor.constraint(equalToConstant: SeparatorLineConstant.height),
+            
+            containerView.topAnchor.constraint(equalTo: separatorLineView.bottomAnchor, constant: containerViewConstant.top),
+            containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: containerViewConstant.leading),
+            containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: containerViewConstant.trailing),
+            containerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
+    }
+}
+
+// MARK: - Private Methods
+private extension FriendAddViewController {
+    func updateResultView(_ resultView: FreindAddResultViewProtocol) {
+        containerView.subviews.forEach { $0.removeFromSuperview() }
+        containerView.addSubview(resultView)
+        resultView.translatesAutoresizingMaskIntoConstraints = false
         
+        NSLayoutConstraint.activate([
+            resultView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            resultView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            resultView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            resultView.heightAnchor.constraint(equalToConstant: resultView.height())
+        ])
     }
 }
 
 @available(iOS 17.0, *)
 #Preview {
-    FirendAddViewController()
+    FriendAddViewController()
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
@@ -1,0 +1,84 @@
+//
+//  FriendAddViewController.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/28.
+//
+
+import UIKit
+
+final class FirendAddViewController: BaseViewController {
+    // MARK: - Constant
+    private enum NameTextFieldConstant {
+        static let top: CGFloat = 20
+        static let leading: CGFloat = 40
+        static let height: CGFloat = 20
+        static let placeholder = "친구 닉네임"
+    }
+    
+    private enum NameCountLabelConstant {
+        static let trailing: CGFloat = -40
+        static let countTitle = "0/10"
+    }
+    
+    private enum SeparatorLineConstant {
+        static let top: CGFloat = 5
+        static let leading: CGFloat = 40
+        static let trailing: CGFloat = -40
+        static let height: CGFloat = 1
+    }
+    
+    // MARK: - UI Components
+    private lazy var nickNameTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = NameTextFieldConstant.placeholder
+        return textField
+    }()
+    
+    private lazy var nickNameCountLabel: UILabel = {
+        let label = UILabel()
+        label.text = NameCountLabelConstant.countTitle
+        label.textColor = FlipMateColor.gray5.color
+        return label
+    }()
+    
+    private let separatorLineView: UIView = {
+        let view = UIView()
+        view.backgroundColor = FlipMateColor.gray5.color
+        return view
+    }()
+    
+    // MARK: - Life cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    // MARK: - Configure UI
+    override func configureUI() {
+        [nickNameTextField, nickNameCountLabel, separatorLineView].forEach {
+            view.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            nickNameTextField.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: NameTextFieldConstant.top),
+            nickNameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: NameTextFieldConstant.leading),
+            nickNameTextField.trailingAnchor.constraint(equalTo: nickNameCountLabel.leadingAnchor),
+            nickNameTextField.heightAnchor.constraint(equalToConstant: NameTextFieldConstant.height),
+            
+            nickNameCountLabel.centerYAnchor.constraint(equalTo: nickNameTextField.centerYAnchor),
+            nickNameCountLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: NameCountLabelConstant.trailing),
+            
+            separatorLineView.topAnchor.constraint(equalTo: nickNameTextField.bottomAnchor, constant: SeparatorLineConstant.top),
+            separatorLineView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: SeparatorLineConstant.leading),
+            separatorLineView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: SeparatorLineConstant.trailing),
+            separatorLineView.heightAnchor.constraint(equalToConstant: SeparatorLineConstant.height)
+        ])
+        
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    FirendAddViewController()
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
@@ -28,7 +28,7 @@ final class FriendAddViewController: BaseViewController {
         static let height: CGFloat = 1
     }
     
-    private enum containerViewConstant {
+    private enum ContainerViewConstant {
         static let top: CGFloat = 15
         static let leading: CGFloat = 40
         static let trailing: CGFloat = -40
@@ -87,9 +87,9 @@ final class FriendAddViewController: BaseViewController {
             separatorLineView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: SeparatorLineConstant.trailing),
             separatorLineView.heightAnchor.constraint(equalToConstant: SeparatorLineConstant.height),
             
-            containerView.topAnchor.constraint(equalTo: separatorLineView.bottomAnchor, constant: containerViewConstant.top),
-            containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: containerViewConstant.leading),
-            containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: containerViewConstant.trailing),
+            containerView.topAnchor.constraint(equalTo: separatorLineView.bottomAnchor, constant: ContainerViewConstant.top),
+            containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: ContainerViewConstant.leading),
+            containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: ContainerViewConstant.trailing),
             containerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
     }

--- a/iOS/FlipMate/FlipMate/Resources/Assets.xcassets/FilpMateColor/Gray3.colorset/Contents.json
+++ b/iOS/FlipMate/FlipMate/Resources/Assets.xcassets/FilpMateColor/Gray3.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.346",
+          "green" : "0.350",
+          "red" : "0.345"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/iOS/FlipMate/FlipMate/Resources/Assets.xcassets/FilpMateColor/Gray5.colorset/Contents.json
+++ b/iOS/FlipMate/FlipMate/Resources/Assets.xcassets/FilpMateColor/Gray5.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.778",
+          "green" : "0.774",
+          "red" : "0.771"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
closed #238 
## 완료된 기능
- 친구 검색 TextField UI 구현
- 내 닉네임 화면 UI 구현
- 검색 결과 없을 떄 UI 구현
- 검색 결과 있을 떄 UI 구현

## 실행 결과
| 검색을 안한 상태 | 검색 결과가 없을 때 | 검색 결과가 있을 때 |
| -------- | -------- | -------- |
| ![simulator_screenshot_41F78F64-C1D3-4819-B409-74903C2EFCC7](https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/29afc05b-7389-43af-a66a-5c8f4621b076) | ![simulator_screenshot_98E1D8DD-7D6B-4228-BF2B-EBF52B817806](https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/83e176b4-bf7b-4e7a-a6c2-fcdd5f159a05) | ![simulator_screenshot_29FB52D5-60B0-4C82-B8A3-01143B11ADDA](https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/9f7a3de1-e9c9-466d-a641-1bad95624490)|

## 고민과 해결과정
### 검색결과와 TextField 상황에 따른 UI 업데이트
기획한 의도대로 UI가 보여지기 위해서는 친구 검색 TextField 아래에 각각의 상황에 맞는 View를 표시해야했습니다.
그래서 각 화면들을 프로토콜로 추상화를 하였고 메소드를 통해 해당 추상화된 뷰를 전달받아 뷰를 표시해주는 방식으로 구현했습니다.
ContainerView를 통해 먼저 기본적인 레이아웃을 잡고 해당 메소드가 호출이 되면 ContainerView의 서브 뷰를 삭제해주고
새로운 서브뷰를 등록하고 각각의 View의 원하는 높이에 맞게 오토레이아웃을 설정해주었습니다~!
혹시 프로토콜 추상화말고 더 좋은 방법이 있으면 알려주시면 감사하겠습니다.
