### PR TITLE
[iOS] 친구 추가 비즈니스 로직 구현 및 테스트코드 작성

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -84,6 +84,22 @@
 		2C9F623D2B1756E400AE63F9 /* Friend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F620C2B17241200AE63F9 /* Friend.swift */; };
 		2C9F623E2B1756EB00AE63F9 /* FlipMateLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DE493C2B05DEA400ACE6DD /* FlipMateLogger.swift */; };
 		2C9F623F2B1756FE00AE63F9 /* FlipMateConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DE493F2B05E67200ACE6DD /* FlipMateConstant.swift */; };
+		2C9F62422B176A0400AE63F9 /* FriendUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62402B1769FD00AE63F9 /* FriendUseCaseTests.swift */; };
+		2C9F62432B176A9000AE63F9 /* DefaultFriendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62102B17363400AE63F9 /* DefaultFriendUseCase.swift */; };
+		2C9F62442B176AA500AE63F9 /* DefaultFriendRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62142B1736BE00AE63F9 /* DefaultFriendRepository.swift */; };
+		2C9F62472B176AEC00AE63F9 /* MockFriendRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62462B176AEC00AE63F9 /* MockFriendRepository.swift */; };
+		2C9F62482B176AEE00AE63F9 /* MockFriendRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62462B176AEC00AE63F9 /* MockFriendRepository.swift */; };
+		2C9F62492B176F6300AE63F9 /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3430982B0C8427008CBC85 /* Provider.swift */; };
+		2C9F624A2B176FD900AE63F9 /* URLSessionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C34309A2B0C8674008CBC85 /* URLSessionable.swift */; };
+		2C9F624B2B176FDC00AE63F9 /* Responsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595AA2B0C81B800558FAA /* Responsable.swift */; };
+		2C9F624C2B176FE800AE63F9 /* FriendFollowReqeustDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62212B173AB500AE63F9 /* FriendFollowReqeustDTO.swift */; };
+		2C9F624D2B176FEA00AE63F9 /* FriendEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62252B1742D200AE63F9 /* FriendEndpoints.swift */; };
+		2C9F624E2B176FEF00AE63F9 /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3430962B0C7ED8008CBC85 /* EndPoint.swift */; };
+		2C9F624F2B176FF200AE63F9 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6057A58C2B0C7F0F00EE58E8 /* Requestable.swift */; };
+		2C9F62502B176FFC00AE63F9 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3430A22B0DA5A5008CBC85 /* HTTPHeader.swift */; };
+		2C9F62512B176FFE00AE63F9 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595A82B0C7F3500558FAA /* HTTPMethod.swift */; };
+		2C9F62532B17700500AE63F9 /* BaseComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3430A02B0DA4E6008CBC85 /* BaseComponents.swift */; };
+		2C9F62542B17701300AE63F9 /* KeyChainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38422E2B0F747B001E2803 /* KeyChainManager.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -228,6 +244,8 @@
 		2C9F62252B1742D200AE63F9 /* FriendEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendEndpoints.swift; sourceTree = "<group>"; };
 		2C9F622E2B17505B00AE63F9 /* FriendAddViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendAddViewModelTests.swift; sourceTree = "<group>"; };
 		2C9F62362B17517100AE63F9 /* MockFriendUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFriendUseCase.swift; sourceTree = "<group>"; };
+		2C9F62402B1769FD00AE63F9 /* FriendUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendUseCaseTests.swift; sourceTree = "<group>"; };
+		2C9F62462B176AEC00AE63F9 /* MockFriendRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFriendRepository.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -568,6 +586,7 @@
 		2C9F62272B174FC200AE63F9 /* FlipMateUseCaseTests */ = {
 			isa = PBXGroup;
 			children = (
+				2C9F62452B176AD100AE63F9 /* Mock */,
 				2C9F62292B17500B00AE63F9 /* SocialScene */,
 			);
 			path = FlipMateUseCaseTests;
@@ -585,6 +604,7 @@
 		2C9F62292B17500B00AE63F9 /* SocialScene */ = {
 			isa = PBXGroup;
 			children = (
+				2C9F62402B1769FD00AE63F9 /* FriendUseCaseTests.swift */,
 			);
 			path = SocialScene;
 			sourceTree = "<group>";
@@ -601,6 +621,14 @@
 			isa = PBXGroup;
 			children = (
 				2C9F62362B17517100AE63F9 /* MockFriendUseCase.swift */,
+			);
+			path = Mock;
+			sourceTree = "<group>";
+		};
+		2C9F62452B176AD100AE63F9 /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+				2C9F62462B176AEC00AE63F9 /* MockFriendRepository.swift */,
 			);
 			path = Mock;
 			sourceTree = "<group>";
@@ -1315,6 +1343,7 @@
 				2C9F620F2B1735C700AE63F9 /* FriendUseCase.swift in Sources */,
 				2C801D802B04B68900A7ABAE /* TimerUseCase.swift in Sources */,
 				6086464E2B0DDA1300B0C1BC /* CategoryRepository.swift in Sources */,
+				2C9F62472B176AEC00AE63F9 /* MockFriendRepository.swift in Sources */,
 				2C9F620B2B171C8300AE63F9 /* FriendAddViewModel.swift in Sources */,
 				2C2F21782B0F4CCC00B45BA8 /* StudyLog.swift in Sources */,
 				ED82F00B2B128C4D005BB32D /* UIColor++Extension.swift in Sources */,
@@ -1404,17 +1433,32 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C9F62442B176AA500AE63F9 /* DefaultFriendRepository.swift in Sources */,
 				2C9F62312B1750A300AE63F9 /* FriendAddViewModel.swift in Sources */,
+				2C9F62492B176F6300AE63F9 /* Provider.swift in Sources */,
+				2C9F624B2B176FDC00AE63F9 /* Responsable.swift in Sources */,
+				2C9F62542B17701300AE63F9 /* KeyChainManager.swift in Sources */,
+				2C9F624E2B176FEF00AE63F9 /* EndPoint.swift in Sources */,
+				2C9F62422B176A0400AE63F9 /* FriendUseCaseTests.swift in Sources */,
 				2C9F62392B1756BC00AE63F9 /* NetworkError.swift in Sources */,
 				2C9F62382B17517B00AE63F9 /* MockFriendUseCase.swift in Sources */,
+				2C9F62512B176FFE00AE63F9 /* HTTPMethod.swift in Sources */,
+				2C9F624D2B176FEA00AE63F9 /* FriendEndpoints.swift in Sources */,
 				2C9F623C2B1756D800AE63F9 /* UserProfileResposeDTO.swift in Sources */,
 				600908D52AFCD7E00065DFFB /* NetworkServiceTests.swift in Sources */,
+				2C9F62482B176AEE00AE63F9 /* MockFriendRepository.swift in Sources */,
+				2C9F62502B176FFC00AE63F9 /* HTTPHeader.swift in Sources */,
 				2C9F623B2B1756D500AE63F9 /* StatusResponseDTO.swift in Sources */,
 				2C9F623E2B1756EB00AE63F9 /* FlipMateLogger.swift in Sources */,
 				2C9F62302B17508500AE63F9 /* FriendAddViewModelTests.swift in Sources */,
+				2C9F62432B176A9000AE63F9 /* DefaultFriendUseCase.swift in Sources */,
+				2C9F624F2B176FF200AE63F9 /* Requestable.swift in Sources */,
 				2C9F623D2B1756E400AE63F9 /* Friend.swift in Sources */,
+				2C9F62532B17700500AE63F9 /* BaseComponents.swift in Sources */,
 				2C9F623F2B1756FE00AE63F9 /* FlipMateConstant.swift in Sources */,
 				2C9F62352B17515800AE63F9 /* FriendRepository.swift in Sources */,
+				2C9F624A2B176FD900AE63F9 /* URLSessionable.swift in Sources */,
+				2C9F624C2B176FE800AE63F9 /* FriendFollowReqeustDTO.swift in Sources */,
 				2C9F62342B17514D00AE63F9 /* FriendUseCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -72,6 +72,18 @@
 		2C9F62222B173AB500AE63F9 /* FriendFollowReqeustDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62212B173AB500AE63F9 /* FriendFollowReqeustDTO.swift */; };
 		2C9F62242B173ADA00AE63F9 /* UserProfileResposeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62232B173ADA00AE63F9 /* UserProfileResposeDTO.swift */; };
 		2C9F62262B1742D200AE63F9 /* FriendEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62252B1742D200AE63F9 /* FriendEndpoints.swift */; };
