### PR TITLE
[BE#308] 일간 통계 기능 구현

### DIFF
--- a/BE/src/study-logs/dto/response/daily-stat.dto.ts
+++ b/BE/src/study-logs/dto/response/daily-stat.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CategoryDto } from 'src/categories/dto/response/category.dto';
+
+export class dailyStatDto {
+  @ApiProperty({
+    type: 'number',
+    example: 10000,
+    description: '해당 날짜의 총 학습 시간',
+  })
+  total_time: number;
+
+  @ApiProperty({
+    type: Array(CategoryDto),
+    description: '학습 한 카테고리들',
+  })
+  categories: object[];
+
+  @ApiProperty({
+    type: 'number',
+    example: '3',
+    description: '해당 날짜에 유저의 학습 시간이 전체 유저 중 상위 몇 %인지',
+  })
+  percentage: number;
+}

--- a/BE/src/study-logs/study-logs.service.ts
+++ b/BE/src/study-logs/study-logs.service.ts
@@ -15,6 +15,8 @@ export class StudyLogsService {
   constructor(
     @InjectRepository(StudyLogs)
     private studyLogsRepository: Repository<StudyLogs>,
+    @InjectRepository(UsersModel)
+    private usersRepository: Repository<UsersModel>,
     private redisService: RedisService,
   ) {}
 
@@ -134,7 +136,8 @@ export class StudyLogsService {
       [date],
     );
     const rank = result.findIndex((user) => user.user_id === userId) + 1;
-    return (rank / result.length) * 100;
+    const userCount = await this.usersRepository.count();
+    return (rank / userCount) * 100;
   }
 
   entityToDto(studyLog: StudyLogs): StudyLogsDto {

--- a/BE/src/study-logs/study-logs.service.ts
+++ b/BE/src/study-logs/study-logs.service.ts
@@ -122,6 +122,21 @@ export class StudyLogsService {
     this.studyLogsRepository.delete({ user_id: { id: id } });
   }
 
+  async calculatePercentage(userId: number, date: string): Promise<number> {
+    const result = await this.studyLogsRepository.query(
+      `
+      SELECT user_id, SUM(learning_time) AS total_time
+      FROM study_logs
+      WHERE date = ?
+      GROUP BY user_id
+      ORDER BY total_time DESC;
+    `,
+      [date],
+    );
+    const rank = result.findIndex((user) => user.user_id === userId) + 1;
+    return (rank / result.length) * 100;
+  }
+
   entityToDto(studyLog: StudyLogs): StudyLogsDto {
     const { id, date, created_at, type, learning_time, user_id, category_id } =
       studyLog;


### PR DESCRIPTION
# 이슈번호-작업이름
close #308

## 완료된 기능
- 일간 통계 기능 구현

## 고민과 해결과정
학습 시간과 카테고리 가져오는 건 기존 서비스 코드 사용했고, 랭킹? 구하는 건 쿼리로 쉬워서 바로 됐습니다

```sql
      SELECT user_id, SUM(learning_time) AS total_time
      FROM study_logs
      WHERE date = ?
      GROUP BY user_id
      ORDER BY total_time DESC;
```
위 쿼리로 유저 별 학습 시간 찾은 다음에

```ts
    const rank = result.findIndex((user) => user.user_id === userId) + 1;
    const userCount = await this.usersRepository.count();
    return (rank / userCount) * 100;
```
유저 아이디 인덱스를 이용해서 전체 유저 중 몇 등인지 계산하는 방식으로 했습니다
