### PR TITLE
[iOS/#329] 일간 학습 통계 로직 구현

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -203,6 +203,9 @@
 		ED6865CA2B1E454E001A2AAD /* DefaultChartRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6865C92B1E454E001A2AAD /* DefaultChartRepository.swift */; };
 		ED6865CC2B1E494D001A2AAD /* ChartUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6865CB2B1E494D001A2AAD /* ChartUseCase.swift */; };
 		ED6865CE2B1E49A6001A2AAD /* DefaultChartUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6865CD2B1E49A6001A2AAD /* DefaultChartUseCase.swift */; };
+		ED6865D02B1F1429001A2AAD /* ChartDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6865CF2B1F1429001A2AAD /* ChartDIContainer.swift */; };
+		ED6865D32B1F1464001A2AAD /* ChartFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6865D22B1F1464001A2AAD /* ChartFlowCoordinator.swift */; };
+		ED6865D62B1F14CF001A2AAD /* ChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6865D52B1F14CF001A2AAD /* ChartViewModel.swift */; };
 		ED82F0072B126C95005BB32D /* UITextField++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82F0062B126C95005BB32D /* UITextField++Extension.swift */; };
 		ED82F00B2B128C4D005BB32D /* UIColor++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82F00A2B128C4D005BB32D /* UIColor++Extension.swift */; };
 		ED9B2A7F2B06033F008FE1C5 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9B2A7E2B06033F008FE1C5 /* Category.swift */; };
@@ -412,6 +415,9 @@
 		ED6865C92B1E454E001A2AAD /* DefaultChartRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChartRepository.swift; sourceTree = "<group>"; };
 		ED6865CB2B1E494D001A2AAD /* ChartUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartUseCase.swift; sourceTree = "<group>"; };
 		ED6865CD2B1E49A6001A2AAD /* DefaultChartUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChartUseCase.swift; sourceTree = "<group>"; };
+		ED6865CF2B1F1429001A2AAD /* ChartDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartDIContainer.swift; sourceTree = "<group>"; };
+		ED6865D22B1F1464001A2AAD /* ChartFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartFlowCoordinator.swift; sourceTree = "<group>"; };
+		ED6865D52B1F14CF001A2AAD /* ChartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartViewModel.swift; sourceTree = "<group>"; };
 		ED82F0062B126C95005BB32D /* UITextField++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField++Extension.swift"; sourceTree = "<group>"; };
 		ED82F00A2B128C4D005BB32D /* UIColor++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor++Extension.swift"; sourceTree = "<group>"; };
 		ED9B2A7E2B06033F008FE1C5 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
@@ -920,6 +926,8 @@
 		600908F32AFCDCE70065DFFB /* ChartScene */ = {
 			isa = PBXGroup;
 			children = (
+				ED6865D12B1F1459001A2AAD /* Flow */,
+				ED6865D42B1F14C3001A2AAD /* ViewModel */,
 				ED6865BB2B1DEE2A001A2AAD /* View */,
 				2C5CDA592B025435007AFC57 /* ViewController */,
 			);
@@ -1088,6 +1096,7 @@
 				2C88DD062B125781000B4686 /* TabBarDIContainer.swift */,
 				2C88DD0A2B1340E4000B4686 /* CategoryDIContainer.swift */,
 				2CDCD03C2B1871E60080DCDE /* SocialDIContainer.swift */,
+				ED6865CF2B1F1429001A2AAD /* ChartDIContainer.swift */,
 			);
 			path = DIContainer;
 			sourceTree = "<group>";
@@ -1248,6 +1257,22 @@
 				ED6865C32B1E4303001A2AAD /* DailyChartLogResponseDTO.swift */,
 			);
 			path = ChartScene;
+			sourceTree = "<group>";
+		};
+		ED6865D12B1F1459001A2AAD /* Flow */ = {
+			isa = PBXGroup;
+			children = (
+				ED6865D22B1F1464001A2AAD /* ChartFlowCoordinator.swift */,
+			);
+			path = Flow;
+			sourceTree = "<group>";
+		};
+		ED6865D42B1F14C3001A2AAD /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				ED6865D52B1F14CF001A2AAD /* ChartViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		EDC851D02B04EE74009031EA /* View */ = {
@@ -1612,6 +1637,7 @@
 				2CE84EFB2B0B92BA00E2FB71 /* UICollectionReusableView++Extension.swift in Sources */,
 				ED3595B72B0C887C00558FAA /* TimerFinishRequestDTO.swift in Sources */,
 				2C2F217A2B0F4CF900B45BA8 /* StudyLogUseCase.swift in Sources */,
+				ED6865D62B1F14CF001A2AAD /* ChartViewModel.swift in Sources */,
 				ED3595A92B0C7F3500558FAA /* HTTPMethod.swift in Sources */,
 				2C87C27D2B1DF1C300A26313 /* DefaultUserInfoRepository.swift in Sources */,
 				2C9F62052B160B3900AE63F9 /* NoResultView.swift in Sources */,
@@ -1666,6 +1692,7 @@
 				600908C02AFCD7DF0065DFFB /* SceneDelegate.swift in Sources */,
 				ED6865A72B17932F001A2AAD /* SocialDetailRequestDTO.swift in Sources */,
 				2C3430B12B0DE3D0008CBC85 /* Date++Extension.swift in Sources */,
+				ED6865D02B1F1429001A2AAD /* ChartDIContainer.swift in Sources */,
 				2C9F62152B1736BE00AE63F9 /* DefaultFriendRepository.swift in Sources */,
 				2CDCD0672B18D0330080DCDE /* FriendUser.swift in Sources */,
 				ED6865CC2B1E494D001A2AAD /* ChartUseCase.swift in Sources */,
@@ -1693,6 +1720,7 @@
 				2C9F62262B1742D200AE63F9 /* FriendEndpoints.swift in Sources */,
 				ED6865CE2B1E49A6001A2AAD /* DefaultChartUseCase.swift in Sources */,
 				2CDCD03D2B1871E60080DCDE /* SocialDIContainer.swift in Sources */,
+				ED6865D32B1F1464001A2AAD /* ChartFlowCoordinator.swift in Sources */,
 				2C87C2792B1C794000A26313 /* UpdateFriend.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		ED6865D02B1F1429001A2AAD /* ChartDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6865CF2B1F1429001A2AAD /* ChartDIContainer.swift */; };
 		ED6865D32B1F1464001A2AAD /* ChartFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6865D22B1F1464001A2AAD /* ChartFlowCoordinator.swift */; };
 		ED6865D62B1F14CF001A2AAD /* ChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6865D52B1F14CF001A2AAD /* ChartViewModel.swift */; };