+		2C9F62302B17508500AE63F9 /* FriendAddViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F622E2B17505B00AE63F9 /* FriendAddViewModelTests.swift */; };
+		2C9F62312B1750A300AE63F9 /* FriendAddViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F620A2B171C8300AE63F9 /* FriendAddViewModel.swift */; };
+		2C9F62342B17514D00AE63F9 /* FriendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F620E2B1735C700AE63F9 /* FriendUseCase.swift */; };
+		2C9F62352B17515800AE63F9 /* FriendRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62122B17366200AE63F9 /* FriendRepository.swift */; };
+		2C9F62372B17517100AE63F9 /* MockFriendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62362B17517100AE63F9 /* MockFriendUseCase.swift */; };
+		2C9F62382B17517B00AE63F9 /* MockFriendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62362B17517100AE63F9 /* MockFriendUseCase.swift */; };
+		2C9F62392B1756BC00AE63F9 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6057A58E2B0C801300EE58E8 /* NetworkError.swift */; };
+		2C9F623B2B1756D500AE63F9 /* StatusResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6001959F2B0DFA3900F02BA4 /* StatusResponseDTO.swift */; };
+		2C9F623C2B1756D800AE63F9 /* UserProfileResposeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62232B173ADA00AE63F9 /* UserProfileResposeDTO.swift */; };
+		2C9F623D2B1756E400AE63F9 /* Friend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F620C2B17241200AE63F9 /* Friend.swift */; };
+		2C9F623E2B1756EB00AE63F9 /* FlipMateLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DE493C2B05DEA400ACE6DD /* FlipMateLogger.swift */; };
+		2C9F623F2B1756FE00AE63F9 /* FlipMateConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DE493F2B05E67200ACE6DD /* FlipMateConstant.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -100,7 +112,6 @@
 		60DE49402B05E67200ACE6DD /* FlipMateConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DE493F2B05E67200ACE6DD /* FlipMateConstant.swift */; };
 		60F67C682B0E1785002C8BF3 /* CategoryUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F67C672B0E1785002C8BF3 /* CategoryUseCase.swift */; };
 		60F67C6A2B0E1868002C8BF3 /* DefaultCategoryUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F67C692B0E1868002C8BF3 /* DefaultCategoryUseCase.swift */; };
-		60F67C6C2B0E1E02002C8BF3 /* CategoryRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F67C6B2B0E1E02002C8BF3 /* CategoryRepositoryTests.swift */; };
 		60F6FD732B0B5E130057CE0B /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F6FD722B0B5E130057CE0B /* SignUpViewController.swift */; };
 		A18D97900627849B3EFACF76 /* Pods_FlipMate_FlipMateUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */; };
 		ED3595A92B0C7F3500558FAA /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595A82B0C7F3500558FAA /* HTTPMethod.swift */; };
@@ -215,6 +226,8 @@
 		2C9F62212B173AB500AE63F9 /* FriendFollowReqeustDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendFollowReqeustDTO.swift; sourceTree = "<group>"; };
 		2C9F62232B173ADA00AE63F9 /* UserProfileResposeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileResposeDTO.swift; sourceTree = "<group>"; };
 		2C9F62252B1742D200AE63F9 /* FriendEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendEndpoints.swift; sourceTree = "<group>"; };
+		2C9F622E2B17505B00AE63F9 /* FriendAddViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendAddViewModelTests.swift; sourceTree = "<group>"; };
+		2C9F62362B17517100AE63F9 /* MockFriendUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFriendUseCase.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -249,7 +262,6 @@
 		60DE493F2B05E67200ACE6DD /* FlipMateConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlipMateConstant.swift; sourceTree = "<group>"; };
 		60F67C672B0E1785002C8BF3 /* CategoryUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryUseCase.swift; sourceTree = "<group>"; };
 		60F67C692B0E1868002C8BF3 /* DefaultCategoryUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCategoryUseCase.swift; sourceTree = "<group>"; };
-		60F67C6B2B0E1E02002C8BF3 /* CategoryRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepositoryTests.swift; sourceTree = "<group>"; };
 		60F6FD722B0B5E130057CE0B /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		71ED06C5254CFE8E3AB612B4 /* Pods-FlipMate.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMate.debug.xcconfig"; path = "Target Support Files/Pods-FlipMate/Pods-FlipMate.debug.xcconfig"; sourceTree = "<group>"; };
 		BC232C114FB45EEC8C2E974D /* Pods-FlipMate.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMate.release.xcconfig"; path = "Target Support Files/Pods-FlipMate/Pods-FlipMate.release.xcconfig"; sourceTree = "<group>"; };
@@ -553,6 +565,46 @@
 			path = SocialScene;
 			sourceTree = "<group>";
 		};
+		2C9F62272B174FC200AE63F9 /* FlipMateUseCaseTests */ = {
+			isa = PBXGroup;
+			children = (
+				2C9F62292B17500B00AE63F9 /* SocialScene */,
+			);
+			path = FlipMateUseCaseTests;
+			sourceTree = "<group>";
+		};
+		2C9F62282B174FDB00AE63F9 /* FlipMateViewModelTests */ = {
+			isa = PBXGroup;
+			children = (
+				2C9F62332B17513800AE63F9 /* Mock */,
+				2C9F62322B17512E00AE63F9 /* SocialScene */,
+			);
+			path = FlipMateViewModelTests;
+			sourceTree = "<group>";
+		};
+		2C9F62292B17500B00AE63F9 /* SocialScene */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SocialScene;
+			sourceTree = "<group>";
+		};
+		2C9F62322B17512E00AE63F9 /* SocialScene */ = {
+			isa = PBXGroup;
+			children = (
+				2C9F622E2B17505B00AE63F9 /* FriendAddViewModelTests.swift */,
+			);
+			path = SocialScene;
+			sourceTree = "<group>";
+		};
+		2C9F62332B17513800AE63F9 /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+				2C9F62362B17517100AE63F9 /* MockFriendUseCase.swift */,
+			);
+			path = Mock;
+			sourceTree = "<group>";
+		};
 		48114A3517087E7FD0C9546F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -572,6 +624,8 @@
 				60243EEF2B05D24D0098A92F /* .swiftlint.yml */,
 				600908BC2AFCD7DF0065DFFB /* FlipMate */,
 				600908D32AFCD7E00065DFFB /* FlipMateTests */,
+				2C9F62282B174FDB00AE63F9 /* FlipMateViewModelTests */,
+				2C9F62272B174FC200AE63F9 /* FlipMateUseCaseTests */,
 				600908DD2AFCD7E00065DFFB /* FlipMateUITests */,
 				600908BB2AFCD7DF0065DFFB /* Products */,
 				48114A3517087E7FD0C9546F /* Pods */,
@@ -609,7 +663,6 @@
 			isa = PBXGroup;
 			children = (
 				600908D42AFCD7E00065DFFB /* NetworkServiceTests.swift */,
-				60F67C6B2B0E1E02002C8BF3 /* CategoryRepositoryTests.swift */,
 			);
 			path = FlipMateTests;
 			sourceTree = "<group>";
@@ -1289,6 +1342,7 @@
 				ED38422F2B0F747B001E2803 /* KeyChainManager.swift in Sources */,
 				ED3842292B0F3B19001E2803 /* DefaultGoogleAuthRepository.swift in Sources */,
 				600908BE2AFCD7DF0065DFFB /* AppDelegate.swift in Sources */,
+				2C9F62372B17517100AE63F9 /* MockFriendUseCase.swift in Sources */,
 				2CE84EFB2B0B92BA00E2FB71 /* UICollectionReusableView++Extension.swift in Sources */,
 				ED3595B72B0C887C00558FAA /* TimerFinishRequestDTO.swift in Sources */,
 				2C2F217A2B0F4CF900B45BA8 /* StudyLogUseCase.swift in Sources */,
