### PR TITLE
[iOS#328] actor을 활용한 이미지 캐싱 구현

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -50,6 +50,10 @@
 		2C87C2812B1DF2C000A26313 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2802B1DF2C000A26313 /* UserInfo.swift */; };
 		2C87C2832B1DF30E00A26313 /* UserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2822B1DF30E00A26313 /* UserInfoUseCase.swift */; };
 		2C87C2852B1DF32A00A26313 /* DefaultUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2842B1DF32A00A26313 /* DefaultUserInfoUseCase.swift */; };
+		2C87C2912B1F212200A26313 /* ImageDownLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2902B1F212200A26313 /* ImageDownLoader.swift */; };
+		2C87C2932B1F344500A26313 /* UIImageView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2922B1F344500A26313 /* UIImageView++Extension.swift */; };
+		2C87C2952B1F345800A26313 /* ImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2942B1F345800A26313 /* ImageFetcher.swift */; };
+		2C87C2972B1F346700A26313 /* ImageDownLoaderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2962B1F346700A26313 /* ImageDownLoaderError.swift */; };
 		2C88DCF22B124238000B4686 /* AppFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCF12B124238000B4686 /* AppFlowCoordinator.swift */; };
 		2C88DCF42B124272000B4686 /* AppDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCF32B124272000B4686 /* AppDIContainer.swift */; };
 		2C88DCF62B124292000B4686 /* TimerSceneDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88DCF52B124292000B4686 /* TimerSceneDIContainer.swift */; };
@@ -276,6 +280,10 @@
 		2C87C2802B1DF2C000A26313 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		2C87C2822B1DF30E00A26313 /* UserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoUseCase.swift; sourceTree = "<group>"; };
 		2C87C2842B1DF32A00A26313 /* DefaultUserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultUserInfoUseCase.swift; sourceTree = "<group>"; };
+		2C87C2902B1F212200A26313 /* ImageDownLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownLoader.swift; sourceTree = "<group>"; };
+		2C87C2922B1F344500A26313 /* UIImageView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView++Extension.swift"; sourceTree = "<group>"; };
+		2C87C2942B1F345800A26313 /* ImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFetcher.swift; sourceTree = "<group>"; };
+		2C87C2962B1F346700A26313 /* ImageDownLoaderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownLoaderError.swift; sourceTree = "<group>"; };
 		2C88DCF12B124238000B4686 /* AppFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlowCoordinator.swift; sourceTree = "<group>"; };
 		2C88DCF32B124272000B4686 /* AppDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainer.swift; sourceTree = "<group>"; };
 		2C88DCF52B124292000B4686 /* TimerSceneDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerSceneDIContainer.swift; sourceTree = "<group>"; };
@@ -613,6 +621,16 @@
 				2C87C2762B1C789A00A26313 /* FriendStatusPollingManager.swift */,
 			);
 			path = FriendStatusPollingManager;
