### PR TITLE
[iOS#312] 카테고리 뷰 네비게이션 타이틀 추가

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
@@ -93,7 +93,7 @@ final class SocialViewController: BaseViewController {
     
     // MARK: - Configure UI
     override func configureUI() {
-        title = Constant.title
+        navigationItem.title = Constant.title
         
         let subviews = [
             profileImageView,

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -52,6 +52,7 @@ final class CategorySettingViewController: BaseViewController {
     
     // MARK: - Configure UI
     override func configureUI() {
+        title = Constant.title
         view.addSubview(collectionView)
         
         NSLayoutConstraint.activate([
@@ -224,5 +225,11 @@ private extension CategorySettingViewController {
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         
         return [deleteAction, cancelAction]
+    }
+}
+
+private extension CategorySettingViewController {
+    enum Constant {
+        static let title = "카테고리 관리"
     }
 }


### PR DESCRIPTION
close #312 

## 완료된 기능
- 카테고리 뷰 네비게이션 타이틀 추가
- 소셜 뷰 탭 바 타이틀 제거

## 고민과 해결과정
- 타이머 뷰에도 네비게이션 타이틀을 추가해 보았었는데, 시간 크기에 비해 타이틀 크기가 너무 작아 이상해서 빼버렸습니다.
- 소셜 뷰의 탭 바 타이틀이 없는 것이 낫다고 생각해 제외해 보았습니다.
  - 아이폰 SE에서의 위치 문제 포함