@@ -1350,8 +1404,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C9F62312B1750A300AE63F9 /* FriendAddViewModel.swift in Sources */,
+				2C9F62392B1756BC00AE63F9 /* NetworkError.swift in Sources */,
+				2C9F62382B17517B00AE63F9 /* MockFriendUseCase.swift in Sources */,
+				2C9F623C2B1756D800AE63F9 /* UserProfileResposeDTO.swift in Sources */,
 				600908D52AFCD7E00065DFFB /* NetworkServiceTests.swift in Sources */,
-				60F67C6C2B0E1E02002C8BF3 /* CategoryRepositoryTests.swift in Sources */,
+				2C9F623B2B1756D500AE63F9 /* StatusResponseDTO.swift in Sources */,
+				2C9F623E2B1756EB00AE63F9 /* FlipMateLogger.swift in Sources */,
+				2C9F62302B17508500AE63F9 /* FriendAddViewModelTests.swift in Sources */,
+				2C9F623D2B1756E400AE63F9 /* Friend.swift in Sources */,
+				2C9F623F2B1756FE00AE63F9 /* FlipMateConstant.swift in Sources */,
+				2C9F62352B17515800AE63F9 /* FriendRepository.swift in Sources */,
+				2C9F62342B17514D00AE63F9 /* FriendUseCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		2C9F62032B16021E00AE63F9 /* FriendSearchResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62022B16021E00AE63F9 /* FriendSearchResultView.swift */; };
 		2C9F62052B160B3900AE63F9 /* NoResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62042B160B3900AE63F9 /* NoResultView.swift */; };
 		2C9F62082B16398D00AE63F9 /* FreindAddResultViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62072B16398D00AE63F9 /* FreindAddResultViewProtocol.swift */; };
+		2C9F620B2B171C8300AE63F9 /* FriendAddViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F620A2B171C8300AE63F9 /* FriendAddViewModel.swift */; };
+		2C9F620D2B17241200AE63F9 /* Friend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F620C2B17241200AE63F9 /* Friend.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -197,6 +199,8 @@
 		2C9F62022B16021E00AE63F9 /* FriendSearchResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSearchResultView.swift; sourceTree = "<group>"; };
 		2C9F62042B160B3900AE63F9 /* NoResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoResultView.swift; sourceTree = "<group>"; };
 		2C9F62072B16398D00AE63F9 /* FreindAddResultViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreindAddResultViewProtocol.swift; sourceTree = "<group>"; };
+		2C9F620A2B171C8300AE63F9 /* FriendAddViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendAddViewModel.swift; sourceTree = "<group>"; };
+		2C9F620C2B17241200AE63F9 /* Friend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Friend.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -518,6 +522,14 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		2C9F62092B171C4D00AE63F9 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				2C9F620A2B171C8300AE63F9 /* FriendAddViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		48114A3517087E7FD0C9546F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -642,6 +654,7 @@
 			children = (
 				2C9F62062B16397400AE63F9 /* Protocol */,
 				2C9F61FF2B1601E800AE63F9 /* View */,
+				2C9F62092B171C4D00AE63F9 /* ViewModel */,
 				2C5CDA4D2B0253F5007AFC57 /* ViewController */,
 			);
 			path = SocialScene;
@@ -817,6 +830,7 @@
 				ED9B2A7E2B06033F008FE1C5 /* Category.swift */,
 				2C2F21772B0F4CCC00B45BA8 /* StudyLog.swift */,
 				ED3842202B0F1CF9001E2803 /* User.swift */,
+				2C9F620C2B17241200AE63F9 /* Friend.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -1202,6 +1216,7 @@
 				60F67C6A2B0E1868002C8BF3 /* DefaultCategoryUseCase.swift in Sources */,
 				2C5CDA4B2B0252C1007AFC57 /* LoginType.swift in Sources */,
 				600195A02B0DFA3900F02BA4 /* StatusResponseDTO.swift in Sources */,
+				2C9F620D2B17241200AE63F9 /* Friend.swift in Sources */,
 				60F6FD732B0B5E130057CE0B /* SignUpViewController.swift in Sources */,
 				2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */,
 				ED3595B02B0C82C800558FAA /* TimerStartRequestDTO.swift in Sources */,
@@ -1216,6 +1231,7 @@
 				2C2F21802B0F4DA600B45BA8 /* MockURLSession.swift in Sources */,
 				2C801D802B04B68900A7ABAE /* TimerUseCase.swift in Sources */,
 				6086464E2B0DDA1300B0C1BC /* CategoryRepository.swift in Sources */,
+				2C9F620B2B171C8300AE63F9 /* FriendAddViewModel.swift in Sources */,
 				2C2F21782B0F4CCC00B45BA8 /* StudyLog.swift in Sources */,
 				ED82F00B2B128C4D005BB32D /* UIColor++Extension.swift in Sources */,
 				2C88DD132B14C51B000B4686 /* TimerFinishUseCase.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -65,6 +65,13 @@
 		2C9F62082B16398D00AE63F9 /* FreindAddResultViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62072B16398D00AE63F9 /* FreindAddResultViewProtocol.swift */; };
 		2C9F620B2B171C8300AE63F9 /* FriendAddViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F620A2B171C8300AE63F9 /* FriendAddViewModel.swift */; };
 		2C9F620D2B17241200AE63F9 /* Friend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F620C2B17241200AE63F9 /* Friend.swift */; };
+		2C9F620F2B1735C700AE63F9 /* FriendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F620E2B1735C700AE63F9 /* FriendUseCase.swift */; };
+		2C9F62112B17363400AE63F9 /* DefaultFriendUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62102B17363400AE63F9 /* DefaultFriendUseCase.swift */; };
+		2C9F62132B17366200AE63F9 /* FriendRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62122B17366200AE63F9 /* FriendRepository.swift */; };
+		2C9F62152B1736BE00AE63F9 /* DefaultFriendRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62142B1736BE00AE63F9 /* DefaultFriendRepository.swift */; };
+		2C9F62222B173AB500AE63F9 /* FriendFollowReqeustDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62212B173AB500AE63F9 /* FriendFollowReqeustDTO.swift */; };
+		2C9F62242B173ADA00AE63F9 /* UserProfileResposeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62232B173ADA00AE63F9 /* UserProfileResposeDTO.swift */; };
+		2C9F62262B1742D200AE63F9 /* FriendEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F62252B1742D200AE63F9 /* FriendEndpoints.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -201,6 +208,13 @@
 		2C9F62072B16398D00AE63F9 /* FreindAddResultViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreindAddResultViewProtocol.swift; sourceTree = "<group>"; };
 		2C9F620A2B171C8300AE63F9 /* FriendAddViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendAddViewModel.swift; sourceTree = "<group>"; };
 		2C9F620C2B17241200AE63F9 /* Friend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Friend.swift; sourceTree = "<group>"; };
+		2C9F620E2B1735C700AE63F9 /* FriendUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendUseCase.swift; sourceTree = "<group>"; };
+		2C9F62102B17363400AE63F9 /* DefaultFriendUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFriendUseCase.swift; sourceTree = "<group>"; };
+		2C9F62122B17366200AE63F9 /* FriendRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendRepository.swift; sourceTree = "<group>"; };
+		2C9F62142B1736BE00AE63F9 /* DefaultFriendRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFriendRepository.swift; sourceTree = "<group>"; };
+		2C9F62212B173AB500AE63F9 /* FriendFollowReqeustDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendFollowReqeustDTO.swift; sourceTree = "<group>"; };
+		2C9F62232B173ADA00AE63F9 /* UserProfileResposeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileResposeDTO.swift; sourceTree = "<group>"; };
+		2C9F62252B1742D200AE63F9 /* FriendEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendEndpoints.swift; sourceTree = "<group>"; };
 		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
@@ -530,6 +544,15 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		2C9F62162B1736F200AE63F9 /* SocialScene */ = {
+			isa = PBXGroup;
+			children = (
+				2C9F62212B173AB500AE63F9 /* FriendFollowReqeustDTO.swift */,
+				2C9F62232B173ADA00AE63F9 /* UserProfileResposeDTO.swift */,
+			);
+			path = SocialScene;
+			sourceTree = "<group>";
+		};
 		48114A3517087E7FD0C9546F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -722,6 +745,7 @@
 				2C3430AC2B0DDF25008CBC85 /* DefaultTimerRepository.swift */,
 				2C2F217D2B0F4D7F00B45BA8 /* DefaultStudyLogRepository.swift */,
 				ED3842302B0F94E6001E2803 /* DefaultCategoryRepository.swift */,