+		ED6865D82B1F32EF001A2AAD /* CustomCalenderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6865D72B1F32EF001A2AAD /* CustomCalenderView.swift */; };
 		ED82F0072B126C95005BB32D /* UITextField++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82F0062B126C95005BB32D /* UITextField++Extension.swift */; };
 		ED82F00B2B128C4D005BB32D /* UIColor++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82F00A2B128C4D005BB32D /* UIColor++Extension.swift */; };
 		ED9B2A7F2B06033F008FE1C5 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9B2A7E2B06033F008FE1C5 /* Category.swift */; };
@@ -418,6 +419,7 @@
 		ED6865CF2B1F1429001A2AAD /* ChartDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartDIContainer.swift; sourceTree = "<group>"; };
 		ED6865D22B1F1464001A2AAD /* ChartFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartFlowCoordinator.swift; sourceTree = "<group>"; };
 		ED6865D52B1F14CF001A2AAD /* ChartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartViewModel.swift; sourceTree = "<group>"; };
+		ED6865D72B1F32EF001A2AAD /* CustomCalenderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCalenderView.swift; sourceTree = "<group>"; };
 		ED82F0062B126C95005BB32D /* UITextField++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField++Extension.swift"; sourceTree = "<group>"; };
 		ED82F00A2B128C4D005BB32D /* UIColor++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor++Extension.swift"; sourceTree = "<group>"; };
 		ED9B2A7E2B06033F008FE1C5 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
@@ -1247,6 +1249,7 @@
 				ED6865BC2B1DEE3D001A2AAD /* DailyChartView.swift */,
 				ED6865C02B1E3B48001A2AAD /* WeeklyChartView.swift */,
 				ED6865BE2B1E2FA6001A2AAD /* ChartSegmentedControl.swift */,
+				ED6865D72B1F32EF001A2AAD /* CustomCalenderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1648,6 +1651,7 @@
 				2C3430992B0C8427008CBC85 /* Provider.swift in Sources */,
 				2C2F21702B0F429800B45BA8 /* StudyLogResponseDTO.swift in Sources */,
 				2C2F216E2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift in Sources */,
+				ED6865D82B1F32EF001A2AAD /* CustomCalenderView.swift in Sources */,
 				2CDCD06E2B18EB4B0080DCDE /* UserInfoStorage.swift in Sources */,
 				2CE84EF72B0B7F3C00E2FB71 /* CategorySettingSection.swift in Sources */,
 				2C88DD112B14C50F000B4686 /* DefaultTimerFinishUseCase.swift in Sources */,

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		60F67C682B0E1785002C8BF3 /* CategoryUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F67C672B0E1785002C8BF3 /* CategoryUseCase.swift */; };
 		60F67C6A2B0E1868002C8BF3 /* DefaultCategoryUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F67C692B0E1868002C8BF3 /* DefaultCategoryUseCase.swift */; };
 		60F6FD732B0B5E130057CE0B /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F6FD722B0B5E130057CE0B /* SignUpViewController.swift */; };
+		ED1B3F292B1F8AA300FB9DBC /* WeeklyChartLogResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1B3F282B1F8AA300FB9DBC /* WeeklyChartLogResponseDTO.swift */; };
 		ED3595A92B0C7F3500558FAA /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595A82B0C7F3500558FAA /* HTTPMethod.swift */; };
 		ED3595AB2B0C81B800558FAA /* Responsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595AA2B0C81B800558FAA /* Responsable.swift */; };
 		ED3595B02B0C82C800558FAA /* TimerStartRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3595AF2B0C82C800558FAA /* TimerStartRequestDTO.swift */; };
@@ -380,6 +381,7 @@
 		8ED331B3B7BDE8C6BB68666F /* Pods-FlipMate-FlipMateUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMate-FlipMateUITests.debug.xcconfig"; path = "Target Support Files/Pods-FlipMate-FlipMateUITests/Pods-FlipMate-FlipMateUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		D2F176F76D65D7B591BA21B0 /* Pods-FlipMate-FlipMateUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMate-FlipMateUITests.release.xcconfig"; path = "Target Support Files/Pods-FlipMate-FlipMateUITests/Pods-FlipMate-FlipMateUITests.release.xcconfig"; sourceTree = "<group>"; };
 		E627FDBCC589BEB94FCC114A /* Pods-FlipMateTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMateTests.debug.xcconfig"; path = "Target Support Files/Pods-FlipMateTests/Pods-FlipMateTests.debug.xcconfig"; sourceTree = "<group>"; };
+		ED1B3F282B1F8AA300FB9DBC /* WeeklyChartLogResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyChartLogResponseDTO.swift; sourceTree = "<group>"; };
 		ED3595A82B0C7F3500558FAA /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		ED3595AA2B0C81B800558FAA /* Responsable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Responsable.swift; sourceTree = "<group>"; };
 		ED3595AF2B0C82C800558FAA /* TimerStartRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerStartRequestDTO.swift; sourceTree = "<group>"; };
@@ -1258,6 +1260,7 @@
 			isa = PBXGroup;
 			children = (
 				ED6865C32B1E4303001A2AAD /* DailyChartLogResponseDTO.swift */,
+				ED1B3F282B1F8AA300FB9DBC /* WeeklyChartLogResponseDTO.swift */,
 			);
 			path = ChartScene;
 			sourceTree = "<group>";
@@ -1688,6 +1691,7 @@
 				2C88DCF22B124238000B4686 /* AppFlowCoordinator.swift in Sources */,
 				2C9F62112B17363400AE63F9 /* DefaultFriendUseCase.swift in Sources */,
 				2CDCD0642B18CEDF0080DCDE /* FriendsResponseDTO.swift in Sources */,
