### PR TITLE
[iOS/#313] 네비게이션 바 색상 통일 

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -158,6 +158,9 @@ final class SignUpViewController: BaseViewController {
             signUpButton.trailingAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -32)
         ])
+        
+        self.navigationController?.navigationBar.tintColor = .label
+        self.navigationController?.navigationBar.topItem?.title = ""
     }
     
     func drawTextFieldUnderline() {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -62,10 +62,6 @@ final class CategorySettingViewController: BaseViewController {
             collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
         
-        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
-        backBarButtonItem.tintColor = .label
-        navigationItem.backBarButtonItem = backBarButtonItem
-        
         self.navigationController?.navigationBar.tintColor = .label
         self.navigationController?.navigationBar.topItem?.title = ""
     }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -61,6 +61,13 @@ final class CategorySettingViewController: BaseViewController {
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
+        
+        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        backBarButtonItem.tintColor = .label
+        navigationItem.backBarButtonItem = backBarButtonItem
+        
+        self.navigationController?.navigationBar.tintColor = .label
+        self.navigationController?.navigationBar.topItem?.title = ""
     }
     
     override func bind() {


### PR DESCRIPTION
close #313 

## 완료된 기능
- 네비게이션 바 버튼 색상 .label로 변경

## 고민과 해결과정
### 전역 네비게이션 바 설정?
- 처음에는 모든 네비게이션 바에 동일한 설정을 주기 위해 커스텀 네비게이션 바 컨트롤러를 사용해볼까 고민했었다.
- 그러나 현재 Coordinator들에 가해져야 하는 변경점이 많을 것 같아서, 필요한 뷰 컨트롤러에서 직접적으로 값을 변경하고 있다.