+				2C9F62142B1736BE00AE63F9 /* DefaultFriendRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -744,6 +768,7 @@
 				2C3430AA2B0DDB8D008CBC85 /* TimerEndpoints.swift */,
 				2C2F21752B0F440D00B45BA8 /* StudyLogEndpoints.swift */,
 				2C2F217F2B0F4DA600B45BA8 /* MockURLSession.swift */,
+				2C9F62252B1742D200AE63F9 /* FriendEndpoints.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -754,6 +779,7 @@
 				6001959F2B0DFA3900F02BA4 /* StatusResponseDTO.swift */,
 				ED3842192B0F1B66001E2803 /* LoginScene */,
 				ED3595AE2B0C82A200558FAA /* TimerScene */,
+				2C9F62162B1736F200AE63F9 /* SocialScene */,
 				608646512B0DDBCC00B0C1BC /* Category */,
 			);
 			path = DataMapping;
@@ -844,6 +870,7 @@
 				2C2F216D2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift */,
 				ED3842242B0F1DDA001E2803 /* DefaultGoogleAuthUseCase.swift */,
 				2C88DD102B14C50F000B4686 /* DefaultTimerFinishUseCase.swift */,
+				2C9F62102B17363400AE63F9 /* DefaultFriendUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -856,6 +883,7 @@
 				2C2F21792B0F4CF900B45BA8 /* StudyLogUseCase.swift */,
 				ED3842262B0F1E0C001E2803 /* GoogleAuthUseCase.swift */,
 				2C88DD122B14C51B000B4686 /* TimerFinishUseCase.swift */,
+				2C9F620E2B1735C700AE63F9 /* FriendUseCase.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -867,6 +895,7 @@
 				6086464D2B0DDA1300B0C1BC /* CategoryRepository.swift */,
 				2C2F217B2B0F4D4000B45BA8 /* StudyLogRepository.swift */,
 				ED3842222B0F1D70001E2803 /* GoogleAuthRepostiory.swift */,
+				2C9F62122B17366200AE63F9 /* FriendRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -1203,6 +1232,7 @@
 			files = (
 				2C3430A32B0DA5A5008CBC85 /* HTTPHeader.swift in Sources */,
 				EDC851D22B04EE83009031EA /* CategoryListCollectionViewCell.swift in Sources */,
+				2C9F62222B173AB500AE63F9 /* FriendFollowReqeustDTO.swift in Sources */,
 				ED38422C2B0F4531001E2803 /* LoginViewModel.swift in Sources */,
 				2C43A0D82B037BBC0005596A /* FeedbackManager.swift in Sources */,
 				ED3595AB2B0C81B800558FAA /* Responsable.swift in Sources */,
@@ -1229,6 +1259,7 @@
 				2C9F61F72B14EFA200AE63F9 /* CategoryManager.swift in Sources */,
 				2C88DCF62B124292000B4686 /* TimerSceneDIContainer.swift in Sources */,
 				2C2F21802B0F4DA600B45BA8 /* MockURLSession.swift in Sources */,
+				2C9F620F2B1735C700AE63F9 /* FriendUseCase.swift in Sources */,
 				2C801D802B04B68900A7ABAE /* TimerUseCase.swift in Sources */,
 				6086464E2B0DDA1300B0C1BC /* CategoryRepository.swift in Sources */,
 				2C9F620B2B171C8300AE63F9 /* FriendAddViewModel.swift in Sources */,
@@ -1253,6 +1284,7 @@
 				2C9F62012B1601F200AE63F9 /* MyNickNameView.swift in Sources */,
 				6057A58D2B0C7F0F00EE58E8 /* Requestable.swift in Sources */,
 				2C3430A72B0DD0F6008CBC85 /* TimerRepsoitory.swift in Sources */,
+				2C9F62132B17366200AE63F9 /* FriendRepository.swift in Sources */,
 				6057A58F2B0C801300EE58E8 /* NetworkError.swift in Sources */,
 				ED38422F2B0F747B001E2803 /* KeyChainManager.swift in Sources */,
 				ED3842292B0F3B19001E2803 /* DefaultGoogleAuthRepository.swift in Sources */,
@@ -1287,12 +1319,14 @@
 				2C4D55B32B035484006D7C26 /* DeviceOrientation.swift in Sources */,
 				ED3842272B0F1E0C001E2803 /* GoogleAuthUseCase.swift in Sources */,
 				2C88DCF22B124238000B4686 /* AppFlowCoordinator.swift in Sources */,
+				2C9F62112B17363400AE63F9 /* DefaultFriendUseCase.swift in Sources */,
 				EDC851C72B021492009031EA /* TabBarViewController.swift in Sources */,
 				2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */,
 				2C5CDA572B025426007AFC57 /* FlipMateColor.swift in Sources */,
 				2C2F217C2B0F4D4000B45BA8 /* StudyLogRepository.swift in Sources */,
 				600908C02AFCD7DF0065DFFB /* SceneDelegate.swift in Sources */,
 				2C3430B12B0DE3D0008CBC85 /* Date++Extension.swift in Sources */,
+				2C9F62152B1736BE00AE63F9 /* DefaultFriendRepository.swift in Sources */,
 				2C2F217E2B0F4D7F00B45BA8 /* DefaultStudyLogRepository.swift in Sources */,
 				2C5CDA4F2B025403007AFC57 /* SocialViewController.swift in Sources */,
 				2C88DD052B1256D0000B4686 /* TabBarFlowCoordinator.swift in Sources */,
@@ -1306,7 +1340,9 @@
 				ED3842312B0F94E6001E2803 /* DefaultCategoryRepository.swift in Sources */,
 				ED3595C12B0DC2F100558FAA /* CategoryColorSelectView.swift in Sources */,
 				ED38421B2B0F1B7E001E2803 /* GoogleAuthRequestDTO.swift in Sources */,
+				2C9F62242B173ADA00AE63F9 /* UserProfileResposeDTO.swift in Sources */,
 				EDC851D92B05C37C009031EA /* DeviceMotionManager.swift in Sources */,