+				ED1B3F292B1F8AA300FB9DBC /* WeeklyChartLogResponseDTO.swift in Sources */,
 				EDC851C72B021492009031EA /* TabBarViewController.swift in Sources */,
 				2CE84EF12B0B77BD00E2FB71 /* UICollectionView++Extension.swift in Sources */,
 				2C5CDA572B025426007AFC57 /* FlipMateColor.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/ChartDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/ChartDIContainer.swift
@@ -5,4 +5,26 @@
 //  Created by 신민규 on 12/5/23.
 //
 
-import Foundation
+import UIKit
+
+final class ChartDIContainer: ChartFlowCoordinatorDependencies {
+    struct Dependencies {
+        let provider: Providable
+    }
+    
+    private let dependencies: Dependencies
+    
+    init(dependencies: Dependencies) {
+        self.dependencies = dependencies
+    }
+    
+    func makeChartFlowCoordinator(navigationController: UINavigationController) -> ChartFlowCoordinator {
+        return ChartFlowCoordinator(
+            dependencies: self,
+            navigationController: navigationController)
+    }
+    
+    func makeChartViewController(actions: ChartViewModelActions) -> UIViewController {
+        return ChartViewController()
+    }
+}

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/ChartDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/ChartDIContainer.swift
@@ -1,0 +1,8 @@
+//
+//  ChartDIContainer.swift
+//  FlipMate
+//
+//  Created by 신민규 on 12/5/23.
+//
+
+import Foundation

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TabBarDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TabBarDIContainer.swift
@@ -40,6 +40,12 @@ final class TabBarDIContainer: TabBarFlowCoordinatorDependencies {
         return SocialDIContainer(dependencies: dependencies)
     }
     
+    func makeChartDIContainer() -> ChartDIContainer {
+        let dependencies = ChartDIContainer.Dependencies(provider: dependencies.provider)
+        
+        return ChartDIContainer(dependencies: dependencies)
+    }
+    
     func makeTimerViewController() -> UIViewController {
         return UIViewController()
     }

--- a/iOS/FlipMate/FlipMate/Common/Logger/FlipMateLogger.swift
+++ b/iOS/FlipMate/FlipMate/Common/Logger/FlipMateLogger.swift
@@ -16,4 +16,5 @@ enum FMLogger {
     static let appLifeCycle = Logger(subsystem: FMConstant.bundleID, category: "appLifeCycle")
     static let timer = Logger(subsystem: FMConstant.bundleID, category: "timer")
     static let friend = Logger(subsystem: FMConstant.bundleID, category: "friend")
+    static let chart = Logger(subsystem: FMConstant.bundleID, category: "chart")
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/BaseComponents.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/BaseComponents.swift
@@ -20,5 +20,4 @@ enum Paths {
     static let nickNameValidation = "/user/nickname-validation"
     static let friend = "/mates"
     static let user = "/user"
-    static let studyLogs = "/study-logs"
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/ChartEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/ChartEndpoints.swift
@@ -11,7 +11,7 @@ struct ChartEndpoints {
     static func fetchDailyLog(date: Date) -> EndPoint<DailyChartLogResponseDTO> {
         return EndPoint(
             baseURL: BaseURL.flipmateDomain,
-            path: Paths.studylogs + "?date=\(date.dateToString(format: .yyyyMMdd))",
+            path: Paths.studylogs + "/stats" + "?date=\(date.dateToString(format: .yyyyMMdd))",
             method: .get)
     }
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/ChartEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/ChartEndpoints.swift
@@ -14,4 +14,9 @@ struct ChartEndpoints {
             path: Paths.studylogs + "/stats" + "?date=\(date.dateToString(format: .yyyyMMdd))",
             method: .get)
     }
+    
+    static func fetchWeeklyLog() -> EndPoint<WeeklyChartLogResponseDTO> {
+        let date = Date()
+        return EndPoint(baseURL: BaseURL.flipmateDomain, path: Paths.studylogs + "/stats/weekly" + "?date=\(date.dateToString(format: .yyyyMMdd))", method: .get)
+    }
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/ChartScene/DailyChartLogResponseDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/ChartScene/DailyChartLogResponseDTO.swift
@@ -10,7 +10,7 @@ import Foundation
 struct DailyChartLogResponseDTO: Decodable {
     let todayTime: Int
     let categories: [CategoryDTO]?
-    let percentage: Int
+    let percentage: Double
     
     private enum CodingKeys: String, CodingKey {
         case todayTime = "total_time"

--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/ChartScene/WeeklyChartLogResponseDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/ChartScene/WeeklyChartLogResponseDTO.swift
@@ -1,0 +1,22 @@
+//
+//  WeeklyChartLogResponseDTO.swift
+//  FlipMate
+//
+//  Created by 신민규 on 12/6/23.
+//
+
+import Foundation
+
+struct WeeklyChartLogResponseDTO: Decodable {
+    let totalTime: Int
+    let dailyData: [Int]
+    let primaryCategory: String?
+    let percentage: Double
+    
+    private enum CodingKeys: String, CodingKey {
+        case totalTime = "total_time"
+        case dailyData = "daily_data"
+        case primaryCategory = "primary_category"
+        case percentage
+    }
+}

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultChartRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultChartRepository.swift
@@ -14,7 +14,7 @@ final class DefaultChartRepository: ChartRepository {
         self.provider = provider
     }
     
-    func fetchDailyLog(date: Date) async throws -> ChartLog {
+    func fetchDailyLog(date: Date) async throws -> DailyChartLog {
         let endpoint = ChartEndpoints.fetchDailyLog(date: date)
         let responseDTO = try await provider.request(with: endpoint)
         
@@ -22,6 +22,13 @@ final class DefaultChartRepository: ChartRepository {
             return Category(id: dto.id, color: dto.color, subject: dto.name, studyTime: dto.todayTime)
         } ?? []
         
-        return ChartLog(studyLog: StudyLog(totalTime: responseDTO.todayTime, category: categories), percentage: responseDTO.percentage)
+        return DailyChartLog(studyLog: StudyLog(totalTime: responseDTO.todayTime, category: categories), percentage: responseDTO.percentage)
+    }
+    
+    func fetchWeeklyLog() async throws -> WeeklyChartLog {
+        let endpoint = ChartEndpoints.fetchWeeklyLog()
+        let responseDTO = try await provider.request(with: endpoint)
+        
+        return WeeklyChartLog(totalTime: responseDTO.totalTime, dailyData: responseDTO.dailyData, primaryCategory: responseDTO.primaryCategory, percentage: responseDTO.percentage)
     }
 }

--- a/iOS/FlipMate/FlipMate/Domain/Entities/StudyLog.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Entities/StudyLog.swift
@@ -12,9 +12,18 @@ struct StudyLog {
     var category: [Category]
 }
 
-struct ChartLog: Identifiable {
+struct DailyChartLog: Identifiable {
     let id: UUID = UUID()
     
     var studyLog: StudyLog
+    var percentage: Double
+}
+
+struct WeeklyChartLog: Identifiable {
+    let id: UUID = UUID()
+    
+    var totalTime: Int
+    var dailyData: [Int]
+    var primaryCategory: String?
     var percentage: Double
 }

--- a/iOS/FlipMate/FlipMate/Domain/Entities/StudyLog.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Entities/StudyLog.swift
@@ -16,5 +16,5 @@ struct ChartLog: Identifiable {
     let id: UUID = UUID()
     
     var studyLog: StudyLog
-    var percentage: Int
+    var percentage: Double
 }

--- a/iOS/FlipMate/FlipMate/Domain/Entities/StudyLog.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Entities/StudyLog.swift
@@ -12,7 +12,7 @@ struct StudyLog {
     var category: [Category]
 }
 
-struct DailyChartLog: Identifiable {
+struct CategoryChartLog: Identifiable {
     let id: UUID = UUID()
     
     var studyLog: StudyLog
@@ -23,7 +23,14 @@ struct WeeklyChartLog: Identifiable {
     let id: UUID = UUID()
     
     var totalTime: Int
-    var dailyData: [Int]
+    var dailyData: [DailyData]
     var primaryCategory: String?
     var percentage: Double
+}
+
+struct DailyData: Identifiable {
+    let id: UUID = UUID()
+    
+    var day: String
+    var studyTime: Int
 }

--- a/iOS/FlipMate/FlipMate/Domain/Entities/StudyLog.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Entities/StudyLog.swift
@@ -12,7 +12,9 @@ struct StudyLog {
     var category: [Category]
 }
 
-struct ChartLog {
+struct ChartLog: Identifiable {
+    let id: UUID = UUID()
+    
     var studyLog: StudyLog
     var percentage: Int
 }

--- a/iOS/FlipMate/FlipMate/Domain/Repositories/ChartRepository.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Repositories/ChartRepository.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 protocol ChartRepository {
-    func fetchDailyLog(date: Date) async throws -> ChartLog
+    func fetchDailyLog(date: Date) async throws -> DailyChartLog
+    func fetchWeeklyLog() async throws -> WeeklyChartLog
 }

--- a/iOS/FlipMate/FlipMate/Domain/Repositories/ChartRepository.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Repositories/ChartRepository.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 protocol ChartRepository {
-    func fetchDailyLog(date: Date) async throws -> DailyChartLog
+    func fetchDailyLog(date: Date) async throws -> CategoryChartLog
     func fetchWeeklyLog() async throws -> WeeklyChartLog
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
@@ -14,12 +14,7 @@ final class DefaultChartUseCase: ChartUseCase {
         self.repository = repository
     }
     
-    func fetchTodayChartLog() async throws -> ChartLog {
-        let date = Date()
-        return try await repository.fetchDailyLog(date: date)
-    }
-    
-    func fetchDailyChartLog(at date: Date) async throws -> ChartLog {
+    func fetchDailyChartLog(at date: Date) async throws -> DailyChartLog {
         var chartLog = try await repository.fetchDailyLog(date: date)
         
         var etcTime = chartLog.studyLog.category.reduce(0) { (result, category) in
@@ -32,5 +27,9 @@ final class DefaultChartUseCase: ChartUseCase {
             chartLog.studyLog.category.append(etcCategory)
         
         return chartLog
+    }
+    
+    func fetchWeeklyChartLog() async throws -> WeeklyChartLog {
+        return try await repository.fetchWeeklyLog()
     }
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
@@ -20,6 +20,17 @@ final class DefaultChartUseCase: ChartUseCase {
     }
     
     func fetchDailyChartLog(at date: Date) async throws -> ChartLog {
-        return try await repository.fetchDailyLog(date: date)
+        var chartLog = try await repository.fetchDailyLog(date: date)
+        
+        var etcTime = chartLog.studyLog.category.reduce(0) { (result, category) in
+            return result + (category.studyTime ?? 0)
+        }
+        
+        etcTime = chartLog.studyLog.totalTime - etcTime
+        
+        let etcCategory = Category(id: 0, color: "FFFFFFFF", subject: "기타", studyTime: etcTime)
+            chartLog.studyLog.category.append(etcCategory)
+        
+        return chartLog
     }
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
@@ -14,7 +14,7 @@ final class DefaultChartUseCase: ChartUseCase {
         self.repository = repository
     }
     
-    func fetchDailyChartLog(at date: Date) async throws -> DailyChartLog {
+    func fetchDailyChartLog(at date: Date) async throws -> CategoryChartLog {
         var chartLog = try await repository.fetchDailyLog(date: date)
         
         var etcTime = chartLog.studyLog.category.reduce(0) { (result, category) in

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/ChartUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/ChartUseCase.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 protocol ChartUseCase {
-    func fetchDailyChartLog(at date: Date) async throws -> DailyChartLog
+    func fetchDailyChartLog(at date: Date) async throws -> CategoryChartLog
     func fetchWeeklyChartLog() async throws -> WeeklyChartLog
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/ChartUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/ChartUseCase.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 protocol ChartUseCase {
-    func fetchTodayChartLog() async throws -> ChartLog
-    func fetchDailyChartLog(at date: Date) async throws -> ChartLog
+    func fetchDailyChartLog(at date: Date) async throws -> DailyChartLog
+    func fetchWeeklyChartLog() async throws -> WeeklyChartLog
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/Flow/ChartFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/Flow/ChartFlowCoordinator.swift
@@ -1,0 +1,8 @@
+//
+//  ChartFlowCoordinator.swift
+//  FlipMate
+//
+//  Created by 신민규 on 12/5/23.
+//
+
+import Foundation

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/Flow/ChartFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/Flow/ChartFlowCoordinator.swift
@@ -6,3 +6,27 @@
 //
 
 import Foundation
+import UIKit
+
+protocol ChartFlowCoordinatorDependencies {
+    func makeChartFlowCoordinator(navigationController: UINavigationController) -> ChartFlowCoordinator
+    func makeChartViewController(actions: ChartViewModelActions) -> UIViewController
+}
+
+final class ChartFlowCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+    private var navigationController: UINavigationController
+    private var dependencies: ChartFlowCoordinatorDependencies
+    
+    init(dependencies: ChartFlowCoordinatorDependencies, navigationController: UINavigationController) {
+        self.dependencies = dependencies
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        let actions = ChartViewModelActions()
+        let chartViewController = dependencies.makeChartViewController(actions: actions)
+        navigationController.viewControllers = [chartViewController]
+    }
+}
+

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct CustomCalenderView: View {
-    @State private var selectedDate = Date()
+    @Binding var selectedDate: Date
+    @ObservedObject var viewModel: ChartViewModel
     @Environment(\.colorScheme) var colorScheme
     private let calendar = Calendar.current
     
@@ -21,6 +22,9 @@ struct CustomCalenderView: View {
             }
             .frame(height: 30)
             .padding(.horizontal, 25)
+        }
+        .onChange(of: selectedDate) { newDate in
+            viewModel.selectedDateDidChange(newDate: newDate)
         }
     }
     
@@ -73,6 +77,7 @@ struct CustomCalenderView: View {
                                         (colorScheme == .dark ? .white : .black))
                     .onTapGesture {
                         selectedDate = date
+                        
                     }
                 }
             }
@@ -117,8 +122,4 @@ private extension CustomCalenderView {
         dateFormatter.setLocalizedDateFormatFromTemplate("E")
         return dateFormatter.string(from: date)
     }
-}
-
-#Preview {
-    CustomCalenderView()
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
@@ -1,0 +1,129 @@
+//
+//  CustomCalenderView.swift
+//  FlipMate
+//
+//  Created by 신민규 on 12/5/23.
+//
+
+import SwiftUI
+
+struct CustomCalenderView: View {
+    @State private var selectedDate = Date()
+    @Environment(\.colorScheme) var colorScheme
+    private let calendar = Calendar.current
+    
+    var body: some View {
+        VStack(alignment: .center, spacing: 20) {
+            monthView
+            ZStack {
+                dayView
+                blurView
+            }
+            .frame(height: 30)
+            .padding(.horizontal, 25)
+        }
+    }
+    
+    private var monthView: some View {
+        HStack(spacing: 20) {
+            Button(action: {
+                changeMonth(-1)
+            }, label: {
+                Image(systemName: "arrowtriangle.backward")
+                    .padding()
+                }
+            )
+            
+            Text(monthTitle(from: selectedDate))
+                .font(.title)
+            
+            Button(action: {
+                changeMonth(1)
+            }, label: {
+                Image(systemName: "arrowtriangle.forward")
+                    .padding()
+                }
+            )
+        }
+    }
+    
+    @ViewBuilder
+    private var dayView: some View {
+        let today = calendar.date(from: Calendar.current.dateComponents([.year, .month], from: selectedDate))!
+        
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+                let components = (0..<calendar.range(of: .day, in: .month, for: today)!.count)
+                    .map {
+                        calendar.date(byAdding: .day, value: $0, to: today)!
+                    }
+                
+                ForEach(components, id: \.self) { date in
+                    VStack {
+                        Text(day(from: date))
+                            .font(.caption)
+                        Text("\(calendar.component(.day, from: date))")
+                    }
+                    .frame(width: 30, height: 30)
+                    .padding(5)
+                    .background(calendar.isDate(selectedDate, equalTo: date, toGranularity: .day) ? (colorScheme == .dark ? .white : .darkBlue) : Color.clear)
+                    .cornerRadius(16)
+                    .foregroundColor(calendar.isDate(selectedDate, equalTo: date, toGranularity: .day) ? (colorScheme == .dark ? .black : .white) : (colorScheme == .dark ? .white : .black))
+                    .onTapGesture {
+                        selectedDate = date
+                    }
+                }
+            }
+        }
+    }
+    
+    private var blurView: some View {
+        HStack {
+            LinearGradient(gradient: Gradient(colors: [(colorScheme == .dark ? Color.black.opacity(1) : Color.white.opacity(1)), (colorScheme == .dark ? Color.black.opacity(0) : Color.white.opacity(0))]), startPoint: .leading, endPoint: /*@START_MENU_TOKEN@*/.trailing/*@END_MENU_TOKEN@*/)
+                .frame(width: 20)
+                .edgesIgnoringSafeArea(.leading)
+            
+            Spacer()
+            
+            LinearGradient(gradient: Gradient(colors: [(colorScheme == .dark ? Color.black.opacity(1) : Color.white.opacity(1)), (colorScheme == .dark ? Color.black.opacity(0) : Color.white.opacity(0))]), startPoint: .trailing, endPoint: .leading)
+                .frame(width: 20)
+                .edgesIgnoringSafeArea(.leading)
+        }
+    }
+}
+
+private extension CustomCalenderView {
+    func monthTitle(from date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.setLocalizedDateFormatFromTemplate("yyyy MMM")
+        return dateFormatter.string(from: date)
+    }
+    
+    func changeMonth(_ value: Int) {
+        guard let date = calendar.date(byAdding: .month, value: value, to: selectedDate) else { return }
+        selectedDate = date
+    }
+    
+    func day(from date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.setLocalizedDateFormatFromTemplate("E")
+        return dateFormatter.string(from: date)
+    }
+}
+
+struct Theme {
+    static func myBackGroundColor(forScheme scheme: ColorScheme) -> Color {
+        let lightColor = Color.white
+        let darkColor = Color.black
+        
+        switch scheme {
+        case .light: return lightColor
+        case .dark: return darkColor
+        @unknown default: return lightColor
+        }
+    }
+}
+
+#Preview {
+    CustomCalenderView()
+}

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
@@ -66,9 +66,11 @@ struct CustomCalenderView: View {
                     }
                     .frame(width: 30, height: 30)
                     .padding(5)
