### PR TITLE
[iOS#272] 자동로그인 구현

### DIFF
--- a/iOS/FlipMate/FlipMate/Application/AppFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Application/AppFlowCoordinator.swift
@@ -28,16 +28,21 @@ final class AppFlowCoordinator: Coordinator {
     private var navigationController: UINavigationController
     private let appDIContainer: AppDIContainer
     
-    // TODO: 추후 자동 로그인 로직 추가
-    var isLogginIn: Bool = false
-    
     init(navigationController: UINavigationController, appDIContainer: AppDIContainer) {
         self.navigationController = navigationController
         self.appDIContainer = appDIContainer
     }
     
     func start() {
-        if isLogginIn {
+        var isLoggedIn: Bool
+        
+        if let token = try? KeychainManager.getAccessToken() {
+            isLoggedIn = true
+        } else {
+            isLoggedIn = false
+        }
+        
+        if isLoggedIn {
             showTabBarViewController()
         } else {
             showLoginViewController()

--- a/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
+++ b/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
@@ -35,7 +35,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         appFlowCoordinator?.start()
         window.makeKeyAndVisible()
-        try? KeychainManager.deleteAccessToken()
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -32,8 +32,8 @@ final class TabBarFlowCoordinator: Coordinator {
             [makeSocialViewController(), makeTimerViewContorller(), makeChartViewController()],
             animated: false
         )
-        navigationController.view.window?.rootViewController = tabBarController
-        navigationController.viewControllers = []
+        navigationController.isNavigationBarHidden = true
+        navigationController.viewControllers = [tabBarController]
         tabBarController.selectedIndex = 1
         tabBarViewController = tabBarController
     }


### PR DESCRIPTION
close #272 

## 완료된 기능
- keychain에서 token에 접근해, 토큰이 있다면 자동 로그인

## 고민과 해결과정
### 자동 로그인 실행해서 탭바 코디네이터를 곧바로 실행 시 화면이 까맣게 나오는 문제
* 탭바 뷰는 상위 네비게이션 컨트롤러로부터 접근한 window의 root view controller를 갈아끼워서 자신을 보여주고 있었다.
* 로그인 뷰를 통하지 않고, 앱 실행시 곧바로 탭바 뷰가 나오게 될 때는 window에 접근할 수 없어 까만 뷰가 나온다.
* 이를 해결하기 위해 navigation controller의 root view controlelr를 갈아끼워주는 방법이 아닌, navigation controller의 하위 뷰 컨트롤러로 탭바 뷰 컨트롤러를 삽입하는 방식을 선택했다.