### PR TITLE
[iOS#275] 회원가입 뷰 연결, 중복 닉네임 검사 로직 수정

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -131,8 +131,8 @@
 		608646572B0DE31800B0C1BC /* CategoryResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608646562B0DE31800B0C1BC /* CategoryResponseDTO.swift */; };
 		608646592B0DE61200B0C1BC /* CategoryEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608646582B0DE61200B0C1BC /* CategoryEndpoints.swift */; };
 		6096F91E2B04F3CA00D0B972 /* FaceDown.ahap in Resources */ = {isa = PBXBuildFile; fileRef = 6096F91D2B04F3CA00D0B972 /* FaceDown.ahap */; };
-		60C2F2862B172D6900EBDD78 /* FriendsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C2F2852B172D6900EBDD78 /* FriendsCollectionViewCell.swift */; };
 		60A0B8E12B181C4900510299 /* Data++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A0B8E02B181C4900510299 /* Data++Extension.swift */; };
+		60C2F2862B172D6900EBDD78 /* FriendsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C2F2852B172D6900EBDD78 /* FriendsCollectionViewCell.swift */; };
 		60DE493D2B05DEA400ACE6DD /* FlipMateLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DE493C2B05DEA400ACE6DD /* FlipMateLogger.swift */; };
 		60DE49402B05E67200ACE6DD /* FlipMateConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DE493F2B05E67200ACE6DD /* FlipMateConstant.swift */; };
 		60DFDDD92B14FD7800FEF98A /* StatusResponseWithErrorDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DFDDD82B14FD7800FEF98A /* StatusResponseWithErrorDTO.swift */; };
@@ -266,7 +266,6 @@
 		2C9F62362B17517100AE63F9 /* MockFriendUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFriendUseCase.swift; sourceTree = "<group>"; };
 		2C9F62402B1769FD00AE63F9 /* FriendUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendUseCaseTests.swift; sourceTree = "<group>"; };
 		2C9F62462B176AEC00AE63F9 /* MockFriendRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFriendRepository.swift; sourceTree = "<group>"; };
-		2CA80839AC9EFDD4BAA10C67 /* Pods_FlipMate_FlipMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate_FlipMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
 		2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell++Extension.swift"; sourceTree = "<group>"; };
@@ -302,8 +301,8 @@
 		608646562B0DE31800B0C1BC /* CategoryResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryResponseDTO.swift; sourceTree = "<group>"; };
 		608646582B0DE61200B0C1BC /* CategoryEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryEndpoints.swift; sourceTree = "<group>"; };
 		6096F91D2B04F3CA00D0B972 /* FaceDown.ahap */ = {isa = PBXFileReference; lastKnownFileType = text; path = FaceDown.ahap; sourceTree = "<group>"; };
-		60C2F2852B172D6900EBDD78 /* FriendsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsCollectionViewCell.swift; sourceTree = "<group>"; };
 		60A0B8E02B181C4900510299 /* Data++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data++Extension.swift"; sourceTree = "<group>"; };
+		60C2F2852B172D6900EBDD78 /* FriendsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsCollectionViewCell.swift; sourceTree = "<group>"; };
 		60DE493C2B05DEA400ACE6DD /* FlipMateLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlipMateLogger.swift; sourceTree = "<group>"; };
 		60DE493F2B05E67200ACE6DD /* FlipMateConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlipMateConstant.swift; sourceTree = "<group>"; };
 		60DFDDD82B14FD7800FEF98A /* StatusResponseWithErrorDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusResponseWithErrorDTO.swift; sourceTree = "<group>"; };
@@ -1048,6 +1047,14 @@
 			path = Constant;
 			sourceTree = "<group>";
 		};
+		60DFDDDC2B16383900FEF98A /* NickNameValidator */ = {
+			isa = PBXGroup;
+			children = (
+				60DFDDDD2B16384500FEF98A /* NickNameValidator.swift */,
+			);
+			path = NickNameValidator;
+			sourceTree = "<group>";
+		};
 		8323E91B4E0224828FF69A42 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1056,14 +1063,7 @@
 				2A07EAC691AD64BBA3FD43FE /* Pods_FlipMateTests.framework */,
 			);
 			name = Frameworks;
-        };
-		60DFDDDC2B16383900FEF98A /* NickNameValidator */ = {
-			isa = PBXGroup;
-			children = (
-				60DFDDDD2B16384500FEF98A /* NickNameValidator.swift */,
-			);
-			path = NickNameValidator;
-			sourceTree = "<group>";
+			sourceTree = "<unknown>";
 		};
 		ED3595AE2B0C82A200558FAA /* TimerScene */ = {
 			isa = PBXGroup;

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/LoginDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/LoginDIContainer.swift
@@ -31,6 +31,18 @@ final class LoginDIContainer: LoginFlowCoordinatorDependencies {
         )
     }
     