-                    .background(calendar.isDate(selectedDate, equalTo: date, toGranularity: .day) ? (colorScheme == .dark ? .white : .darkBlue) : Color.clear)
+                    .background(calendar.isDate(selectedDate, equalTo: date, toGranularity: .day) ? 
+                                (colorScheme == .dark ? .white : .darkBlue) : Color.clear)
                     .cornerRadius(16)
-                    .foregroundColor(calendar.isDate(selectedDate, equalTo: date, toGranularity: .day) ? (colorScheme == .dark ? .black : .white) : (colorScheme == .dark ? .white : .black))
+                    .foregroundColor(calendar.isDate(selectedDate, equalTo: date, toGranularity: .day) ? (colorScheme == .dark ? .black : .white) : 
+                                        (colorScheme == .dark ? .white : .black))
                     .onTapGesture {
                         selectedDate = date
                     }
@@ -79,13 +81,19 @@ struct CustomCalenderView: View {
     
     private var blurView: some View {
         HStack {
-            LinearGradient(gradient: Gradient(colors: [(colorScheme == .dark ? Color.black.opacity(1) : Color.white.opacity(1)), (colorScheme == .dark ? Color.black.opacity(0) : Color.white.opacity(0))]), startPoint: .leading, endPoint: /*@START_MENU_TOKEN@*/.trailing/*@END_MENU_TOKEN@*/)
+            LinearGradient(gradient: 
+                            Gradient(colors: [(colorScheme == .dark ? Color.black.opacity(1) : Color.white.opacity(1)), 
+                                              (colorScheme == .dark ? Color.black.opacity(0) : Color.white.opacity(0))]),
+                           startPoint: .leading, endPoint: /*@START_MENU_TOKEN@*/.trailing/*@END_MENU_TOKEN@*/)
                 .frame(width: 20)
                 .edgesIgnoringSafeArea(.leading)
             
             Spacer()
             
-            LinearGradient(gradient: Gradient(colors: [(colorScheme == .dark ? Color.black.opacity(1) : Color.white.opacity(1)), (colorScheme == .dark ? Color.black.opacity(0) : Color.white.opacity(0))]), startPoint: .trailing, endPoint: .leading)
+            LinearGradient(gradient: 
+                            Gradient(colors: [(colorScheme == .dark ? Color.black.opacity(1) : Color.white.opacity(1)),
+                                                       (colorScheme == .dark ? Color.black.opacity(0) : Color.white.opacity(0))]), 
+                           startPoint: .trailing, endPoint: .leading)
                 .frame(width: 20)
                 .edgesIgnoringSafeArea(.leading)
         }
@@ -108,19 +116,6 @@ private extension CustomCalenderView {
         let dateFormatter = DateFormatter()
         dateFormatter.setLocalizedDateFormatFromTemplate("E")
         return dateFormatter.string(from: date)
-    }
-}
-
-struct Theme {
-    static func myBackGroundColor(forScheme scheme: ColorScheme) -> Color {
-        let lightColor = Color.white
-        let darkColor = Color.black
-        
-        switch scheme {
-        case .light: return lightColor
-        case .dark: return darkColor
-        @unknown default: return lightColor
-        }
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
@@ -24,7 +24,9 @@ struct CustomCalenderView: View {
             .padding(.horizontal, 25)
         }
         .onChange(of: selectedDate) { newDate in
-            viewModel.selectedDateDidChange(newDate: newDate)
+            Task {
+                try await viewModel.selectedDateDidChange(newDate: newDate)
+            }
         }
     }
     

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -23,7 +23,6 @@ struct DailyChartView: View {
                             .annotation(position: .overlay) {
                                 Text("\(category.studyTime ?? 0)")
                                     .font(.headline)
-                                    .foregroundStyle(.darkBlue)
                             }
                     }
                 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -32,6 +32,7 @@ struct DailyChartView: View {
                         Text("총 학습 시간").font(.callout)
                             .foregroundStyle(.secondary)
                         Text("\(totalTime.secondsToStringTime())").font(.system(size: 36))}
+                    .padding(.bottom, 20)
                 }
             } else if #available(iOS 16.0, *) {
                     Text("총 학습 시간").font(.callout)

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -10,7 +10,7 @@ import Charts
 
 struct DailyChartView: View {
     @ObservedObject var viewModel: ChartViewModel
-    @State var date = Date()
+    @State private var selectedDate = Date()
     
     init(viewModel: ChartViewModel) {
         self.viewModel = viewModel
@@ -18,7 +18,7 @@ struct DailyChartView: View {
     
     var body: some View {
         VStack {
-            CustomCalenderView()
+            CustomCalenderView(selectedDate: $selectedDate, viewModel: viewModel)
             if #available(iOS 17.0, *) {
                 Chart {
                     ForEach(viewModel.dailyChartLog.studyLog.category, id: \.subject) { category in

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -9,14 +9,19 @@ import SwiftUI
 import Charts
 
 struct DailyChartView: View {
+    @ObservedObject var viewModel: ChartViewModel
     @State var date = Date()
-    var totalTime: Int = 25230
+    
+    init(viewModel: ChartViewModel) {
+        self.viewModel = viewModel
+    }
+    
     var body: some View {
         VStack {
             CustomCalenderView()
             if #available(iOS 17.0, *) {
                 Chart {
-                    ForEach(dailyData, id: \.subject) { category in
+                    ForEach(viewModel.dailyChartLog.studyLog.category, id: \.subject) { category in
                         SectorMark(angle: .value("시간", category.studyTime ?? 0), innerRadius: .ratio(0.65), angularInset: 3.0)
                             .foregroundStyle(by: .value("카테고리", category.subject))
                             .cornerRadius(10.0)
@@ -26,21 +31,21 @@ struct DailyChartView: View {
                             }
                     }
                 }
-                .frame(height: 500)
+                .frame(height: 400)
                 .chartBackground { _ in
                     VStack {
                         Text("총 학습 시간").font(.callout)
                             .foregroundStyle(.secondary)
-                        Text("\(totalTime.secondsToStringTime())").font(.system(size: 36))}
+                        Text("\(viewModel.dailyChartLog.studyLog.totalTime.secondsToStringTime())").font(.system(size: 36))}
                     .padding(.bottom, 20)
                 }
             } else if #available(iOS 16.0, *) {
                     Text("총 학습 시간").font(.callout)
                         .foregroundStyle(.secondary)
-                    Text("\(totalTime.secondsToStringTime())").font(.system(size: 36))
+                    Text("\(viewModel.dailyChartLog.studyLog.totalTime.secondsToStringTime())").font(.system(size: 36))
         
                     Chart {
-                        ForEach(dailyData, id: \.subject) { category in
+                        ForEach(viewModel.dailyChartLog.studyLog.category, id: \.subject) { category in
                             BarMark(x: .value("시간", Float(category.studyTime ?? 0) / 60), y: .value("카테고리", category.subject))
                                 .foregroundStyle(by: .value("", category.color))
                         }
@@ -55,14 +60,6 @@ struct DailyChartView: View {
     }
 }
 
-let dailyData: [Category] = [.init(id: 1, color: "1591FFFF", subject: "요리", studyTime: 1241),
-                        .init(id: 2, color: "295AA5FF", subject: "김장", studyTime: 675),
-                        .init(id: 3, color: "000000FF", subject: "제빵", studyTime: 51),
-                        .init(id: 4, color: "66FF00FF", subject: "도둑질", studyTime: 964),
-                        .init(id: 5, color: "FF000000", subject: "게임", studyTime: 549),
-                        .init(id: 6, color: "0000BBEE", subject: "티타임", studyTime: 440),
-                        .init(id: 7, color: "638109FF", subject: "공부", studyTime: 40)]
-
 #Preview {
-    DailyChartView()
+    DailyChartView(viewModel: ChartViewModel(chartUseCase: DefaultChartUseCase(repository: DefaultChartRepository(provider: Provider(urlSession: URLSession.shared))), actions: ChartViewModelActions()))
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -26,12 +26,14 @@ struct DailyChartView: View {
                             .foregroundStyle(by: .value("카테고리", category.subject))
                             .cornerRadius(10.0)
                             .annotation(position: .overlay) {
-                                Text("\(category.studyTime ?? 0)")
-                                    .font(.headline)
+                                if category.studyTime != 0 {
+                                    Text("\(category.studyTime ?? 0)")
+                                        .font(.headline)
+                                }
                             }
                     }
                 }
-                .frame(height: 400)
+                .frame(height: 400 * (UIScreen.main.bounds.size.height / 844))
                 .chartBackground { _ in
                     VStack {
                         Text("총 학습 시간").font(.callout)
@@ -51,7 +53,7 @@ struct DailyChartView: View {
                         }
                     }
                     .chartLegend(.hidden)
-                    .frame(height: 400)
+                    .frame(height: 360 * (UIScreen.main.bounds.size.height / 844))
                     .chartXAxisLabel("분 (m)")
             } else {
                 Text("iOS 16.0 이상 버전부터 차트 기능 사용 가능")
@@ -60,6 +62,3 @@ struct DailyChartView: View {
     }
 }
 
-#Preview {
-    DailyChartView(viewModel: ChartViewModel(chartUseCase: DefaultChartUseCase(repository: DefaultChartRepository(provider: Provider(urlSession: URLSession.shared))), actions: ChartViewModelActions()))
-}

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -13,7 +13,7 @@ struct DailyChartView: View {
     var totalTime: Int = 25230
     var body: some View {
         VStack {
-            DatePicker("", selection: $date, displayedComponents: [.date])
+            CustomCalenderView()
             if #available(iOS 17.0, *) {
                 Chart {
                     ForEach(dailyData, id: \.subject) { category in

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/WeeklyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/WeeklyChartView.swift
@@ -9,55 +9,30 @@ import SwiftUI
 import Charts
 
 struct WeeklyChartView: View {
-    @State var date = Date()
-    var totalTime: Int = 25230
+    @ObservedObject var viewModel: ChartViewModel
+    
+    init(viewModel: ChartViewModel) {
+        self.viewModel = viewModel
+    }
+    
     var body: some View {
         VStack {
-            if #available(iOS 17.0, *) {
+            Text("주간 학습 통계").font(.title).padding(.trailing, 150).padding(.bottom, 30)
+            if #available(iOS 16.0, *) {
                 Chart {
-                    ForEach(weeklyData, id: \.subject) { category in
-                        SectorMark(angle: .value("시간", category.studyTime ?? 0), innerRadius: .ratio(0.65), angularInset: 3.0)
-                            .foregroundStyle(by: .value("카테고리", category.subject))
-                            .cornerRadius(10.0)
-                            .annotation(position: .overlay) {
-                                Text("\(category.studyTime ?? 0)")
-                                    .font(.headline)
-                                    .foregroundStyle(.darkBlue)
-                            }
+                    ForEach(viewModel.weeklyChartLog.dailyData, id: \.day) { data in
+                        BarMark(x: .value("요일", data.day), y: .value("분", Float(data.studyTime) / 60))
+                            .foregroundStyle(by: .value("", data.day))
                     }
                 }
-                .frame(height: 500)
-                .chartBackground { _ in
-                    VStack {
-                        Text("오늘의 학습 시간").font(.callout)
-                            .foregroundStyle(.secondary)
-                        Text("\(totalTime)s").font(.system(size: 36))}
-                }
-            } else if #available(iOS 16.0, *) {
-                Chart {
-                    ForEach(weeklyData, id: \.subject) { category in
-                        BarMark(x: .value("시간", Float(category.studyTime ?? 0) / 60), y: .value("카테고리", category.subject))
-                            .foregroundStyle(by: .value("", category.color))
-                        }
-                    }
-                .chartLegend(.hidden)
-                .frame(height: 300)
-                .chartXAxisLabel("분 (m)")
+                .frame(height: 400 * (UIScreen.main.bounds.size.height / 844))
             } else {
                 Text("iOS 16.0 이상 버전부터 차트 기능 사용 가능")
             }
-        }.padding()
+        }
     }
 }
 
-let weeklyData: [Category] = [.init(id: 1, color: "1591FFFF", subject: "요리", studyTime: 1241),
-                        .init(id: 2, color: "295AA5FF", subject: "김장", studyTime: 675),
-                        .init(id: 3, color: "000000FF", subject: "제빵", studyTime: 51),
-                        .init(id: 4, color: "66FF00FF", subject: "도둑질", studyTime: 964),
-                        .init(id: 5, color: "FF000000", subject: "게임", studyTime: 549),
-                        .init(id: 6, color: "0000BBEE", subject: "티타임", studyTime: 440),
-                        .init(id: 7, color: "638109FF", subject: "공부", studyTime: 40)]
-
 #Preview {
-    WeeklyChartView()
+    WeeklyChartView(viewModel: ChartViewModel(chartUseCase: DefaultChartUseCase(repository: DefaultChartRepository(provider: Provider(urlSession: URLSession.shared)))))
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -41,10 +41,15 @@ final class ChartViewController: BaseViewController {
             weeklyChartView.isHidden = !dailyChartView.isHidden
         }
     }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setSegmentControll()
         
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(true, animated: true)
     }
     
     override func configureUI() {

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -13,7 +13,7 @@ final class ChartViewController: BaseViewController {
         let segmentedControl = ChartSegmentedControl(items: ["일간", "주간"])
         segmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: FlipMateColor.gray2.color as Any, 
             .font: FlipMateFont.mediumRegular.font], for: .normal)
-        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: FlipMateColor.darkBlue.color as Any, 
+        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.label, 
             .font: FlipMateFont.mediumBold.font], for: .selected)
         segmentedControl.translatesAutoresizingMaskIntoConstraints = false
         

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -63,8 +63,8 @@ final class ChartViewController: BaseViewController {
         ])
         NSLayoutConstraint.activate([
             dailyChartView.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor, constant: 30),
-            dailyChartView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 25),
-            dailyChartView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -25),
+            dailyChartView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 5),
+            dailyChartView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -5),
             dailyChartView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -80)
         ])
         NSLayoutConstraint.activate([

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -56,7 +56,7 @@ final class ChartViewController: BaseViewController {
         self.view.addSubview(self.weeklyChartView)
         
         NSLayoutConstraint.activate([
-            segmentedControl.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            segmentedControl.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
             segmentedControl.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 15),
             segmentedControl.heightAnchor.constraint(equalToConstant: 50),
             segmentedControl.widthAnchor.constraint(equalToConstant: 140)
@@ -84,7 +84,7 @@ private extension ChartViewController {
     }
     
     func setDailyChart() {
-        let dailyChartView = DailyChartView()
+        let dailyChartView = DailyChartView(viewModel: ChartViewModel(chartUseCase: DefaultChartUseCase(repository: DefaultChartRepository(provider: Provider(urlSession: URLSession.shared))), actions: nil))
         let hostingController = UIHostingController(rootView: dailyChartView)
         addChild(hostingController)
         guard let newChartView = hostingController.view else { return }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -28,8 +28,6 @@ final class ChartViewController: BaseViewController {
     
     private var weeklyChartView: UIView = {
         let view = UIView()
-        view.backgroundColor = .yellow
-        view.translatesAutoresizingMaskIntoConstraints = false
         
         return view
     }()
@@ -55,6 +53,7 @@ final class ChartViewController: BaseViewController {
     override func configureUI() {
         super.configureUI()
         setDailyChart()
+        setWeeklyChart()
         
         self.view.addSubview(self.segmentedControl)
         self.view.addSubview(self.dailyChartView)
@@ -94,6 +93,17 @@ private extension ChartViewController {
         addChild(hostingController)
         guard let newChartView = hostingController.view else { return }
         self.dailyChartView = newChartView
+        self.view.addSubview(newChartView)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        hostingController.didMove(toParent: self)
+    }
+    
+    func setWeeklyChart() {
+        let weeklyChartView = WeeklyChartView(viewModel: ChartViewModel(chartUseCase: DefaultChartUseCase(repository: DefaultChartRepository(provider: Provider(urlSession: URLSession.shared))), actions: nil))
+        let hostingController = UIHostingController(rootView: weeklyChartView)
+        addChild(hostingController)
+        guard let newChartView = hostingController.view else { return }
+        self.weeklyChartView = newChartView
         self.view.addSubview(newChartView)
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
         hostingController.didMove(toParent: self)

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
@@ -13,7 +13,7 @@ struct ChartViewModelActions {
 }
 
 final class ChartViewModel: ObservableObject {
-    @Published var dailyChartLog: DailyChartLog = .init(studyLog: StudyLog(totalTime: 0, category: []), percentage: 0)
+    @Published var dailyChartLog: CategoryChartLog = .init(studyLog: StudyLog(totalTime: 0, category: []), percentage: 0)
     @Published var weeklyChartLog: WeeklyChartLog = .init(totalTime: 0, dailyData: [], percentage: 0)
     
     private var cancellables = Set<AnyCancellable>()
@@ -26,7 +26,6 @@ final class ChartViewModel: ObservableObject {
     }
     
     func selectedDateDidChange(newDate: Date) async throws {
-        FMLogger.chart.log("\(self.dailyChartLog.studyLog.totalTime)")
         try await fetchDailyData(date: newDate)
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+struct ChartViewModelActions {
+    
+}
+
+

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
@@ -24,7 +24,17 @@ final class ChartViewModel: ObservableObject {
         self.actions = actions
     }
     
-    func selectedDateDidChange(newDate: Date) {
-        FMLogger.chart.log("\(newDate)로 날짜 바뀌었네?")
+    func selectedDateDidChange(newDate: Date) async throws {
+        FMLogger.chart.log("\(self.dailyChartLog.studyLog.totalTime)")
+        try await fetchDailyData(date: newDate)
+    }
+}
+
+private extension ChartViewModel {
+    func fetchDailyData(date: Date) async throws {
+        let newDailyChartLog = try await chartUseCase.fetchDailyChartLog(at: date)
+        DispatchQueue.main.async {
+            self.dailyChartLog = newDailyChartLog
+        }
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
@@ -13,7 +13,8 @@ struct ChartViewModelActions {
 }
 
 final class ChartViewModel: ObservableObject {
-    @Published var dailyChartLog: ChartLog = .init(studyLog: StudyLog(totalTime: 0, category: []), percentage: 0)
+    @Published var dailyChartLog: DailyChartLog = .init(studyLog: StudyLog(totalTime: 0, category: []), percentage: 0)
+    @Published var weeklyChartLog: WeeklyChartLog = .init(totalTime: 0, dailyData: [], percentage: 0)
     
     private var cancellables = Set<AnyCancellable>()
     private let chartUseCase: ChartUseCase
@@ -35,6 +36,13 @@ private extension ChartViewModel {
         let newDailyChartLog = try await chartUseCase.fetchDailyChartLog(at: date)
         DispatchQueue.main.async {
             self.dailyChartLog = newDailyChartLog
+        }
+    }
+    
+    func fetchWeeklyData() async throws {
+        let newWeeklyChartLog = try await chartUseCase.fetchWeeklyChartLog()
+        DispatchQueue.main.async {
+            self.weeklyChartLog = newWeeklyChartLog
         }
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
@@ -6,9 +6,25 @@
 //
 
 import Foundation
+import Combine
 
 struct ChartViewModelActions {
     
 }
 
-
+final class ChartViewModel: ObservableObject {
+    @Published var dailyChartLog: ChartLog = .init(studyLog: StudyLog(totalTime: 0, category: []), percentage: 0)
+    
+    private var cancellables = Set<AnyCancellable>()
+    private let chartUseCase: ChartUseCase
+    private let actions: ChartViewModelActions?
+    
+    init(chartUseCase: ChartUseCase, actions: ChartViewModelActions? = nil) {
+        self.chartUseCase = chartUseCase
+        self.actions = actions
+    }
+    
+    func selectedDateDidChange(newDate: Date) {
+        FMLogger.chart.log("\(newDate)로 날짜 바뀌었네?")
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  ChartViewModel.swift
+//  FlipMate
+//
+//  Created by 신민규 on 12/5/23.
+//
+
+import Foundation

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -12,6 +12,7 @@ protocol TabBarFlowCoordinatorDependencies {
     func makeTimerViewController() -> UIViewController
     func makeTimerDIContainer() -> TimerSceneDIContainer
     func makeSocialDIContainer() -> SocialDIContainer
+    func makeChartDIContainer() -> ChartDIContainer
 }
 
 final class TabBarFlowCoordinator: Coordinator {
@@ -67,6 +68,9 @@ final class TabBarFlowCoordinator: Coordinator {
             systemName: Constant.chartNomalImageName)
         navigationViewController.tabBarItem.selectedImage = UIImage(
             systemName: Constant.chartSelectedImageName)
+        let chartDIContainer = dependencies.makeChartDIContainer()
+        let coordinator = chartDIContainer.makeChartFlowCoordinator(navigationController: navigationViewController)
+        coordinator.start()
         return navigationViewController
     }
     


### PR DESCRIPTION
close #329 

## 완료된 기능

- 코디네이터 패턴으로 통계 페이지 연결
- Custom Date Picker 구현
- 기타 카테고리 계산하는 로직 추가
- 주간 학습 통계 UI 구현

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/138603822/95b9817f-c9d3-4f1f-b844-4d14473f1d77





## 고민과 해결과정

1. 다크모드 대응 문제 노션에 업로드 해 두었습니다.

2. Custom Date Picker의 Date Property (날짜 변화) <-> 차트 View의 SelectedDate <-> View Model의 날짜별 차트 관리에서 고민이 있었는데, @Binding property wrapper를 활용해서 바인딩하였습니다.

3. 카테고리를 설정하지 않고 학습한 시간의 라벨을 따로 빼주어야 했는데, 다음과 같은 코드로 UseCase에서 계산해주었습니다.

```swift
func fetchDailyChartLog(at date: Date) async throws -> CategoryChartLog {
        var chartLog = try await repository.fetchDailyLog(date: date)
        
        var etcTime = chartLog.studyLog.category.reduce(0) { (result, category) in
            return result + (category.studyTime ?? 0)
        }
        
        etcTime = chartLog.studyLog.totalTime - etcTime
        
        let etcCategory = Category(id: 0, color: "FFFFFFFF", subject: "기타", studyTime: etcTime)
            chartLog.studyLog.category.append(etcCategory)
        
        return chartLog
    }
```

4. 차트페이지에서 SE 대응이 조금 힘들어서 Autolayout으로 지정한 Constant Height를 Device에 대응시키기 위해서 
`(UIScreen.main.bounds.size.height / 844)` 값을 모두 곱해주었는 데, 해당 방법이 Device에는 정확히 대응할 수 있는데, 옳은 방법인 지는 모르겠습니다.