### PR TITLE
[BE#314] 카테고리, 친구 추가 최대 수 제한

### DIFF
--- a/BE/src/categories/categories.service.spec.ts
+++ b/BE/src/categories/categories.service.spec.ts
@@ -93,6 +93,8 @@ describe('CategoriesService', () => {
         BadRequestException,
       );
     });
+
+    it.todo('카테고리는 최대 10개까지 추가할 수 있다');
   });
 
   describe('.findByUserId()', () => {

--- a/BE/src/categories/categories.service.ts
+++ b/BE/src/categories/categories.service.ts
@@ -31,6 +31,15 @@ export class CategoriesService {
       throw new NotFoundException('해당 id의 유저가 존재하지 않습니다.');
     }
 
+    const categoryCount = await this.categoriesRepository.count({
+      where: { user_id: { id: user.id } },
+    });
+    if (categoryCount >= 10) {
+      throw new BadRequestException(
+        '카테고리는 최대 10개까지 생성할 수 있습니다.',
+      );
+    }
+
     const category = this.categoriesRepository.create({
       ...categoriesData,
       user_id: user,

--- a/BE/src/mates/mates.service.spec.ts
+++ b/BE/src/mates/mates.service.spec.ts
@@ -73,6 +73,8 @@ describe('MatesService', () => {
       });
     });
 
+    it.todo('친구는 최대 10명까지 추가할 수 있다.');
+
     it('자신을 친구 추가 할 수 없다.', async () => {
       expect(service.addMate(user, '어린콩')).rejects.toThrow(
         BadRequestException,

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -110,6 +110,14 @@ export class MatesService {
       throw new NotFoundException('해당 유저는 존재하지 않습니다.');
     }
 
+    const matesCount = await this.matesRepository.count({
+      where: { follower_id: user },
+    });
+
+    if (matesCount >= 10) {
+      throw new BadRequestException('친구는 최대 10명까지 추가할 수 있습니다.');
+    }
+
     const isExist = await this.matesRepository.findOne({
       where: { follower_id: user, following_id: following },
     });


### PR DESCRIPTION
# 이슈번호-작업이름
close #314 
## 완료된 기능
- 카테고리 최대 수 제한
- 친구 추가 최대 수 제한

## 고민과 해결과정
```ts
    const matesCount = await this.matesRepository.count({
      where: { follower_id: user },
    });

    if (matesCount >= 10) {
      throw new BadRequestException('친구는 최대 10명까지 추가할 수 있습니다.');
    }
```
이런 식으로 해당 유저의 친구 수가 10명 이상이면 예외 처리 했습니다
카테고리도 같은 방식이에요