+    func makeSignUpViewController(actions: SignUpViewModelActions) -> UIViewController {
+        return SignUpViewController(
+            viewModel: SignUpViewModel(
+                usecase: DefaultSignUpUseCase(
+                    repository: DefaultSignUpRepository(
+                        provider: dependencies.provider),
+                    validator: NickNameValidator()),
+                actions: actions
+            )
+        )
+    }
+    
     func makeTabBarDIContainer() -> TabBarDIContainer {
         let dependencies = TabBarDIContainer.Dependencies(
             provider: dependencies.provider,

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultSignUpUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultSignUpUseCase.swift
@@ -19,7 +19,7 @@ final class DefaultSignUpUseCase: SignUpUseCase {
     
     func isNickNameValid(_ nickName: String) async throws -> NickNameValidationState {
         let isDuplicated = try await repository.checkIfNickNameIsDuplicated(nickName)
-        guard isDuplicated else {
+        guard !isDuplicated else {
             return .duplicated
         }
         let validationState = validator.checkNickNameValidationState(nickName)

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 
 protocol LoginFlowCoordinatorDependencies {
     func makeLoginViewController(actions: LoginViewModelActions) -> UIViewController
+    func makeSignUpViewController(actions: SignUpViewModelActions) -> UIViewController
     func makeTabBarDIContainer() -> TabBarDIContainer
 }
 
@@ -18,7 +19,7 @@ final class LoginFlowCoordinator: Coordinator {
     
     private var navigationViewController: UINavigationController
     private let dependencies: LoginFlowCoordinatorDependencies
-        
+    
     init(navigationViewController: UINavigationController, dependencies: LoginFlowCoordinatorDependencies) {
         self.navigationViewController = navigationViewController
         self.dependencies = dependencies
@@ -34,6 +35,13 @@ final class LoginFlowCoordinator: Coordinator {
         navigationViewController.viewControllers = [viewController]
     }
     
+    private func showSignUpController() {
+        let actions = SignUpViewModelActions(
+            didFinishSignUp: showTabBarController)
+        let signUpController = dependencies.makeSignUpViewController(actions: actions)
+        navigationViewController.pushViewController(signUpController, animated: true)
+    }
+    
     private func showTabBarController() {
         let tabBarDIContainer = dependencies.makeTabBarDIContainer()
         let coordinator = tabBarDIContainer.makeTabBarFlowCoordinator(
@@ -41,9 +49,5 @@ final class LoginFlowCoordinator: Coordinator {
         coordinator.parentCoordinator = self
         childCoordinators.append(coordinator)
         coordinator.start()
-    }
-    
-    func didFinishLogin() {
-        parentCoordinator?.childDidFinish(self)
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/Flows/LoginFlowCoordinator.swift
@@ -26,8 +26,9 @@ final class LoginFlowCoordinator: Coordinator {
     
     func start() {
         let actions = LoginViewModelActions(
+            showSignUpViewController: showSignUpController,
             showTabBarController: showTabBarController,
-            didFinishLogin: didFinishLogin
+            skippedLogin: showTabBarController
         )
         let viewController = dependencies.makeLoginViewController(actions: actions)
         navigationViewController.viewControllers = [viewController]

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/LoginViewController.swift
@@ -32,10 +32,6 @@ final class LoginViewController: BaseViewController {
         fatalError("Don't use storyboard")
     }
     
-    deinit {
-        loginViewModel.didFinishLogin()
-    }
-    
     // MARK: - UI Components
     private var logoImageView: UIImageView = {
         let imageView = UIImageView()
@@ -63,7 +59,7 @@ final class LoginViewController: BaseViewController {
         return label
     }()
     
-    private var googleLoginButton: UIButton = {
+    private lazy var googleLoginButton: UIButton = {
         let button = UIButton()
         button.setLoginButton(type: .google)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -89,9 +85,7 @@ final class LoginViewController: BaseViewController {
     }()
     
     // MARK: - Life Cycle
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
+
     
     // MARK: - UI Setting
     override func configureUI() {
@@ -138,9 +132,10 @@ final class LoginViewController: BaseViewController {
                 if let isMember = isMember {
                     if isMember {
                         FMLogger.device.log("타이머 창으로 이동합니다")
-                        loginViewModel.didLogin()
+                        loginViewModel.didFinishLoginAndIsMember()
                     } else {
                         FMLogger.device.log("회원가입 창으로 이동합니다")
+                        loginViewModel.didFinishLoginAndIsNotMember()
                     }
                 }
             }
@@ -151,7 +146,7 @@ final class LoginViewController: BaseViewController {
 // MARK: - Objc func
 private extension LoginViewController {
     @objc func loginSkipButtonDidTapped() {
-        loginViewModel.didLogin()
+        loginViewModel.skippedLogin()
     }
     
     @objc func handleGoogleLoginButton() {

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/LoginViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/LoginViewModel.swift
@@ -9,13 +9,15 @@ import Foundation
 import Combine
 
 struct LoginViewModelActions {
+    let showSignUpViewController: () -> Void
     let showTabBarController: () -> Void
-    let didFinishLogin: () -> Void
+    let skippedLogin: () -> Void
 }
 
 protocol LoginViewModelInput {
-    func didLogin()
-    func didFinishLogin()
+    func skippedLogin()
+    func didFinishLoginAndIsMember()
+    func didFinishLoginAndIsNotMember()
     func requestLogin(accessToken: String)
 }
 
@@ -26,6 +28,7 @@ protocol LoginViewModelOutput {
 typealias LoginViewModelProtocol = LoginViewModelInput & LoginViewModelOutput
 
 final class LoginViewModel: LoginViewModelProtocol {
+
     // MARK: properties
     private let googleAuthUseCase: GoogleAuthUseCase
     private let cancellables: Set<AnyCancellable> = []
@@ -43,14 +46,18 @@ final class LoginViewModel: LoginViewModelProtocol {
     }
     
     // MARK: - input
-    func didLogin() {
+    func skippedLogin() {
+        actions?.skippedLogin()
+    }
+    
+    func didFinishLoginAndIsMember() {
         actions?.showTabBarController()
     }
     
-    func didFinishLogin() {
-        actions?.didFinishLogin()
+    func didFinishLoginAndIsNotMember() {
+        actions?.showSignUpViewController()
     }
-    
+
     func requestLogin(accessToken: String) {
         Task {
             do {
@@ -67,8 +74,8 @@ final class LoginViewModel: LoginViewModelProtocol {
                 } else {
                     FMLogger.user.log("나는 아직 회원이 아니야")
                 }
-            } catch {
-                FMLogger.general.error("로그인 중 에러 발생")
+            } catch let error {
+                FMLogger.general.error("로그인 중 에러 발생 : \(error)")
             }
         }
     }

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -71,11 +71,9 @@ final class SignUpViewModel: SignUpViewModelProtocol {
             do {
                 try await useCase.signUpUser(nickName: userName, profileImageData: profileImageData)
                 isSignUpCompletedSubject.send()
-                guard let actions = actions else {
-                    FMLogger.general.error("no actions")
-                    return
+                DispatchQueue.main.async {
+                    self.actions?.didFinishSignUp()
                 }
-                actions.didFinishSignUp()
             } catch let error {
                 errorSubject.send(error)
             }

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -27,15 +27,15 @@ final class TabBarFlowCoordinator: Coordinator {
     }
     
     func start() {
-        let tabBarController = self.dependencies.makeTabBarController()
+        let tabBarController = dependencies.makeTabBarController()
         tabBarController.setViewControllers(
-            [self.makeSocialViewController(), self.makeTimerViewContorller(), self.makeChartViewController()],
+            [makeSocialViewController(), makeTimerViewContorller(), makeChartViewController()],
             animated: false
         )
-        self.navigationController.isNavigationBarHidden = true
-        self.navigationController.viewControllers = [tabBarController]
+        navigationController.isNavigationBarHidden = true
+        navigationController.viewControllers = [tabBarController]
         tabBarController.selectedIndex = 1
-        self.tabBarViewController = tabBarController
+        tabBarViewController = tabBarController
     }
     
     private func makeTimerViewContorller() -> UINavigationController {

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -27,17 +27,15 @@ final class TabBarFlowCoordinator: Coordinator {
     }
     
     func start() {
-        DispatchQueue.main.async {
-            let tabBarController = self.dependencies.makeTabBarController()
-            tabBarController.setViewControllers(
-                [self.makeSocialViewController(), self.makeTimerViewContorller(), self.makeChartViewController()],
-                animated: false
-            )
-            self.navigationController.isNavigationBarHidden = true
-            self.navigationController.viewControllers = [tabBarController]
-            tabBarController.selectedIndex = 1
-            self.tabBarViewController = tabBarController
-        }
+        let tabBarController = self.dependencies.makeTabBarController()
+        tabBarController.setViewControllers(
+            [self.makeSocialViewController(), self.makeTimerViewContorller(), self.makeChartViewController()],
+            animated: false
+        )
+        self.navigationController.isNavigationBarHidden = true
+        self.navigationController.viewControllers = [tabBarController]
+        tabBarController.selectedIndex = 1
+        self.tabBarViewController = tabBarController
     }
     
     private func makeTimerViewContorller() -> UINavigationController {

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -27,15 +27,17 @@ final class TabBarFlowCoordinator: Coordinator {
     }
     
     func start() {
-        let tabBarController = dependencies.makeTabBarController()
-        tabBarController.setViewControllers(
-            [makeSocialViewController(), makeTimerViewContorller(), makeChartViewController()],
-            animated: false
-        )
-        navigationController.view.window?.rootViewController = tabBarController
-        navigationController.viewControllers = []
-        tabBarController.selectedIndex = 1
-        tabBarViewController = tabBarController
+        DispatchQueue.main.async {
+            let tabBarController = self.dependencies.makeTabBarController()
+            tabBarController.setViewControllers(
+                [self.makeSocialViewController(), self.makeTimerViewContorller(), self.makeChartViewController()],
+                animated: false
+            )
+            self.navigationController.isNavigationBarHidden = true
+            self.navigationController.viewControllers = [tabBarController]
+            tabBarController.selectedIndex = 1
+            self.tabBarViewController = tabBarController
+        }
     }
     
     private func makeTimerViewContorller() -> UINavigationController {
@@ -55,7 +57,7 @@ final class TabBarFlowCoordinator: Coordinator {
             systemName: Constant.socialSelectedImageName)
         return navigationViewController
     }
-
+    
     private func makeChartViewController() -> UINavigationController {
         let navigationViewController = UINavigationController()
         navigationViewController.tabBarItem.image = UIImage(

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
@@ -30,7 +30,7 @@ final class TimerFlowCoordinator: Coordinator {
             showTimerFinishViewController: showTimerFinishViewController)
         let viewController = dependencies.makeTimerViewController(actions: actions)
         timerViewController = viewController
-        self.navigationController.viewControllers = [viewController]
+        navigationController.viewControllers = [viewController]
     }
     
     private func showCategorySettingViewController() {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
@@ -30,7 +30,9 @@ final class TimerFlowCoordinator: Coordinator {
             showTimerFinishViewController: showTimerFinishViewController)
         let viewController = dependencies.makeTimerViewController(actions: actions)
         timerViewController = viewController
-        navigationController.viewControllers = [viewController]
+        DispatchQueue.main.async {
+            self.navigationController.viewControllers = [viewController]
+        }
     }
     
     private func showCategorySettingViewController() {
@@ -42,7 +44,7 @@ final class TimerFlowCoordinator: Coordinator {
         childCoordinators.append(coordinator)
     }
     
-    private func showTimerFinishViewController(studyEndLog: StudyEndLog) -> Void {
+    private func showTimerFinishViewController(studyEndLog: StudyEndLog) {
         let actions = TimerFinishViewModelActions(
             didSaveStudyEndLog: didSaveStudyEndLog,
             didCancleStudyEndLog: didCancleStudyEndLog)

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/TimerFlowCoordinator.swift
@@ -30,9 +30,7 @@ final class TimerFlowCoordinator: Coordinator {
             showTimerFinishViewController: showTimerFinishViewController)
         let viewController = dependencies.makeTimerViewController(actions: actions)
         timerViewController = viewController
-        DispatchQueue.main.async {
-            self.navigationController.viewControllers = [viewController]
-        }
+        self.navigationController.viewControllers = [viewController]
     }
     
     private func showCategorySettingViewController() {


### PR DESCRIPTION
close #275 

## 완료된 기능
- 회원가입 화면 연결
- 중복 닉네임 검사 기능 고치기 완료

## 고민과 해결과정
### 메인 스레드에서 뷰 수정하기 문제
* Swift는 기본적으로 DispatchQueue.global, Task 등의 새로운 작업 흐름을 생성하는 코드를 만나지 않으면 main에서 sync하게 실행된다.
* 회원가입 완료 후 탭 바 뷰로 이동하는 로직은 뷰를 변경하기 때문에 메인 스레드에서 처리되어야 한다.
* 그런데 탭 바 뷰로 이동하는 로직을 실행하는 함수를 Task {} 안에 넣어 놓았었다.
* 이로 인해 메인 스레드가 아닌 다른 스레드에서 뷰의 변경이 일어나, 앱이 크래시가 나는 현상이 있었다.
* 처음에는 정확한 원인을 찾지 못하고 뷰를 이동시키는 모든 로직마다 DispatchQueue.main을 해 주었다.
* 그러나 Task 내부에서 실행한 최상위 함수가 원인임을 찾고, 해당 함수를 메인 스레드에서 실행하도록 변경해서 해결하였다. 