### PR TITLE
[iOS#289] 소셜 화면 친구 상태 비즈니스 로직 구현

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -103,6 +103,17 @@
 		2CDCD03D2B1871E60080DCDE /* SocialDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD03C2B1871E60080DCDE /* SocialDIContainer.swift */; };
 		2CDCD0402B1872060080DCDE /* SocialFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD03F2B1872060080DCDE /* SocialFlowCoordinator.swift */; };
 		2CDCD0422B1873F60080DCDE /* SocialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD0412B1873F60080DCDE /* SocialViewModel.swift */; };
+		2CDCD0442B1887200080DCDE /* SocialUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD0432B1887200080DCDE /* SocialUseCase.swift */; };
+		2CDCD0462B1889040080DCDE /* DefaultSocialUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD0452B1889040080DCDE /* DefaultSocialUseCase.swift */; };
+		2CDCD0482B18893A0080DCDE /* SocialRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD0472B18893A0080DCDE /* SocialRepository.swift */; };
+		2CDCD04A2B18895E0080DCDE /* DefaultSocialRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD0492B18895E0080DCDE /* DefaultSocialRepository.swift */; };
+		2CDCD04C2B18899A0080DCDE /* SocialEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD04B2B18899A0080DCDE /* SocialEndpoints.swift */; };
+		2CDCD0562B18C8960080DCDE /* UserEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD0552B18C8960080DCDE /* UserEndpoints.swift */; };
+		2CDCD0642B18CEDF0080DCDE /* FriendsResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD0632B18CEDF0080DCDE /* FriendsResponseDTO.swift */; };
+		2CDCD0672B18D0330080DCDE /* FriendUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD0662B18D0330080DCDE /* FriendUser.swift */; };
+		2CDCD0692B18D0D10080DCDE /* FriendSearchItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD0682B18D0D10080DCDE /* FriendSearchItem.swift */; };
+		2CDCD06C2B18E6960080DCDE /* UserDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD06B2B18E6960080DCDE /* UserDefault.swift */; };
+		2CDCD06E2B18EB4B0080DCDE /* UserInfoStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDCD06D2B18EB4B0080DCDE /* UserInfoStorage.swift */; };
 		2CE84EEF2B0B742A00E2FB71 /* CategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */; };
 		2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */; };
 		2CE84EF52B0B783800E2FB71 /* UICollectionViewCell++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */; };
@@ -272,6 +283,17 @@
 		2CDCD03C2B1871E60080DCDE /* SocialDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialDIContainer.swift; sourceTree = "<group>"; };
 		2CDCD03F2B1872060080DCDE /* SocialFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialFlowCoordinator.swift; sourceTree = "<group>"; };
 		2CDCD0412B1873F60080DCDE /* SocialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialViewModel.swift; sourceTree = "<group>"; };
+		2CDCD0432B1887200080DCDE /* SocialUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialUseCase.swift; sourceTree = "<group>"; };
+		2CDCD0452B1889040080DCDE /* DefaultSocialUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSocialUseCase.swift; sourceTree = "<group>"; };
+		2CDCD0472B18893A0080DCDE /* SocialRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialRepository.swift; sourceTree = "<group>"; };
+		2CDCD0492B18895E0080DCDE /* DefaultSocialRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSocialRepository.swift; sourceTree = "<group>"; };
+		2CDCD04B2B18899A0080DCDE /* SocialEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialEndpoints.swift; sourceTree = "<group>"; };
+		2CDCD0552B18C8960080DCDE /* UserEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEndpoints.swift; sourceTree = "<group>"; };
+		2CDCD0632B18CEDF0080DCDE /* FriendsResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsResponseDTO.swift; sourceTree = "<group>"; };
+		2CDCD0662B18D0330080DCDE /* FriendUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendUser.swift; sourceTree = "<group>"; };
+		2CDCD0682B18D0D10080DCDE /* FriendSearchItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSearchItem.swift; sourceTree = "<group>"; };
+		2CDCD06B2B18E6960080DCDE /* UserDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefault.swift; sourceTree = "<group>"; };
+		2CDCD06D2B18EB4B0080DCDE /* UserInfoStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoStorage.swift; sourceTree = "<group>"; };
 		2CE84EEE2B0B742A00E2FB71 /* CategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySettingViewController.swift; sourceTree = "<group>"; };
 		2CE84EF02B0B77BD00E2FB71 /* UICollectionView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++Extension.swift"; sourceTree = "<group>"; };
 		2CE84EF42B0B783800E2FB71 /* UICollectionViewCell++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell++Extension.swift"; sourceTree = "<group>"; };
@@ -411,6 +433,7 @@
 		2C3430952B0C7E44008CBC85 /* PersistenceService */ = {
 			isa = PBXGroup;
 			children = (
+				2CDCD06D2B18EB4B0080DCDE /* UserInfoStorage.swift */,
 			);
 			path = PersistenceService;
 			sourceTree = "<group>";
@@ -615,6 +638,7 @@
 			children = (
 				2C9F62212B173AB500AE63F9 /* FriendFollowReqeustDTO.swift */,
 				2C9F62232B173ADA00AE63F9 /* UserProfileResposeDTO.swift */,
+				2CDCD0632B18CEDF0080DCDE /* FriendsResponseDTO.swift */,
 			);
 			path = SocialScene;
 			sourceTree = "<group>";
@@ -675,6 +699,23 @@
 				2CDCD03F2B1872060080DCDE /* SocialFlowCoordinator.swift */,
 			);
 			path = Flow;