+			sourceTree = "<group>";
+		};
+		2C87C28F2B1F210F00A26313 /* ImageDownloader */ = {
+			isa = PBXGroup;
+			children = (
+				2C87C2902B1F212200A26313 /* ImageDownLoader.swift */,
+				2C87C2942B1F345800A26313 /* ImageFetcher.swift */,
+				2C87C2962B1F346700A26313 /* ImageDownLoaderError.swift */,
+			);
+			path = ImageDownloader;
 			sourceTree = "<group>";
 		};
 		2C88DCF72B1242C7000B4686 /* Flows */ = {
@@ -1025,6 +1043,7 @@
 		600908FE2AFCDF8D0065DFFB /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				2C87C28F2B1F210F00A26313 /* ImageDownloader */,
 				2C87C2752B1C788700A26313 /* FriendStatusPollingManager */,
 				60DFDDDC2B16383900FEF98A /* NickNameValidator */,
 				2C9F61F52B14EA9800AE63F9 /* CategoryManager */,
@@ -1045,6 +1064,7 @@
 				2C3430B02B0DE3D0008CBC85 /* Date++Extension.swift */,
 				2CE84EFA2B0B92BA00E2FB71 /* UICollectionReusableView++Extension.swift */,
 				ED6865A32B1649ED001A2AAD /* String++Extension.swift */,
+				2C87C2922B1F344500A26313 /* UIImageView++Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1560,6 +1580,7 @@
 				2CDCD0482B18893A0080DCDE /* SocialRepository.swift in Sources */,
 				601EB73D2B14D67600C5B216 /* SignUpUseCase.swift in Sources */,
 				608646572B0DE31800B0C1BC /* CategoryResponseDTO.swift in Sources */,
+				2C87C2952B1F345800A26313 /* ImageFetcher.swift in Sources */,
 				ED38421F2B0F1C7A001E2803 /* GoogleAuthResponseDTO.swift in Sources */,
 				ED6865BF2B1E2FA6001A2AAD /* ChartSegmentedControl.swift in Sources */,
 				ED3595B22B0C83D700558FAA /* TimerStartResponseDTO.swift in Sources */,
@@ -1643,12 +1664,14 @@
 				60DFDDD92B14FD7800FEF98A /* StatusResponseWithErrorDTO.swift in Sources */,
 				2C2F21762B0F440D00B45BA8 /* StudyLogEndpoints.swift in Sources */,
 				ED6865BD2B1DEE3D001A2AAD /* DailyChartView.swift in Sources */,
+				2C87C2932B1F344500A26313 /* UIImageView++Extension.swift in Sources */,
 				601EB73B2B148F9A00C5B216 /* SignUpViewModel.swift in Sources */,
 				2C5E34BE2B1B51CB00FD481B /* FriendStatus.swift in Sources */,
 				2C87C2812B1DF2C000A26313 /* UserInfo.swift in Sources */,
 				ED6865CA2B1E454E001A2AAD /* DefaultChartRepository.swift in Sources */,
 				ED6865A42B1649ED001A2AAD /* String++Extension.swift in Sources */,
 				2C87C2772B1C789A00A26313 /* FriendStatusPollingManager.swift in Sources */,
+				2C87C2912B1F212200A26313 /* ImageDownLoader.swift in Sources */,
 				ED6865C62B1E438B001A2AAD /* ChartEndpoints.swift in Sources */,
 				2C88DD0F2B14C22C000B4686 /* TimerFinishViewModel.swift in Sources */,
 				2C4D55B32B035484006D7C26 /* DeviceOrientation.swift in Sources */,
@@ -1689,6 +1712,7 @@
 				60DFDDDB2B14FE0100FEF98A /* SignUpResponseDTO.swift in Sources */,
 				ED38421B2B0F1B7E001E2803 /* GoogleAuthRequestDTO.swift in Sources */,
 				2C9F62242B173ADA00AE63F9 /* UserProfileResposeDTO.swift in Sources */,
+				2C87C2972B1F346700A26313 /* ImageDownLoaderError.swift in Sources */,
 				EDC851D92B05C37C009031EA /* DeviceMotionManager.swift in Sources */,
 				2C9F62262B1742D200AE63F9 /* FriendEndpoints.swift in Sources */,
 				ED6865CE2B1E49A6001A2AAD /* DefaultChartUseCase.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
@@ -40,9 +40,10 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
     // MARK: - UI Components
     private lazy var profileImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
+        imageView.contentMode = .scaleAspectFill
         imageView.backgroundColor = FlipMateColor.gray2.color
         imageView.layer.cornerRadius = ProfileImageConstant.cornerRadius
+        imageView.clipsToBounds = true
         return imageView
     }()
     
@@ -79,7 +80,7 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
     
     func updateUI(friendSearchItem: FreindSeacrhItem) {
         nickNameLabel.text = friendSearchItem.nickname
-        profileImageView.image = UIImage(resource: .defaultProfile)
+        profileImageView.setImage(url: friendSearchItem.iamgeURL)
     }
     
     func tapPublisher() -> AnyPublisher<Void, Never> {

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendsCollectionViewCell.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendsCollectionViewCell.swift
@@ -108,8 +108,7 @@ final class FriendsCollectionViewCell: UICollectionViewCell {
     
     func configure(friend: Friend) {
         // TODO: - 이미지 캐싱
-        let image = UIImage(resource: .defaultProfile)
-        profileImageView.image = image
+        profileImageView.setImage(url: friend.profileImageURL)
         userNameLabel.text = friend.nickName
         learningTimeLabel.text = friend.totalTime.secondsToStringTime()
         profileImageView.layer.borderColor = friend.isStuding ? UIColor.green.cgColor : UIColor.red.cgColor

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialDetailViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialDetailViewController.swift
@@ -275,6 +275,7 @@ final class SocialDetailViewController: BaseViewController {
                 guard let self = self else { return }
                 self.nickNameLabel.text = friend.nickName
                 self.dailyStudyTimeLabel.text = friend.totalTime.secondsToStringTime()
+                self.profileImageView.setImage(url: friend.profileImageURL)
             }
             .store(in: &cancellables)
         

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialDetailViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialDetailViewController.swift
@@ -59,6 +59,7 @@ final class SocialDetailViewController: BaseViewController {
         imageView.contentMode = .scaleAspectFill
         imageView.backgroundColor = FlipMateColor.gray2.color
         imageView.layer.cornerRadius = LayoutConstant.profileImageWidth / 2
+        imageView.clipsToBounds = true
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
         return imageView

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
@@ -190,6 +190,14 @@ final class SocialViewController: BaseViewController {
             }
             .store(in: &cancellables)
         
+        viewModel.profileImagePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] imageURL in
+                guard let self = self else { return }
+                self.profileImageView.setImage(url: imageURL)
+            }
+            .store(in: &cancellables)
+        
         viewModel.updateFriendStatus
             .receive(on: DispatchQueue.main)
             .sink { [weak self] updateFreinds in

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
@@ -24,6 +24,7 @@ protocol SocialViewModelInput {
 protocol SocialViewModelOutput {
     var freindsPublisher: AnyPublisher<[Friend], Never> { get }
     var nicknamePublisher: AnyPublisher<String, Never> { get }
+    var profileImagePublisher: AnyPublisher<String, Never> { get }
     var updateFriendStatus: AnyPublisher<[UpdateFriend], Never> { get }
     var stopFriendStatus: AnyPublisher<[StopFriend], Never> { get }
 }
@@ -34,6 +35,7 @@ final class SocialViewModel: SocialViewModelProtocol {
     // MARK: - Subject
     private var freindsSubject = PassthroughSubject<[Friend], Never>()
     private var nicknameSubject = CurrentValueSubject<String, Never>(UserInfoStorage.nickname)
+    private var profileImageSubject = CurrentValueSubject<String, Never>(UserInfoStorage.profileImageURL)
     private var updateFriendSubject = PassthroughSubject<[UpdateFriend], Never>()
     private var stopFriendSubject = PassthroughSubject<[StopFriend], Never>()
     
@@ -59,6 +61,10 @@ final class SocialViewModel: SocialViewModelProtocol {
     
     var nicknamePublisher: AnyPublisher<String, Never> {
         return nicknameSubject.eraseToAnyPublisher()
+    }
+    
+    var profileImagePublisher: AnyPublisher<String, Never> {
+        return profileImageSubject.eraseToAnyPublisher()
     }
     
     var updateFriendStatus: AnyPublisher<[UpdateFriend], Never> {
@@ -152,6 +158,13 @@ private extension SocialViewModel {
             .sink { [weak self] nickName in
                 guard let self = self else { return }
                 self.nicknameSubject.send(nickName)
+            }
+            .store(in: &cancellables)
+        
+        UserInfoStorage.$profileImageURL
+            .sink { [weak self] profileImageURL in
+                guard let self = self else { return }
+                self.profileImageSubject.send(profileImageURL)
             }
             .store(in: &cancellables)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/UIImageView++Extension.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/UIImageView++Extension.swift
@@ -1,0 +1,29 @@
+//
+//  UIImageView++Extension.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/05.
+//
+
+import UIKit
+
+extension UIImageView {
+    func downLoadImage(with url: String) async throws {
+        let image = try await ImageDownLoader.shared.image(from: url)
+        self.image = image
+    }
+    
+    func setImage(url: String?) {
+        Task {
+            do {
+                guard let imageURL = url else {
+                    self.image = UIImage(resource: .defaultProfile)
+                    return
+                }
+                try await self.downLoadImage(with: imageURL)
+            } catch {
+                self.image = UIImage(resource: .defaultProfile)
+            }
+        }
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/ImageDownloader/ImageDownLoader.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/ImageDownloader/ImageDownLoader.swift
@@ -1,0 +1,35 @@
+//
+//  ImageDownLoader.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/05.
+//
+
+import UIKit
+
+actor ImageDownLoader {
+    static let shared = ImageDownLoader()
+    private init() {}
+    
+    private var cache: [URL: UIImage] = [:]
+    
+    func image(from urlPath: String) async throws -> UIImage? {
+        guard let url = URL(string: urlPath) else { throw ImageDownLoaderError.invalidURLString }
+                
+        if let cached = cache[url] {
+            return cached
+        }
+        
+        let image = try await downloadImage(from: url)
+        
+        cache[url] = cache[url, default: image]
+        
+        return cache[url]
+        
+    }
+    
+    private func downloadImage(from url: URL) async throws -> UIImage {
+        let imageFetchProvider = ImageFetcher.shared
+        return try await imageFetchProvider.fetchImage(with: url)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/ImageDownloader/ImageDownLoaderError.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/ImageDownloader/ImageDownLoaderError.swift
@@ -1,0 +1,22 @@
+//
+//  ImageDownLoaderError.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/05.
+//
+
+import Foundation
+
+enum ImageDownLoaderError: LocalizedError {
+    case invalidURLString
+    case unSupportImage
+    case statusCodeError
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidURLString: return "형식에 맞지 않는 URL입니다."
+        case .unSupportImage: return "지원하지 않는 이미지 형식입니다."
+        case .statusCodeError: return "상태 코드 범위 비정상"
+        }
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/ImageDownloader/ImageFetcher.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/ImageDownloader/ImageFetcher.swift
@@ -1,0 +1,26 @@
+//
+//  ImageFetcher.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/05.
+//
+
+import UIKit
+
+struct ImageFetcher {
+    static let shared = ImageFetcher()
+    private init() {}
+    
+    func fetchImage(with url: URL) async throws -> UIImage {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw ImageDownLoaderError.statusCodeError
+        }
+        
+        guard let image = UIImage(data: data) else {
+            throw ImageDownLoaderError.unSupportImage
+        }
+        
+        return image
+    }
+}


### PR DESCRIPTION
closed #328 

## 완료된 기능
- ImageFetcher 구현
- ImageDownLoader 구현
- 본일 프로필 사진 이미지 보이도록 수정
- 소셜 화면 친구 이미지, 상세화면 이미지 캐싱 적용

## 실행 결과
https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/72a83f6e-0b25-4bf2-9d8f-77c6de025a1a

## 고민과 해결과정
### Actor 활용
[WWDC2021 - actor](https://developer.apple.com/videos/play/wwdc2021/10133/)
위의 WWDC 세션을 참고하여 구현을 진행하였습니다.

딕셔너리는 Thread safe하지 않기 때문에 같은 키에 여러 Thread가 접근하였을 때 런타임 에러가 발생해 
Lock, Serial Dispatch Queue을 사용해서 thread safe하게 해줘야하지만.. 
actor을 통해 구현하게 되면 여러 위와 같은 효과를 내준다고하여 actor을 사용하여 간단하게 구현해봤습니다.

### 이미지 캐싱 방식
1. 이미지 URL을 통해 이미지 요청
2. memory cache 딕셔너리 탐색
2-1. 값이 존재하는 URL인 경우 UIImage 리턴
2-2. 값이 존재하지 않는 URL인 경우 네트워킹하여 다운로드하여 UImage memory cahce에 저장, 리턴

싱글톤으로 선언된 ImageDownLoader을 통해 UIImageView extension을 통해 이미지를 가져오고 image로 설정하였습니다.
아무래도  싱글톤으로 사용하는 것이 마음에 걸려 최대한 클린아키텍처 레이어에 맞게 
AppDIContainer에서 의존성을 주입하고 Repository에서 주입받은 ImageFetcher을 통해 방식으로 구현을 시도해보았는데 도저히 진척이 없어서 포기했습니다..


