### PR TITLE
[BE#259] Exception 로그, 프로필 변경시 닉네임 중복 예외

### DIFF
--- a/BE/src/common/exception-filter/http-exception-filter.ts
+++ b/BE/src/common/exception-filter/http-exception-filter.ts
@@ -1,0 +1,36 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  Logger,
+} from '@nestjs/common';
+import { LoggingInterceptor } from '../logging.interceptor';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(LoggingInterceptor.name);
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const request = ctx.getRequest();
+    const status = exception.getStatus();
+
+    const requestToResponse: `${number}ms` = request.now
+      ? `${Date.now() - request.now}ms`
+      : `0ms`;
+
+    const errorResponse = {
+      statusCode: status,
+      message: exception?.message,
+      error: exception?.getResponse()['error'],
+      path: request.url,
+      timestamp: new Date().toLocaleString('kr'),
+    };
+    this.logger.warn(
+      `[Exception] ${status} ${exception?.message} ${requestToResponse}`,
+    );
+
+    response.status(status).json(errorResponse);
+  }
+}

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -7,6 +7,7 @@ import { readFileSync } from 'fs';
 import { WinstonModule } from 'nest-winston';
 import { loggerConfig } from './common/logging.config';
 import { LoggingInterceptor } from './common/logging.interceptor';
+import { HttpExceptionFilter } from './common/exception-filter/http-exception-filter';
 
 async function bootstrap() {
   const configService = new ConfigService();
@@ -36,6 +37,7 @@ async function bootstrap() {
 
   app.useGlobalPipes(new ValidationPipe());
   app.useGlobalInterceptors(new LoggingInterceptor());
+  app.useGlobalFilters(new HttpExceptionFilter());
 
   await app.listen(configService.get<number>('PORT') || 3000);
 }

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -64,9 +64,15 @@ export class UsersService {
     if (image_url) {
       selectedUser.image_url = image_url;
     }
-
-    const updatedUser = await this.usersRepository.save(selectedUser);
-    return updatedUser;
+    try {
+      const updatedUser = await this.usersRepository.save(selectedUser);
+      return updatedUser;
+    } catch (error) {
+      if (error.code === 'ER_DUP_ENTRY' || error.errno === 1062) {
+        throw new BadRequestException('닉네임이 이미 사용 중입니다.');
+      }
+      throw error;
+    }
   }
 
   async isUniqueNickname(nickname: string): Promise<object> {


### PR DESCRIPTION
close #259 

## 완료한 기능
- Exception 로깅
- 프로필 변경시 닉네임 중복 예외

## 고민

### Exception 로깅이 안된 이유
<img width="831" alt="스크린샷 2023-11-29 오후 2 34 15" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/0b166613-790a-4247-b170-b0725f620be7">
patch요청에 대해서 응답이 찍히지 않았다. 그 이유는 뭘까

<img width="483" alt="스크린샷 2023-11-25 오후 5 07 52" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/d984509c-2578-4808-a271-012a7d0fd1ed">

Interceptor에서 요청과 응답에대해 찍어주고 있는데 예외가 나면 response를 캐치하지 못한다. 그래서 ExceptionFilter를 통해 예외시 로그를 따로 만들어주었다.

```ts

@Catch(HttpException)
export class HttpExceptionFilter implements ExceptionFilter {
  private readonly logger = new Logger(LoggingInterceptor.name);
  catch(exception: HttpException, host: ArgumentsHost) {
    const ctx = host.switchToHttp();
    const response = ctx.getResponse();
    const request = ctx.getRequest();
    const status = exception.getStatus();

    const requestToResponse: `${number}ms` = request.now
      ? `${Date.now() - request.now}ms`
      : `0ms`;

    const errorResponse = {
      statusCode: status,
      message: exception?.message,
      error: exception?.getResponse()['error'],
      path: request.url,
      timestamp: new Date().toLocaleString('kr'),
    };
    this.logger.warn(
      `[Exception] ${status} ${exception?.message} ${requestToResponse}`,
    ); // 이 부분에서 로그를 찍어준다.

    response.status(status).json(errorResponse); //이 부분에서 응답을 변경해준다.
  }
}
```

<img width="690" alt="스크린샷 2023-11-29 오후 2 37 15" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/be6f0b8e-c914-473a-8b67-18d51781fe6b">


우리의 로그에는 warn레벨로 위와같이 찍히고

<img width="480" alt="스크린샷 2023-11-29 오후 2 36 42" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/a3c8ac1e-71ae-491b-9ff7-69a02abf67fb">

클라이언트 응답은 위와 같이 오게된다.


### 프로필 변경시 닉네임 중복 예외

유저가 생성될 때에는 중복 예외처리를 했는데, 프로필 변경시에 닉네임 중복 예외를 처리하지 않았다. 아무리 중복검사가 있어서 클라이언트 측에서 잘 처리해준다더라도, 서버측에서는 이 예외를 처리하는 게 맞다고 판단해서 아래와 같이 예외처리를 추가함

```ts
async updateUser(
    user_id: number,
    user: UpdateUserDto,
    image_url?: string,
  ): Promise<UsersModel> {
    const selectedUser = await this.usersRepository.findOne({
      where: { id: user_id },
    });
    if (user.nickname) {
      selectedUser.nickname = user.nickname;
    }
    if (image_url) {
      selectedUser.image_url = image_url;
    }
    // 여기부터 변경된 try catch 부분
    try {
      const updatedUser = await this.usersRepository.save(selectedUser);
      return updatedUser;
    } catch (error) {
      if (error.code === 'ER_DUP_ENTRY' || error.errno === 1062) {
        throw new BadRequestException('닉네임이 이미 사용 중입니다.');
      }
      throw error;
    }
  }
```