+				2C9F62262B1742D200AE63F9 /* FriendEndpoints.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/FlipMate/FlipMate.xcodeproj/xcshareddata/xcschemes/FlipMateTests.xcscheme
+++ b/iOS/FlipMate/FlipMate.xcodeproj/xcshareddata/xcschemes/FlipMateTests.xcscheme
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "600908CF2AFCD7E00065DFFB"
+               BuildableName = "FlipMateTests.xctest"
+               BlueprintName = "FlipMateTests"
+               ReferencedContainer = "container:FlipMate.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOS/FlipMate/FlipMate/Common/Logger/FlipMateLogger.swift
+++ b/iOS/FlipMate/FlipMate/Common/Logger/FlipMateLogger.swift
@@ -15,4 +15,5 @@ enum FMLogger {
     static let viewLifeCycle = Logger(subsystem: FMConstant.bundleID, category: "viewLifeCycle")
     static let appLifeCycle = Logger(subsystem: FMConstant.bundleID, category: "appLifeCycle")
     static let timer = Logger(subsystem: FMConstant.bundleID, category: "timer")
+    static let friend = Logger(subsystem: FMConstant.bundleID, category: "friend")
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/BaseComponents.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/BaseComponents.swift
@@ -16,4 +16,6 @@ enum Paths {
     static let categories = "/categories"
     static let googleApp = "/auth/google/app"
     static let studylogs = "/study-logs"
+    static let friend = "/mates"
+    static let user = "/user"
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/SocialScene/FriendFollowReqeustDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/SocialScene/FriendFollowReqeustDTO.swift
@@ -1,0 +1,17 @@
+//
+//  FriendFollowReqeustDTO.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+
+struct FriendFollowReqeustDTO: Encodable {
+    let nickname: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case nickname = "following_nickname"
+    }
+}
+

--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/SocialScene/UserProfileResposeDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/SocialScene/UserProfileResposeDTO.swift
@@ -1,0 +1,16 @@
+//
+//  UserProfileResposeDTO.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+
+struct UserProfileResposeDTO: Decodable {
+    let profileImageURL: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case profileImageURL = "image_url"
+    }
+}

--- a/iOS/FlipMate/FlipMate/Data/Network/FriendEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/FriendEndpoints.swift
@@ -8,13 +8,14 @@
 import Foundation
 
 struct FriendEndpoints {
-    static func followFriend(with firendFollowRequestDTO: FriendFollowReqeustDTO) -> EndPoint<StatusResponseDTO> {
+    static func followFriend(with friendFollowRequestDTO: FriendFollowReqeustDTO) -> EndPoint<StatusResponseDTO> {
         let encoder = JSONEncoder()
-        let data = try? encoder.encode(firendFollowRequestDTO)
+        let data = try? encoder.encode(friendFollowRequestDTO)
         return EndPoint(
             baseURL: BaseURL.flipmateDomain,
             path: Paths.friend,
-            method: .post)
+            method: .post,
+            data: data)
     }
     
     static func searchFriend(at nickname: String) -> EndPoint<UserProfileResposeDTO> {

--- a/iOS/FlipMate/FlipMate/Data/Network/FriendEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/FriendEndpoints.swift
@@ -1,0 +1,26 @@
+//
+//  FriendEndpoints.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+
+struct FriendEndpoints {
+    static func followFriend(with firendFollowRequestDTO: FriendFollowReqeustDTO) -> EndPoint<StatusResponseDTO> {
+        let encoder = JSONEncoder()
+        let data = try? encoder.encode(firendFollowRequestDTO)
+        return EndPoint(
+            baseURL: BaseURL.flipmateDomain,
+            path: Paths.friend,
+            method: .post)
+    }
+    
+    static func searchFriend(at nickname: String) -> EndPoint<UserProfileResposeDTO> {
+        return EndPoint(
+            baseURL: BaseURL.flipmateDomain,
+            path: Paths.user + "/profile?nickname=\(nickname)",
+            method: .get)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultFriendRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultFriendRepository.swift
@@ -16,14 +16,22 @@ final class DefaultFriendRepository: FriendRepository {
         self.provider = provider
     }
     
-    func follow(at nickname: String) -> AnyPublisher<StatusResponseDTO, NetworkError> {
+    func follow(at nickname: String) -> AnyPublisher<String, NetworkError> {
         let reqeustDTO = FriendFollowReqeustDTO(nickname: nickname)
         let endPoint = FriendEndpoints.followFriend(with: reqeustDTO)
         return provider.request(with: endPoint)
+            .map { response -> String in
+                return response.message
+            }
+            .eraseToAnyPublisher()
     }
     
-    func search(at nickname: String) -> AnyPublisher<UserProfileResposeDTO, NetworkError> {
+    func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
         let endPoint = FriendEndpoints.searchFriend(at: nickname)
         return provider.request(with: endPoint)
+            .map { response -> String in
+                return response.profileImageURL
+            }
+            .eraseToAnyPublisher()
     }
 }

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultFriendRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultFriendRepository.swift
@@ -1,0 +1,29 @@
+//
+//  DefaultFriendRepository.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+import Combine
+
+final class DefaultFriendRepository: FriendRepository {
+    
+    private let provider: Providable
+    
+    init(provider: Providable) {
+        self.provider = provider
+    }
+    
+    func follow(at nickname: String) -> AnyPublisher<StatusResponseDTO, NetworkError> {
+        let reqeustDTO = FriendFollowReqeustDTO(nickname: nickname)
+        let endPoint = FriendEndpoints.followFriend(with: reqeustDTO)
+        return provider.request(with: endPoint)
+    }
+    
+    func search(at nickname: String) -> AnyPublisher<UserProfileResposeDTO, NetworkError> {
+        let endPoint = FriendEndpoints.searchFriend(at: nickname)
+        return provider.request(with: endPoint)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Domain/Entities/Friend.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Entities/Friend.swift
@@ -1,0 +1,13 @@
+//
+//  Friend.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+
+struct Friend {
+    let nickName: String
+    let profileImageURL: String
+}

--- a/iOS/FlipMate/FlipMate/Domain/Repositories/FriendRepository.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Repositories/FriendRepository.swift
@@ -1,0 +1,14 @@
+//
+//  FriendRepository.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+import Combine
+
+protocol FriendRepository {
+    func follow(at nickname: String) -> AnyPublisher<StatusResponseDTO, NetworkError>
+    func search(at nickname: String) -> AnyPublisher<UserProfileResposeDTO, NetworkError>
+}

--- a/iOS/FlipMate/FlipMate/Domain/Repositories/FriendRepository.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Repositories/FriendRepository.swift
@@ -9,6 +9,6 @@ import Foundation
 import Combine
 
 protocol FriendRepository {
-    func follow(at nickname: String) -> AnyPublisher<StatusResponseDTO, NetworkError>
-    func search(at nickname: String) -> AnyPublisher<UserProfileResposeDTO, NetworkError>
+    func follow(at nickname: String) -> AnyPublisher<String, NetworkError>
+    func search(at nickname: String) -> AnyPublisher<String, NetworkError>
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultFriendUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultFriendUseCase.swift
@@ -17,17 +17,9 @@ final class DefaultFriendUseCase: FriendUseCase {
     
     func follow(at nickname: String) -> AnyPublisher<String, NetworkError> {
         return repository.follow(at: nickname)
-            .map { response -> String in
-                return response.message
-            }
-            .eraseToAnyPublisher()
     }
     
     func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
         return repository.search(at: nickname)
-            .map { response -> String in
-                return response.profileImageURL
-            }
-            .eraseToAnyPublisher()
     }
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultFriendUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultFriendUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  DefaultFriendUseCase.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+import Combine
+
+final class DefaultFriendUseCase: FriendUseCase {
+    private let repository: FriendRepository
+    
+    init(repository: FriendRepository) {
+        self.repository = repository
+    }
+    
+    func follow(at nickname: String) -> AnyPublisher<String, NetworkError> {
+        return repository.follow(at: nickname)
+            .map { response -> String in
+                return response.message
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
+        return repository.search(at: nickname)
+            .map { response -> String in
+                return response.profileImageURL
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/FriendUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/FriendUseCase.swift
@@ -1,0 +1,14 @@
+//
+//  FriendUseCase.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+import Combine
+
+protocol FriendUseCase {
+    func follow(at nickname: String) -> AnyPublisher<String, NetworkError>
+    func search(at nickname: String) -> AnyPublisher<String, NetworkError>
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
     // MARK: - Costants
@@ -33,6 +34,10 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
         static let cornerRadius: CGFloat = 10
     }
     
+    // MARK: - Properties
+    private var tapSubject = PassthroughSubject<Void, Never>()
+
+    
     // MARK: - UI Components
     private lazy var profileImageView: UIImageView = {
         let imageView = UIImageView()
@@ -55,6 +60,7 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = FlipMateColor.darkBlue.color
         button.layer.cornerRadius = FlowButtonConstant.cornerRadius
+        button.addTarget(self, action: #selector(followButtonDidTapped), for: .touchUpInside)
         return button
     }()
     
@@ -74,6 +80,10 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
     
     func updateUI(friend: Friend) {
         self.nickNameLabel.text = friend.nickName
+    }
+    
+    func tapPublisher() -> AnyPublisher<Void, Never> {
+        return tapSubject.eraseToAnyPublisher()
     }
 }
 
@@ -102,5 +112,12 @@ private extension FriendSearchResultView {
             flowButton.widthAnchor.constraint(equalToConstant: FlowButtonConstant.width),
             flowButton.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
+    }
+}
+
+// MARK: - Objc func
+private extension FriendSearchResultView {
+    @objc func followButtonDidTapped() {
+        tapSubject.send()
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
@@ -27,7 +27,7 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
         static let top: CGFloat = 15
     }
     
-    private enum FlowButtonConstant {
+    private enum FollowButtonConstant {
         static let title = "친구추가"
         static let top: CGFloat = 15
         static let width: CGFloat = 90
@@ -54,12 +54,12 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
         return label
     }()
     
-    private lazy var flowButton: UIButton = {
+    private lazy var followButton: UIButton = {
         let button = UIButton()
-        button.setTitle(FlowButtonConstant.title, for: .normal)
+        button.setTitle(FollowButtonConstant.title, for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = FlipMateColor.darkBlue.color
-        button.layer.cornerRadius = FlowButtonConstant.cornerRadius
+        button.layer.cornerRadius = FollowButtonConstant.cornerRadius
         button.addTarget(self, action: #selector(followButtonDidTapped), for: .touchUpInside)
         return button
     }()
@@ -94,7 +94,7 @@ private extension FriendSearchResultView {
         backgroundColor = FlipMateColor.gray3.color
         layer.cornerRadius = Constant.cornerRadius
 
-        [profileImageView, nickNameLabel, flowButton].forEach {
+        [profileImageView, nickNameLabel, followButton].forEach {
             addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
@@ -108,9 +108,9 @@ private extension FriendSearchResultView {
             nickNameLabel.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: NickNameLabelConstant.top),
             nickNameLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
             
-            flowButton.topAnchor.constraint(equalTo: nickNameLabel.bottomAnchor, constant: FlowButtonConstant.top),
-            flowButton.widthAnchor.constraint(equalToConstant: FlowButtonConstant.width),
-            flowButton.centerXAnchor.constraint(equalTo: centerXAnchor)
+            followButton.topAnchor.constraint(equalTo: nickNameLabel.bottomAnchor, constant: FollowButtonConstant.top),
+            followButton.widthAnchor.constraint(equalToConstant: FollowButtonConstant.width),
+            followButton.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
@@ -71,6 +71,10 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
     func height() -> CGFloat {
         return Constant.height
     }
+    
+    func updateUI(friend: Friend) {
+        self.nickNameLabel.text = friend.nickName
+    }
 }
 
 // MARK: - Private Methods
@@ -99,10 +103,4 @@ private extension FriendSearchResultView {
             flowButton.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
     }
-}
-
-
-@available(iOS 17.0, *)
-#Preview {
-    FriendAddViewController()
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/MyNickNameView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/MyNickNameView.swift
@@ -45,6 +45,10 @@ final class MyNickNameView: UIView, FreindAddResultViewProtocol {
     func height() -> CGFloat {
         return Constant.height
     }
+    
+    func updateUI(nickname: String) {
+        nickNameContentLabel.text = nickname
+    }
 }
 
 // MARK: - Private Method

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
@@ -35,6 +35,10 @@ final class FriendAddViewController: BaseViewController {
         static let trailing: CGFloat = -40
     }
     
+    private enum Constant {
+        static let maxLength = 15
+    }
+    
     // MARK: - Properties
     private let viewModel: FriendAddViewModelProtocol
     private var cancellables = Set<AnyCancellable>()
@@ -132,7 +136,7 @@ final class FriendAddViewController: BaseViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] count in
                 guard let self = self else { return }
-                self.nickNameCountLabel.text = "\(count)/10"
+                self.nickNameCountLabel.text = "\(count)/\(Constant.maxLength)"
             }
             .store(in: &cancellables)
         
@@ -177,6 +181,11 @@ private extension FriendAddViewController {
 extension FriendAddViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         guard let nickname = textField.text else { return }
+        guard nickname.count <= Constant.maxLength else {
+            textField.deleteBackward()
+            textField.resignFirstResponder()
+            return
+        }
         viewModel.nicknameDidChange(at: nickname)
     }
     

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
@@ -143,6 +143,14 @@ final class FriendAddViewController: BaseViewController {
                 self.myNickNameView.updateUI(nickname: myNickname)
             }
             .store(in: &cancellables)
+        
+        friendSearchResultView.tapPublisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                self.viewModel.didFollowFriend()
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -160,6 +168,10 @@ private extension FriendAddViewController {
             resultView.heightAnchor.constraint(equalToConstant: resultView.height())
         ])
     }
+    
+    func setGesture() {
+        
+    }
 }
 
 extension FriendAddViewController: UITextFieldDelegate {
@@ -170,11 +182,7 @@ extension FriendAddViewController: UITextFieldDelegate {
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         guard let nickname = textField.text else { return false }
-        viewModel.didSearchFriend(at: nickname)
+        viewModel.didSearchFriend()
         return true
     }
-}
-@available(iOS 17.0, *)
-#Preview {
-    FriendAddViewController(viewModel: FriendAddViewModel(myNickname: "iOS개발용"))
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 final class FriendAddViewController: BaseViewController {
     // MARK: - Constant
@@ -33,12 +34,17 @@ final class FriendAddViewController: BaseViewController {
         static let leading: CGFloat = 40
         static let trailing: CGFloat = -40
     }
+    
+    // MARK: - Properties
+    private let viewModel: FriendAddViewModelProtocol
+    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - UI Components
     private lazy var nickNameTextField: UITextField = {
         let textField = UITextField()
         textField.placeholder = NameTextFieldConstant.placeholder
         textField.becomeFirstResponder()
+        textField.delegate = self
         return textField
     }()
     
@@ -59,6 +65,16 @@ final class FriendAddViewController: BaseViewController {
     private let myNickNameView = MyNickNameView()
     private let noResultView = NoResultView()
     private let friendSearchResultView = FriendSearchResultView()
+    
+    // MARK: - init
+    init(viewModel: FriendAddViewModelProtocol) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Don't use storyboard")
+    }
     
     // MARK: - Life cycle
     override func viewDidLoad() {
@@ -93,6 +109,41 @@ final class FriendAddViewController: BaseViewController {
             containerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
     }
+    
+    override func bind() {
+        viewModel.searchFreindPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] friend in
+                guard let self = self else { return }
+                self.friendSearchResultView.updateUI(friend: friend)
+                self.updateResultView(friendSearchResultView)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.searchErrorPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                self.updateResultView(noResultView)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.nicknameCountPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] count in
+                guard let self = self else { return }
+                self.nickNameCountLabel.text = "\(count)/10"
+            }
+            .store(in: &cancellables)
+        
+        viewModel.myNicknamePublihser
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] myNickname in
+                guard let self = self else { return }
+                self.myNickNameView.updateUI(nickname: myNickname)
+            }
+            .store(in: &cancellables)
+    }
 }
 
 // MARK: - Private Methods
@@ -111,7 +162,19 @@ private extension FriendAddViewController {
     }
 }
 
+extension FriendAddViewController: UITextFieldDelegate {
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let nickname = textField.text else { return }
+        viewModel.nicknameDidChange(at: nickname)
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard let nickname = textField.text else { return false }
+        viewModel.didSearchFriend(at: nickname)
+        return true
+    }
+}
 @available(iOS 17.0, *)
 #Preview {
-    FriendAddViewController()
+    FriendAddViewController(viewModel: FriendAddViewModel(myNickname: "iOS개발용"))
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
@@ -36,7 +36,7 @@ final class FriendAddViewController: BaseViewController {
     }
     
     private enum Constant {
-        static let maxLength = 15
+        static let maxLength = 10
     }
     
     // MARK: - Properties

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
@@ -1,0 +1,58 @@
+//
+//  FriendAddViewModel.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+import Combine
+
+protocol FriendAddViewModelInput {
+    func nicknameDidChange(at nickname: String)
+    func didFollowFriend(at nickName: String)
+    func didSearchFriend(at nickName: String)
+}
+
+protocol FriendAddViewModelOutput {
+    var searchFreindPublisher: AnyPublisher<Friend, Never> { get }
+    var searchErrorPublisher: AnyPublisher<String, Never> { get }
+    var nicknameCountPublisher: AnyPublisher<Int, Never> { get }
+}
+
+typealias FriendAddViewModelProtocol = FriendAddViewModelInput & FriendAddViewModelOutput
+
+final class FriendAddViewModel: FriendAddViewModelProtocol {
+    // MARK: - Subject
+    var searchResultSubject = PassthroughSubject<Friend, Never>()
+    var searchErrorSubject = PassthroughSubject<String, Never>()
+    var nicknameCountSubject = PassthroughSubject<Int, Never>()
+    
+    // MARK: - output
+    var searchFreindPublisher: AnyPublisher<Friend, Never> {
+        return searchResultSubject.eraseToAnyPublisher()
+    }
+    
+    var searchErrorPublisher: AnyPublisher<String, Never> {
+        return searchErrorSubject.eraseToAnyPublisher()
+    }
+    
+    var nicknameCountPublisher: AnyPublisher<Int, Never> {
+        return nicknameCountSubject.eraseToAnyPublisher()
+    }
+    
+    // MARK: - Input
+    func didFollowFriend(at nickName: String) {
+        // useCase 호출
+    }
+    
+    func didSearchFriend(at nickName: String) {
+        // useCase 호출
+        searchResultSubject.send(Friend(nickName: nickName, profileImageURL: ""))
+        searchErrorSubject.send("검색결과가 없습니다.")
+    }
+    
+    func nicknameDidChange(at nickname: String) {
+        nicknameCountSubject.send(nickname.count)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
@@ -15,8 +15,9 @@ protocol FriendAddViewModelInput {
 }
 
 protocol FriendAddViewModelOutput {
+    var myNicknamePublihser: AnyPublisher<String, Never> { get }
     var searchFreindPublisher: AnyPublisher<Friend, Never> { get }
-    var searchErrorPublisher: AnyPublisher<String, Never> { get }
+    var searchErrorPublisher: AnyPublisher<Void, Never> { get }
     var nicknameCountPublisher: AnyPublisher<Int, Never> { get }
 }
 
@@ -24,16 +25,24 @@ typealias FriendAddViewModelProtocol = FriendAddViewModelInput & FriendAddViewMo
 
 final class FriendAddViewModel: FriendAddViewModelProtocol {
     // MARK: - Subject
-    var searchResultSubject = PassthroughSubject<Friend, Never>()
-    var searchErrorSubject = PassthroughSubject<String, Never>()
-    var nicknameCountSubject = PassthroughSubject<Int, Never>()
+    private lazy var myNicknameSubject = CurrentValueSubject<String, Never>(myNickname)
+    private var searchResultSubject = PassthroughSubject<Friend, Never>()
+    private var searchErrorSubject = PassthroughSubject<Void, Never>()
+    private var nicknameCountSubject = PassthroughSubject<Int, Never>()
+    
+    // MARK: - Properties
+    private let myNickname: String
+    
+    init(myNickname: String) {
+        self.myNickname = myNickname
+    }
     
     // MARK: - output
     var searchFreindPublisher: AnyPublisher<Friend, Never> {
         return searchResultSubject.eraseToAnyPublisher()
     }
     
-    var searchErrorPublisher: AnyPublisher<String, Never> {
+    var searchErrorPublisher: AnyPublisher<Void, Never> {
         return searchErrorSubject.eraseToAnyPublisher()
     }
     
@@ -41,6 +50,10 @@ final class FriendAddViewModel: FriendAddViewModelProtocol {
         return nicknameCountSubject.eraseToAnyPublisher()
     }
     
+    var myNicknamePublihser: AnyPublisher<String, Never> {
+        return myNicknameSubject.eraseToAnyPublisher()
+    }
+
     // MARK: - Input
     func didFollowFriend(at nickName: String) {
         // useCase 호출
@@ -49,7 +62,6 @@ final class FriendAddViewModel: FriendAddViewModelProtocol {
     func didSearchFriend(at nickName: String) {
         // useCase 호출
         searchResultSubject.send(Friend(nickName: nickName, profileImageURL: ""))
-        searchErrorSubject.send("검색결과가 없습니다.")
     }
     
     func nicknameDidChange(at nickname: String) {

--- a/iOS/FlipMate/FlipMateUseCaseTests/Mock/MockFriendRepository.swift
+++ b/iOS/FlipMate/FlipMateUseCaseTests/Mock/MockFriendRepository.swift
@@ -19,11 +19,11 @@ final class MockFriendRepository: FriendRepository {
         self.responseType = reponseType
     }
     
-    func follow(at nickname: String) -> AnyPublisher<StatusResponseDTO, NetworkError> {
+    func follow(at nickname: String) -> AnyPublisher<String, NetworkError> {
         
         if responseType == .success {
             let response = StatusResponseDTO(statusCode: 200, message: "성공")
-            return Just(response).eraseToAnyPublisher()
+            return Just(response.message).eraseToAnyPublisher()
                 .setFailureType(to: NetworkError.self)
                 .eraseToAnyPublisher()
         } else {
@@ -31,10 +31,10 @@ final class MockFriendRepository: FriendRepository {
         }
     }
     
-    func search(at nickname: String) -> AnyPublisher<UserProfileResposeDTO, NetworkError> {
+    func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
         if responseType == .success {
             let response = UserProfileResposeDTO(profileImageURL: "https://flipmate.site:3000")
-            return Just(response).eraseToAnyPublisher()
+            return Just(response.profileImageURL).eraseToAnyPublisher()
                 .setFailureType(to: NetworkError.self)
                 .eraseToAnyPublisher()
         } else {

--- a/iOS/FlipMate/FlipMateUseCaseTests/Mock/MockFriendRepository.swift
+++ b/iOS/FlipMate/FlipMateUseCaseTests/Mock/MockFriendRepository.swift
@@ -1,0 +1,44 @@
+//
+//  MockFriendRepository.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+import Combine
+
+final class MockFriendRepository: FriendRepository {
+    private var responseType: ResponseType
+    
+    init(responseType: ResponseType) {
+        self.responseType = responseType
+    }
+    
+    func changeResponeType(_ reponseType: ResponseType) {
+        self.responseType = reponseType
+    }
+    
+    func follow(at nickname: String) -> AnyPublisher<StatusResponseDTO, NetworkError> {
+        
+        if responseType == .success {
+            let response = StatusResponseDTO(statusCode: 200, message: "성공")
+            return Just(response).eraseToAnyPublisher()
+                .setFailureType(to: NetworkError.self)
+                .eraseToAnyPublisher()
+        } else {
+            return Fail(error: NetworkError.statusCodeError).eraseToAnyPublisher()
+        }
+    }
+    
+    func search(at nickname: String) -> AnyPublisher<UserProfileResposeDTO, NetworkError> {
+        if responseType == .success {
+            let response = UserProfileResposeDTO(profileImageURL: "https://flipmate.site:3000")
+            return Just(response).eraseToAnyPublisher()
+                .setFailureType(to: NetworkError.self)
+                .eraseToAnyPublisher()
+        } else {
+            return Fail(error: NetworkError.statusCodeError).eraseToAnyPublisher()
+        }
+    }
+}

--- a/iOS/FlipMate/FlipMateUseCaseTests/SocialScene/FriendUseCaseTests.swift
+++ b/iOS/FlipMate/FlipMateUseCaseTests/SocialScene/FriendUseCaseTests.swift
@@ -1,0 +1,117 @@
+//
+//  FriendUseCaseTests.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+import XCTest
+import Combine
+@testable import FlipMate
+
+final class FriendUseCaseTests: XCTestCase {
+    private var friendUseCase: FriendUseCase!
+    private var friendRepository: MockFriendRepository!
+    private var cancellables: Set<AnyCancellable>!
+    
+    override func setUpWithError() throws {
+        self.friendRepository = MockFriendRepository(responseType: .success)
+        self.friendUseCase = DefaultFriendUseCase(
+            repository: friendRepository)
+        self.cancellables = Set<AnyCancellable>()
+    }
+    
+    override func tearDownWithError() throws {
+        self.friendUseCase = nil
+        self.cancellables = nil
+        self.friendRepository = nil
+    }
+    
+    func test_팔로우_요청에_성공하면_응답데이터_변환_성공() {
+        let expectation = XCTestExpectation()
+
+        friendUseCase.follow(at: "임현규")
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                expectation.fulfill()
+                switch completion {
+                case .finished:
+                    return
+                case .failure(_):
+                    XCTFail()
+                }
+            } receiveValue: { response in
+                XCTAssertEqual(response, "성공")
+            }
+            .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 5)
+    }
+    
+    func test_팔로우_요청에_실패하면_에러응답() {
+        let expectation = XCTestExpectation()
+
+        friendRepository.changeResponeType(.failure)
+        
+        friendUseCase.follow(at: "임현규")
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                expectation.fulfill()
+                switch completion {
+                case .finished:
+                    XCTFail()
+                case .failure(_):
+                    XCTAssert(true)
+                }
+            } receiveValue: { response in
+                XCTFail()
+            }
+            .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 5)
+    }
+    
+    func test_친구검색_요청에_성공하면_응답데이터_이미지URL로_변환_성공() {
+        let expectation = XCTestExpectation()
+
+        friendUseCase.search(at: "임현규")
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                expectation.fulfill()
+                switch completion {
+                case .finished:
+                    return
+                case .failure(_):
+                    XCTFail()
+                }
+            } receiveValue: { imageURL in
+                XCTAssertEqual(imageURL, "https://flipmate.site:3000")
+            }
+            .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 5)
+    }
+    
+    func test_친구검색_요청에_실패하면_에러응답() {
+        let expectation = XCTestExpectation()
+        friendRepository.changeResponeType(.failure)
+
+        friendUseCase.search(at: "임현규")
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                expectation.fulfill()
+                switch completion {
+                case .finished:
+                    XCTFail()
+                case .failure(_):
+                    XCTAssert(true)
+                }
+            } receiveValue: { response in
+                XCTFail()
+            }
+            .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 5)
+    }
+}

--- a/iOS/FlipMate/FlipMateUseCaseTests/SocialScene/FriendUseCaseTests.swift
+++ b/iOS/FlipMate/FlipMateUseCaseTests/SocialScene/FriendUseCaseTests.swift
@@ -8,7 +8,6 @@
 import Foundation
 import XCTest
 import Combine
-@testable import FlipMate
 
 final class FriendUseCaseTests: XCTestCase {
     private var friendUseCase: FriendUseCase!

--- a/iOS/FlipMate/FlipMateViewModelTests/Mock/MockFriendUseCase.swift
+++ b/iOS/FlipMate/FlipMateViewModelTests/Mock/MockFriendUseCase.swift
@@ -43,16 +43,3 @@ final class MockFriendUseCase: FriendUseCase {
     }
 }
 
-final class FailMockFriendUseCase: FriendUseCase {
-    var followSubject = PassthroughSubject<String, NetworkError>()
-    
-    func follow(at nickname: String) -> AnyPublisher<String, NetworkError> {
-        followSubject.send("success")
-        return followSubject.eraseToAnyPublisher()
-    }
-    
-    func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
-        return Fail(error: NetworkError.statusCodeError).eraseToAnyPublisher()
-    }
-}
-

--- a/iOS/FlipMate/FlipMateViewModelTests/Mock/MockFriendUseCase.swift
+++ b/iOS/FlipMate/FlipMateViewModelTests/Mock/MockFriendUseCase.swift
@@ -1,0 +1,59 @@
+//
+//  MockFriendUseCase.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+import Combine
+
+enum ResponseType {
+    case success
+    case failure
+}
+
+final class MockFriendUseCase: FriendUseCase {
+    private var followSubject = CurrentValueSubject<String, NetworkError>("success")
+    private var searchSubject = CurrentValueSubject<String, NetworkError>("https://flipmate.site:3000")
+    
+    private var type: ResponseType
+    
+    init(type: ResponseType) {
+        self.type = type
+    }
+    
+    func changeType(type: ResponseType) {
+        self.type = type
+    }
+    
+    func follow(at nickname: String) -> AnyPublisher<String, NetworkError> {
+        if type == .failure {
+            return Fail(error: NetworkError.statusCodeError).eraseToAnyPublisher()
+        }
+         
+        return followSubject.eraseToAnyPublisher()
+    }
+    
+    func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
+        if type == .failure {
+            return Fail(error: NetworkError.statusCodeError).eraseToAnyPublisher()
+        }
+        return searchSubject.eraseToAnyPublisher()
+    }
+}
+
+final class FailMockFriendUseCase: FriendUseCase {
+    var followSubject = PassthroughSubject<String, NetworkError>()
+    
+    func follow(at nickname: String) -> AnyPublisher<String, NetworkError> {
+        followSubject.send("success")
+        return followSubject.eraseToAnyPublisher()
+    }
+    
+    func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
+        print("??")
+        return Fail(error: NetworkError.statusCodeError).eraseToAnyPublisher()
+    }
+}
+

--- a/iOS/FlipMate/FlipMateViewModelTests/Mock/MockFriendUseCase.swift
+++ b/iOS/FlipMate/FlipMateViewModelTests/Mock/MockFriendUseCase.swift
@@ -52,7 +52,6 @@ final class FailMockFriendUseCase: FriendUseCase {
     }
     
     func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
-        print("??")
         return Fail(error: NetworkError.statusCodeError).eraseToAnyPublisher()
     }
 }

--- a/iOS/FlipMate/FlipMateViewModelTests/SocialScene/FriendAddViewModelTests.swift
+++ b/iOS/FlipMate/FlipMateViewModelTests/SocialScene/FriendAddViewModelTests.swift
@@ -1,0 +1,76 @@
+//
+//  FriendAddViewModelTests.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/29.
+//
+
+import Foundation
+import XCTest
+import Combine
+
+final class FriendAddViewModelTests: XCTestCase {
+    private var viewModel: FriendAddViewModelProtocol!
+    private var mockUseCase = MockFriendUseCase(type: .success)
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    override func setUpWithError() throws {
+        self.viewModel = FriendAddViewModel(
+            myNickname: "임현규",
+            friendUseCase: mockUseCase)
+    }
+    
+    override func tearDownWithError() throws {
+        self.viewModel = nil
+    }
+    
+    func test_닉네임_검색요청_성공시_imageURL리턴_성공() {
+        let expectation = XCTestExpectation()
+        self.viewModel.didSearchFriend()
+
+        self.viewModel.searchFreindPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { friend in
+                print(friend.profileImageURL)
+                XCTAssertEqual(friend.profileImageURL, "https://flipmate.site:3000")
+                expectation.fulfill()
+            }.store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 5)
+    }
+    
+    func test_닉네임_검색요청_실패시_에러_응답_성공() {
+        let expectation = XCTestExpectation()
+        mockUseCase.changeType(type: .failure)
+        
+        self.viewModel.searchErrorPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { _ in
+                XCTAssert(true)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        self.viewModel.didSearchFriend()
+
+        
+        wait(for: [expectation], timeout: 5)
+    }
+    
+    func test_닉네임_입력시_자릿수_카운팅_성공() {
+        let expectation = XCTestExpectation()
+        self.viewModel.nicknameCountPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { count in
+                print(count)
+                XCTAssertEqual(count, 8)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        self.viewModel.nicknameDidChange(at: "flipmate")
+        
+        wait(for: [expectation], timeout: 5)
+    }
+}


### PR DESCRIPTION
closed #239 

## 완료된 기능
- FriendUseCase 구현 (검색, 추가만 구현했는데 추후에 팔로우 취소, 차단까지 구현하시면 될 것 같습니다.)
- FriendRepository 구현
- FriendViewModel 구현
- FriendViewModel, FriendUseCase 테스트 코드 작성

## 실행 결과
아직 서버쪽에서 친구 추가요청 RepsonseDTO을 바뀐버전으로 안올려주셔서 친구 추가시에 에러가뜹니다!

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/266e1fe5-896d-42b1-9372-eba5c32b9736


## 고민과 해결과정
### ViewModel, UseCase 테스트 코드 작성
이번에 처음으로 VIewModel과 UseCase의 테스트 코드를 작성해보는 시간을 가졌는데요...
도대체 무엇을 테스트를 해야할지에 대해서 상당히 해맸습니다. 아직까지도 답을 못찾은 것 같습니다

ViewModel같은 경우에는 input과 output으로 추상화가 되어있다보니 
특정 input을 실행시켰을 때 이에 관련된 output이 정상적으로 나오는지에 대해서 테스트를 해줬고

UseCase는 Repository로부터 받는 응답 데이터를 entity로 변환이 되었는지 확인을 해주었습니다.

특히, ViewModel의 테스트 코드를 작성을 하면서 실제 다양한 케이스에 대해서 테스트를 해보고 싶었는데
input, output으로 추상화되어있다보니 테스트의 한계가 조금 있었던 것 같습니다.