+			sourceTree = "<group>";
+		};
+		2CDCD0652B18D0280080DCDE /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				2CDCD0662B18D0330080DCDE /* FriendUser.swift */,
+				2CDCD0682B18D0D10080DCDE /* FriendSearchItem.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		2CDCD06A2B18E6850080DCDE /* UserDefault */ = {
+			isa = PBXGroup;
+			children = (
+				2CDCD06B2B18E6960080DCDE /* UserDefault.swift */,
+			);
+			path = UserDefault;
 			sourceTree = "<group>";
 		};
 		48114A3517087E7FD0C9546F /* Pods */ = {
@@ -800,6 +841,7 @@
 		600908F22AFCDCE10065DFFB /* SocialScene */ = {
 			isa = PBXGroup;
 			children = (
+				2CDCD0652B18D0280080DCDE /* Model */,
 				2CDCD03E2B1871FB0080DCDE /* Flow */,
 				ED6865AB2B1795E8001A2AAD /* ViewModel */,
 				2C9F62062B16397400AE63F9 /* Protocol */,
@@ -862,6 +904,7 @@
 				600908FA2AFCDF0F0065DFFB /* Repositories */,
 				600908FC2AFCDF2F0065DFFB /* Network */,
 				600909022AFCDFEA0065DFFB /* Persistants */,
+				2CDCD05D2B18C9BE0080DCDE /* DefaultUserInfoRepository.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -875,6 +918,7 @@
 				ED3842302B0F94E6001E2803 /* DefaultCategoryRepository.swift */,
 				601EB7422B14F83400C5B216 /* DefaultSignUpRepository.swift */,
 				2C9F62142B1736BE00AE63F9 /* DefaultFriendRepository.swift */,
+				2CDCD0492B18895E0080DCDE /* DefaultSocialRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -899,6 +943,8 @@
 				2C2F21752B0F440D00B45BA8 /* StudyLogEndpoints.swift */,
 				2C2F217F2B0F4DA600B45BA8 /* MockURLSession.swift */,
 				2C9F62252B1742D200AE63F9 /* FriendEndpoints.swift */,
+				2CDCD04B2B18899A0080DCDE /* SocialEndpoints.swift */,
+				2CDCD0552B18C8960080DCDE /* UserEndpoints.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -955,6 +1001,7 @@
 		600909012AFCDFD10065DFFB /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				2CDCD06A2B18E6850080DCDE /* UserDefault */,
 				60DE493E2B05E66500ACE6DD /* Constant */,
 				60DE493B2B05DE6700ACE6DD /* Logger */,
 				2C5CDA502B025426007AFC57 /* Base */,
@@ -1007,6 +1054,7 @@
 				601EB73E2B14F37300C5B216 /* DefaultSignUpUseCase.swift */,
 				2C88DD102B14C50F000B4686 /* DefaultTimerFinishUseCase.swift */,
 				2C9F62102B17363400AE63F9 /* DefaultFriendUseCase.swift */,
+				2CDCD0452B1889040080DCDE /* DefaultSocialUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -1021,6 +1069,7 @@
 				601EB73C2B14D67600C5B216 /* SignUpUseCase.swift */,
 				2C88DD122B14C51B000B4686 /* TimerFinishUseCase.swift */,
 				2C9F620E2B1735C700AE63F9 /* FriendUseCase.swift */,
+				2CDCD0432B1887200080DCDE /* SocialUseCase.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1034,6 +1083,7 @@
 				ED3842222B0F1D70001E2803 /* GoogleAuthRepostiory.swift */,
 				601EB7402B14F39B00C5B216 /* SignUpRepository.swift */,
 				2C9F62122B17366200AE63F9 /* FriendRepository.swift */,
+				2CDCD0472B18893A0080DCDE /* SocialRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -1430,6 +1480,7 @@
 				2C88DD072B125781000B4686 /* TabBarDIContainer.swift in Sources */,
 				2C88DD092B1274FA000B4686 /* CategorySettingCoordinator.swift in Sources */,
 				2C4D55AB2B033029006D7C26 /* UIView++Extension.swift in Sources */,
+				2CDCD06C2B18E6960080DCDE /* UserDefault.swift in Sources */,
 				60F67C6A2B0E1868002C8BF3 /* DefaultCategoryUseCase.swift in Sources */,
 				2C5CDA4B2B0252C1007AFC57 /* LoginType.swift in Sources */,
 				600195A02B0DFA3900F02BA4 /* StatusResponseDTO.swift in Sources */,
@@ -1440,16 +1491,19 @@
 				60A0B8E12B181C4900510299 /* Data++Extension.swift in Sources */,
 				ED3595B02B0C82C800558FAA /* TimerStartRequestDTO.swift in Sources */,
 				2C5CDA482B0252B2007AFC57 /* LoginViewController.swift in Sources */,
+				2CDCD0482B18893A0080DCDE /* SocialRepository.swift in Sources */,
 				601EB73D2B14D67600C5B216 /* SignUpUseCase.swift in Sources */,
 				608646572B0DE31800B0C1BC /* CategoryResponseDTO.swift in Sources */,
 				ED38421F2B0F1C7A001E2803 /* GoogleAuthResponseDTO.swift in Sources */,
 				ED3595B22B0C83D700558FAA /* TimerStartResponseDTO.swift in Sources */,
 				2C5CDA582B025426007AFC57 /* FlipMateFont.swift in Sources */,
+				2CDCD04C2B18899A0080DCDE /* SocialEndpoints.swift in Sources */,
 				60DE493D2B05DEA400ACE6DD /* FlipMateLogger.swift in Sources */,
 				2C9F61F72B14EFA200AE63F9 /* CategoryManager.swift in Sources */,
 				2C88DCF62B124292000B4686 /* TimerSceneDIContainer.swift in Sources */,
 				2C2F21802B0F4DA600B45BA8 /* MockURLSession.swift in Sources */,
 				2C9F620F2B1735C700AE63F9 /* FriendUseCase.swift in Sources */,
+				2CDCD0692B18D0D10080DCDE /* FriendSearchItem.swift in Sources */,
 				2C801D802B04B68900A7ABAE /* TimerUseCase.swift in Sources */,
 				6086464E2B0DDA1300B0C1BC /* CategoryRepository.swift in Sources */,
 				2C9F62472B176AEC00AE63F9 /* MockFriendRepository.swift in Sources */,
@@ -1468,9 +1522,11 @@
 				2C3430AB2B0DDB8D008CBC85 /* TimerEndpoints.swift in Sources */,
 				ED3842212B0F1CF9001E2803 /* User.swift in Sources */,
 				2C3430A12B0DA4E6008CBC85 /* BaseComponents.swift in Sources */,
+				2CDCD0462B1889040080DCDE /* DefaultSocialUseCase.swift in Sources */,
 				2C88DD0D2B148E9B000B4686 /* TimerFinishViewController.swift in Sources */,
 				2C3430A12B0DA4E6008CBC85 /* BaseComponents.swift in Sources */,
 				2C2F21832B0F53B500B45BA8 /* StduyLogMock.swift in Sources */,
+				2CDCD0442B1887200080DCDE /* SocialUseCase.swift in Sources */,
 				60F67C682B0E1785002C8BF3 /* CategoryUseCase.swift in Sources */,
 				2C88DCF42B124272000B4686 /* AppDIContainer.swift in Sources */,
 				2C5CDA5B2B025440007AFC57 /* ChartViewController.swift in Sources */,
@@ -1496,6 +1552,7 @@
 				2C3430992B0C8427008CBC85 /* Provider.swift in Sources */,
 				2C2F21702B0F429800B45BA8 /* StudyLogResponseDTO.swift in Sources */,
 				2C2F216E2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift in Sources */,
+				2CDCD06E2B18EB4B0080DCDE /* UserInfoStorage.swift in Sources */,
 				2CE84EF72B0B7F3C00E2FB71 /* CategorySettingSection.swift in Sources */,
 				2C88DD112B14C50F000B4686 /* DefaultTimerFinishUseCase.swift in Sources */,
 				2C3430AD2B0DDF25008CBC85 /* DefaultTimerRepository.swift in Sources */,
@@ -1520,6 +1577,7 @@
 				ED6865A22B162B8F001A2AAD /* SocialChartView.swift in Sources */,
 				2C88DCF22B124238000B4686 /* AppFlowCoordinator.swift in Sources */,
 				2C9F62112B17363400AE63F9 /* DefaultFriendUseCase.swift in Sources */,
+				2CDCD0642B18CEDF0080DCDE /* FriendsResponseDTO.swift in Sources */,
 				EDC851C72B021492009031EA /* TabBarViewController.swift in Sources */,
 				2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */,
 				2C5CDA572B025426007AFC57 /* FlipMateColor.swift in Sources */,
@@ -1529,6 +1587,7 @@
 				ED6865A72B17932F001A2AAD /* SocialDetailRequestDTO.swift in Sources */,
 				2C3430B12B0DE3D0008CBC85 /* Date++Extension.swift in Sources */,
 				2C9F62152B1736BE00AE63F9 /* DefaultFriendRepository.swift in Sources */,
+				2CDCD0672B18D0330080DCDE /* FriendUser.swift in Sources */,
 				2C2F217E2B0F4D7F00B45BA8 /* DefaultStudyLogRepository.swift in Sources */,
 				2C5CDA4F2B025403007AFC57 /* SocialViewController.swift in Sources */,
 				2C88DD052B1256D0000B4686 /* TabBarFlowCoordinator.swift in Sources */,
@@ -1543,6 +1602,7 @@
 				2C9F62082B16398D00AE63F9 /* FreindAddResultViewProtocol.swift in Sources */,
 				ED3842312B0F94E6001E2803 /* DefaultCategoryRepository.swift in Sources */,
 				ED6865AD2B179600001A2AAD /* SocialDetailViewModel.swift in Sources */,
+				2CDCD04A2B18895E0080DCDE /* DefaultSocialRepository.swift in Sources */,
 				ED3595C12B0DC2F100558FAA /* CategoryColorSelectView.swift in Sources */,
 				60DFDDDB2B14FE0100FEF98A /* SignUpResponseDTO.swift in Sources */,
 				ED38421B2B0F1B7E001E2803 /* GoogleAuthRequestDTO.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/SocialDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/SocialDIContainer.swift
@@ -39,7 +39,6 @@ final class SocialDIContainer: SocialFlowCoordinatorDependencies {
     
     func makeFriendAddViewController(actions: FriendAddViewModelActions) -> UIViewController {
         return FriendAddViewController(viewModel: FriendAddViewModel(
-            myNickname: "test",
             friendUseCase: DefaultFriendUseCase(
                 repository: DefaultFriendRepository(
                     provider: dependencies.provider)),

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/SocialDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/SocialDIContainer.swift
@@ -27,7 +27,13 @@ final class SocialDIContainer: SocialFlowCoordinatorDependencies {
     
     func makeSocialViewController(actions: SocialViewModelActions) -> UIViewController {
         return SocialViewController(
-            viewModel: SocialViewModel(actions: actions)
+            viewModel: SocialViewModel(
+                actions: actions,
+                socialUseCase: DefaultSocialUseCase(
+                    repsoitory: DefaultSocialRepository(
+                        provider: dependencies.provider)
+                )
+            )
         )
     }
     

--- a/iOS/FlipMate/FlipMate/Common/UserDefault/UserDefault.swift
+++ b/iOS/FlipMate/FlipMate/Common/UserDefault/UserDefault.swift
@@ -1,0 +1,33 @@
+//
+//  UserDefault.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/01.
+//
+
+import Foundation
+import Combine
+
+@propertyWrapper
+struct UserDefault<T> {
+    private let key: String
+    private let defaultValue: T
+    
+    init(key: String, defaultValue: T) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+
+    var wrappedValue: T {
+        get {
+            return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: key)
+        }
+    }
+    
+    var projectedValue: AnyPublisher<T, Never> {
+        return Just(wrappedValue).eraseToAnyPublisher()
+    }
+}

--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/SocialScene/FriendsResponseDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/SocialScene/FriendsResponseDTO.swift
@@ -1,0 +1,23 @@
+//
+//  FriendsResponseDTO.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/30.
+//
+
+import Foundation
+
+struct FriendsResponseDTO: Decodable {
+    var id: Int
+    var nickname: String
+    var imageURL: String?
+    var totalTime: Int
+    var startTime: Int?
+    
+    private enum CodingKeys: String, CodingKey {
+        case id, nickname
+        case imageURL = "image_url"
+        case totalTime = "total_time"
+        case startTime = "started_at"
+    }
+}

--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/SocialScene/UserProfileResposeDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/SocialScene/UserProfileResposeDTO.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct UserProfileResposeDTO: Decodable {
-    let profileImageURL: String
+    let profileImageURL: String?
     
     private enum CodingKeys: String, CodingKey {
         case profileImageURL = "image_url"

--- a/iOS/FlipMate/FlipMate/Data/Network/SignUpEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/SignUpEndpoints.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct SignUpEndpoints {
     static func nickNameValidation(_ nickName: String) -> EndPoint<NickNameValidationResponseDTO> {
-        let path = Paths.nickNameValidation + "?nickName=\(nickName)"
+        let path = Paths.nickNameValidation + "?nickname=\(nickName)"
         return EndPoint(
             baseURL: BaseURL.flipmateDomain,
             path: path,

--- a/iOS/FlipMate/FlipMate/Data/Network/SocialEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/SocialEndpoints.swift
@@ -1,0 +1,19 @@
+//
+//  SocialEndpoints.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/30.
+//
+
+import Foundation
+import Combine
+
+struct SocialEndpoints {
+    static func getMyFreinds(date: Date) -> EndPoint<[FriendsResponseDTO]> {
+        return EndPoint(
+            baseURL: BaseURL.flipmateDomain,
+            path: Paths.friend + "?date=\(date.dateToString(format: .yyyyMMdd))",
+            method: .get)
+        
+    }
+}

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultFriendRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultFriendRepository.swift
@@ -26,10 +26,10 @@ final class DefaultFriendRepository: FriendRepository {
             .eraseToAnyPublisher()
     }
     
-    func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
+    func search(at nickname: String) -> AnyPublisher<String?, NetworkError> {
         let endPoint = FriendEndpoints.searchFriend(at: nickname)
         return provider.request(with: endPoint)
-            .map { response -> String in
+            .map { response -> String? in
                 return response.profileImageURL
             }
             .eraseToAnyPublisher()

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultSocialRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultSocialRepository.swift
@@ -23,7 +23,8 @@ final class DefaultSocialRepository: SocialRepository {
                     id: $0.id,
                     nickName: $0.nickname,
                     profileImageURL: $0.imageURL,
-                    totalTime: $0.totalTime)
+                    totalTime: $0.totalTime,
+                    isStuding: $0.startTime != nil ? true: false)
                 }
             }
             .eraseToAnyPublisher()

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultSocialRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultSocialRepository.swift
@@ -1,0 +1,31 @@
+//
+//  DefaultSocialRepository.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/30.
+//
+
+import Foundation
+import Combine
+
+final class DefaultSocialRepository: SocialRepository {
+    private let provider: Providable
+    
+    init(provider: Providable) {
+        self.provider = provider
+    }
+    
+    func getMyFriend(date: Date) -> AnyPublisher<[Friend], NetworkError> {
+        let endPoint = SocialEndpoints.getMyFreinds(date: date)
+        return provider.request(with: endPoint)
+            .map { response -> [Friend] in
+                return response.map { Friend(
+                    id: $0.id,
+                    nickName: $0.nickname,
+                    profileImageURL: $0.imageURL,
+                    totalTime: $0.totalTime)
+                }
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/iOS/FlipMate/FlipMate/Domain/Entities/Friend.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Entities/Friend.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 struct Friend {
+    let id: Int?
     let nickName: String
-    let profileImageURL: String
+    let profileImageURL: String?
+    let totalTime: Int?
 }

--- a/iOS/FlipMate/FlipMate/Domain/Entities/Friend.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Entities/Friend.swift
@@ -12,4 +12,5 @@ struct Friend {
     let nickName: String
     let profileImageURL: String?
     let totalTime: Int?
+    let isStuding: Bool
 }

--- a/iOS/FlipMate/FlipMate/Domain/Repositories/FriendRepository.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Repositories/FriendRepository.swift
@@ -10,5 +10,5 @@ import Combine
 
 protocol FriendRepository {
     func follow(at nickname: String) -> AnyPublisher<String, NetworkError>
-    func search(at nickname: String) -> AnyPublisher<String, NetworkError>
+    func search(at nickname: String) -> AnyPublisher<String?, NetworkError>
 }

--- a/iOS/FlipMate/FlipMate/Domain/Repositories/SocialRepository.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Repositories/SocialRepository.swift
@@ -1,0 +1,13 @@
+//
+//  SocialRepository.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/30.
+//
+
+import Foundation
+import Combine
+
+protocol SocialRepository {
+    func getMyFriend(date: Date) -> AnyPublisher<[Friend], NetworkError>
+}

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultFriendUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultFriendUseCase.swift
@@ -19,7 +19,7 @@ final class DefaultFriendUseCase: FriendUseCase {
         return repository.follow(at: nickname)
     }
     
-    func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
+    func search(at nickname: String) -> AnyPublisher<String?, NetworkError> {
         return repository.search(at: nickname)
     }
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultSocialUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultSocialUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  DefaultSocialUseCase.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/30.
+//
+
+import Foundation
+import Combine
+
+final class DefaultSocialUseCase: SocialUseCase {
+    private let repsoitory: SocialRepository
+    
+    init(repsoitory: SocialRepository) {
+        self.repsoitory = repsoitory
+    }
+    
+    func getMyFriend(date: Date) -> AnyPublisher<[Friend], NetworkError> {
+        return repsoitory.getMyFriend(date: date)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/FriendUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/FriendUseCase.swift
@@ -10,5 +10,5 @@ import Combine
 
 protocol FriendUseCase {
     func follow(at nickname: String) -> AnyPublisher<String, NetworkError>
-    func search(at nickname: String) -> AnyPublisher<String, NetworkError>
+    func search(at nickname: String) -> AnyPublisher<String?, NetworkError>
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/SocialUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/SocialUseCase.swift
@@ -1,0 +1,14 @@
+//
+//  SocialUseCase.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/30.
+//
+
+import Foundation
+import Combine
+
+protocol SocialUseCase {
+    func getMyFriend(date: Date) -> AnyPublisher<[Friend], NetworkError>
+}
+

--- a/iOS/FlipMate/FlipMate/PersistenceService/UserInfoStorage.swift
+++ b/iOS/FlipMate/FlipMate/PersistenceService/UserInfoStorage.swift
@@ -1,0 +1,15 @@
+//
+//  UserInfoStorage.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/01.
+//
+
+import Foundation
+
+struct UserInfoStorage {
+    @UserDefault(key: "nickname", defaultValue: "")
+    static var nickname: String
+    @UserDefault(key: "imageData", defaultValue: Data.init())
+    static var imageData: Data?
+}

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -71,6 +71,7 @@ final class SignUpViewModel: SignUpViewModelProtocol {
             do {
                 try await useCase.signUpUser(nickName: userName, profileImageData: profileImageData)
                 isSignUpCompletedSubject.send()
+                UserInfoStorage.nickname = userName
                 DispatchQueue.main.async {
                     self.actions?.didFinishSignUp()
                 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/FriendSearchItem.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/FriendSearchItem.swift
@@ -1,0 +1,13 @@
+//
+//  FriendSearchItem.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/30.
+//
+
+import Foundation
+
+struct FreindSeacrhItem {
+    let nickname: String
+    let iamgeURL: String?
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/FriendUser.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/FriendUser.swift
@@ -15,5 +15,5 @@ struct FriendUser: Hashable {
     let profileImageURL: String?
     let name: String
     let time: Int?
-    var isOnline: Bool
+    var isStuding: Bool
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/FriendUser.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/FriendUser.swift
@@ -1,0 +1,19 @@
+//
+//  FriendUser.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/11/30.
+//
+
+import Foundation
+
+enum Section: CaseIterable {
+    case main
+}
+
+struct FriendUser: Hashable {
+    let profileImageURL: String?
+    let name: String
+    let time: Int?
+    var isOnline: Bool
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
@@ -78,8 +78,9 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
         return Constant.height
     }
     
-    func updateUI(friend: Friend) {
-        self.nickNameLabel.text = friend.nickName
+    func updateUI(friendSearchItem: FreindSeacrhItem) {
+        nickNameLabel.text = friendSearchItem.nickname
+        profileImageView.image = UIImage(resource: .defaultProfile)
     }
     
     func tapPublisher() -> AnyPublisher<Void, Never> {

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendsCollectionViewCell.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendsCollectionViewCell.swift
@@ -86,21 +86,13 @@ final class FriendsCollectionViewCell: UICollectionViewCell {
     }
     
     func configure(friend: FriendUser) {
-        var image: UIImage!
+        // TODO: - 이미지 캐싱
+        let image = UIImage(resource: .defaultProfile)
+        profileImageView.image = image
+        userNameLabel.text = friend.name
+        learningTimeLabel.text = friend.time?.secondsToStringTime()
+        profileImageView.layer.borderColor = friend.isOnline ? UIColor.green.cgColor : UIColor.red.cgColor
         
-        if let url = URL(string: friend.profileImageURL), let data = try? Data(contentsOf: url) {
-            image = UIImage(data: data)
-        } else {
-            // url 오류 있으면 기본 이미지 보여주기
-            image = UIImage(resource: .defaultProfile)
-        }
-        
-        DispatchQueue.main.async {
-            self.profileImageView.image = image
-            self.userNameLabel.text = friend.name
-            self.learningTimeLabel.text = friend.time
-            self.profileImageView.layer.borderColor = friend.isOnline ? UIColor.green.cgColor : UIColor.red.cgColor
-        }
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendsCollectionViewCell.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendsCollectionViewCell.swift
@@ -91,7 +91,7 @@ final class FriendsCollectionViewCell: UICollectionViewCell {
         profileImageView.image = image
         userNameLabel.text = friend.name
         learningTimeLabel.text = friend.time?.secondsToStringTime()
-        profileImageView.layer.borderColor = friend.isOnline ? UIColor.green.cgColor : UIColor.red.cgColor
+        profileImageView.layer.borderColor = friend.isStuding ? UIColor.green.cgColor : UIColor.red.cgColor
         
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
@@ -126,9 +126,9 @@ final class FriendAddViewController: BaseViewController {
     override func bind() {
         viewModel.searchFreindPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] friend in
+            .sink { [weak self] friendSearchItem in
                 guard let self = self else { return }
-                self.friendSearchResultView.updateUI(friend: friend)
+                self.friendSearchResultView.updateUI(friendSearchItem: friendSearchItem)
                 self.updateResultView(friendSearchResultView)
             }
             .store(in: &cancellables)

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
@@ -169,7 +169,7 @@ final class SocialViewController: BaseViewController {
                     profileImageURL: $0.profileImageURL,
                     name: $0.nickName,
                     time: $0.totalTime,
-                    isOnline: true)}
+                    isStuding: $0.isStuding)}
                 )
                 self.diffableDataSource.apply(snapshot, animatingDifferences: true)
             }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
@@ -6,17 +6,7 @@
 //
 
 import UIKit
-
-enum Section: CaseIterable {
-    case main
-}
-
-struct FriendUser: Hashable {
-    let profileImageURL: String
-    let name: String
-    let time: String
-    var isOnline: Bool
-}
+import Combine
 
 final class SocialViewController: BaseViewController {
     
@@ -71,6 +61,7 @@ final class SocialViewController: BaseViewController {
     // MARK: - Properties
     typealias DiffableDataSource = UICollectionViewDiffableDataSource<Section, FriendUser>
     private var diffableDataSource: DiffableDataSource!
+    private var cancellables = Set<AnyCancellable>()
     private let viewModel: SocialViewModelProtocol
     
     // MARK: - init
@@ -86,26 +77,19 @@ final class SocialViewController: BaseViewController {
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = Constant.title
         configureDiffableDataSource()
-        // TODO: 테스트를 위한 임시 데이터 지우고 뷰모델과 연동하기
-        let items = [
-            FriendUser(profileImageURL: "", name: "hid", time: "17:00", isOnline: true),
-            FriendUser(profileImageURL: "", name: "hie", time: "17:00", isOnline: true),
-            FriendUser(profileImageURL: "", name: "hif", time: "17:00", isOnline: true),
-            FriendUser(profileImageURL: "", name: "hix", time: "17:00", isOnline: true),
-            FriendUser(profileImageURL: "", name: "hiz", time: "17:00", isOnline: true),
-            FriendUser(profileImageURL: "", name: "hiy", time: "17:00", isOnline: true)
-        ]
-        var snapshot = NSDiffableDataSourceSnapshot<Section, FriendUser>()
-        snapshot.appendSections([.main])
-        snapshot.appendItems(items)
-        self.diffableDataSource.apply(snapshot, animatingDifferences: true)
         configureNavigationBarItems()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.viewWillAppear()
     }
         
     // MARK: - Configure UI
     override func configureUI() {
+        title = Constant.title
+        
         let subviews = [
             profileImageView,
             userNameLabel,
@@ -170,6 +154,24 @@ final class SocialViewController: BaseViewController {
         addFriendButton.tintColor = .label
         navigationItem.leftBarButtonItem = myPageButton
         navigationItem.rightBarButtonItem = addFriendButton
+    }
+    
+    override func bind() {
+        viewModel.freindsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] friends in
+                guard let self = self else { return }
+                var snapshot = NSDiffableDataSourceSnapshot<Section, FriendUser>()
+                snapshot.appendSections([.main])
+                snapshot.appendItems(friends.map { FriendUser(
+                    profileImageURL: $0.profileImageURL,
+                    name: $0.nickName,
+                    time: $0.totalTime,
+                    isOnline: true)}
+                )
+                self.diffableDataSource.apply(snapshot, animatingDifferences: true)
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
@@ -157,6 +157,8 @@ final class SocialViewController: BaseViewController {
     }
     
     override func bind() {
+        viewModel.viewDidLoad()
+        
         viewModel.freindsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] friends in
@@ -170,6 +172,14 @@ final class SocialViewController: BaseViewController {
                     isOnline: true)}
                 )
                 self.diffableDataSource.apply(snapshot, animatingDifferences: true)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.nicknamePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] nickname in
+                guard let self = self else { return }
+                self.userNameLabel.text = nickname
             }
             .store(in: &cancellables)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
@@ -31,20 +31,18 @@ typealias FriendAddViewModelProtocol = FriendAddViewModelInput & FriendAddViewMo
 
 final class FriendAddViewModel: FriendAddViewModelProtocol {
     // MARK: - Subject
-    private lazy var myNicknameSubject = CurrentValueSubject<String, Never>(myNickname)
+    private lazy var myNicknameSubject = CurrentValueSubject<String, Never>(UserInfoStorage.nickname)
     private var searchResultSubject = PassthroughSubject<FreindSeacrhItem, Never>()
     private var searchErrorSubject = PassthroughSubject<Void, Never>()
     private var nicknameCountSubject = PassthroughSubject<Int, Never>()
     
     // MARK: - Properties
     private var cancellables = Set<AnyCancellable>()
-    private let myNickname: String
     private var friendNickname: String = ""
     private let friendUseCase: FriendUseCase
     private let actions: FriendAddViewModelActions?
     
-    init(myNickname: String, friendUseCase: FriendUseCase, actions: FriendAddViewModelActions? = nil) {
-        self.myNickname = myNickname
+    init(friendUseCase: FriendUseCase, actions: FriendAddViewModelActions? = nil) {
         self.friendUseCase = friendUseCase
         self.actions = actions
     }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
@@ -22,7 +22,7 @@ protocol FriendAddViewModelInput {
 
 protocol FriendAddViewModelOutput {
     var myNicknamePublihser: AnyPublisher<String, Never> { get }
-    var searchFreindPublisher: AnyPublisher<Friend, Never> { get }
+    var searchFreindPublisher: AnyPublisher<FreindSeacrhItem, Never> { get }
     var searchErrorPublisher: AnyPublisher<Void, Never> { get }
     var nicknameCountPublisher: AnyPublisher<Int, Never> { get }
 }
@@ -32,7 +32,7 @@ typealias FriendAddViewModelProtocol = FriendAddViewModelInput & FriendAddViewMo
 final class FriendAddViewModel: FriendAddViewModelProtocol {
     // MARK: - Subject
     private lazy var myNicknameSubject = CurrentValueSubject<String, Never>(myNickname)
-    private var searchResultSubject = PassthroughSubject<Friend, Never>()
+    private var searchResultSubject = PassthroughSubject<FreindSeacrhItem, Never>()
     private var searchErrorSubject = PassthroughSubject<Void, Never>()
     private var nicknameCountSubject = PassthroughSubject<Int, Never>()
     
@@ -50,7 +50,7 @@ final class FriendAddViewModel: FriendAddViewModelProtocol {
     }
     
     // MARK: - output
-    var searchFreindPublisher: AnyPublisher<Friend, Never> {
+    var searchFreindPublisher: AnyPublisher<FreindSeacrhItem, Never> {
         return searchResultSubject.eraseToAnyPublisher()
     }
     
@@ -98,7 +98,10 @@ final class FriendAddViewModel: FriendAddViewModelProtocol {
                 }
             } receiveValue: { [weak self] profileimageURL in
                 guard let self = self else { return }
-                self.searchResultSubject.send(Friend(nickName: friendNickname, profileImageURL: profileimageURL))
+                self.searchResultSubject.send(FreindSeacrhItem(
+                    nickname: friendNickname,
+                    iamgeURL: profileimageURL)
+                )
             }
             .store(in: &cancellables)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
@@ -13,24 +13,56 @@ struct SocialViewModelActions {
 }
 
 protocol SocialViewModelInput {
+    func viewWillAppear()
     func freindAddButtonDidTapped()
 }
 
 protocol SocialViewModelOutput {
-    
+    var freindsPublisher: AnyPublisher<[Friend], Never> { get }
 }
 
 typealias SocialViewModelProtocol = SocialViewModelInput & SocialViewModelOutput
 
 final class SocialViewModel: SocialViewModelProtocol {
+    // MARK: - Subject
+    private var freindsSubject = PassthroughSubject<[Friend], Never>()
     
+    // MARK: - Properties
+    private var cancellables = Set<AnyCancellable>()
     private let actions: SocialViewModelActions?
+    private let socialUseCase: SocialUseCase
     
-    init(actions: SocialViewModelActions? = nil) {
+    // MARK: - init
+    init(actions: SocialViewModelActions? = nil, socialUseCase: SocialUseCase) {
         self.actions = actions
+        self.socialUseCase = socialUseCase
     }
     
+    // MARK: - Output
+    var freindsPublisher: AnyPublisher<[Friend], Never> {
+        return freindsSubject.eraseToAnyPublisher()
+    }
+    
+    // MARK: - Input
     func freindAddButtonDidTapped() {
         actions?.showFriendAddViewController()
+    }
+    
+    func viewWillAppear() {
+        socialUseCase.getMyFriend(date: Date())
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    FMLogger.friend.debug("친구 받아오기 성공")
+                case .failure(let error):
+                    FMLogger.friend.error("친구 받아오기 에러 발생 \(error)")
+                }
+            } receiveValue: { [weak self] freinds in
+                guard let self = self else { return }
+                self.freindsSubject.send(freinds)
+            }
+            .store(in: &cancellables)
+
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -66,7 +66,7 @@ final class TabBarFlowCoordinator: Coordinator {
         navigationViewController.tabBarItem.image = UIImage(
             systemName: Constant.chartNomalImageName)
         navigationViewController.tabBarItem.selectedImage = UIImage(
-            systemName: Constant.socialSelectedImageName)
+            systemName: Constant.chartSelectedImageName)
         return navigationViewController
     }
     

--- a/iOS/FlipMate/FlipMateUseCaseTests/Mock/MockFriendRepository.swift
+++ b/iOS/FlipMate/FlipMateUseCaseTests/Mock/MockFriendRepository.swift
@@ -31,7 +31,7 @@ final class MockFriendRepository: FriendRepository {
         }
     }
     
-    func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
+    func search(at nickname: String) -> AnyPublisher<String?, NetworkError> {
         if responseType == .success {
             let response = UserProfileResposeDTO(profileImageURL: "https://flipmate.site:3000")
             return Just(response.profileImageURL).eraseToAnyPublisher()

--- a/iOS/FlipMate/FlipMateViewModelTests/Mock/MockFriendUseCase.swift
+++ b/iOS/FlipMate/FlipMateViewModelTests/Mock/MockFriendUseCase.swift
@@ -15,7 +15,7 @@ enum ResponseType {
 
 final class MockFriendUseCase: FriendUseCase {
     private var followSubject = CurrentValueSubject<String, NetworkError>("success")
-    private var searchSubject = CurrentValueSubject<String, NetworkError>("https://flipmate.site:3000")
+    private var searchSubject = CurrentValueSubject<String?, NetworkError>("https://flipmate.site:3000")
     
     private var type: ResponseType
     
@@ -35,7 +35,7 @@ final class MockFriendUseCase: FriendUseCase {
         return followSubject.eraseToAnyPublisher()
     }
     
-    func search(at nickname: String) -> AnyPublisher<String, NetworkError> {
+    func search(at nickname: String) -> AnyPublisher<String?, NetworkError> {
         if type == .failure {
             return Fail(error: NetworkError.statusCodeError).eraseToAnyPublisher()
         }


### PR DESCRIPTION
closed #289 
## 완료된 기능
- UserDefault구조체 propertyWrapper와 Publisher을 사용해 구현
- 회원가입 시 닉네임 UseDefault로 저장 (아직 로그인시에 저장은 구현을 못했슴다)
- UseDefault에 저장된 닉네임 필요한 화면에 바인딩
- 소셜 화면 viewDidAppear시 친구 상태 API 호출해서 화면에 바인딩

## 실행 결과
https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/17de5d2e-7a27-4642-886c-7c4dbf80cf58

## 고민과 해결과정
### propertyWrapper와 Publisher을 사용한 편리한 UserDefault 만들기
UserDefault을 Combine을 통해 값을 바인딩 할 수 있는 방법이 없을까 생각하다가
문득 JK님의 마스터 클래스 강의에서 들었던 propertyWrapper을 사용하여 
UserDefault을 읽고 쓸때 get, set을 이용해 편하게 사용하는 방법이 떠올라
Publisher까지 추가하여 바인딩할 수 있도록 구현해봤습니다!
그러나,,, 해당 방식대로 구현하게 되면 Repository <-> Storage을 통해 읽고, 저장하는 방법이 아니라 
아마 추후에 레이어 분리하면서 수정하게 될 것 같습니다 ㅜ



