### PR TITLE
[iOS/#344] 일일 통계 페이지 카테고리 색상 반영

### DIFF
--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
@@ -23,7 +23,7 @@ final class DefaultChartUseCase: ChartUseCase {
         
         etcTime = chartLog.studyLog.totalTime - etcTime
         
-        let etcCategory = Category(id: 0, color: "FFFFFFFF", subject: "기타", studyTime: etcTime)
+        let etcCategory = Category(id: 0, color: "888888FF", subject: "기타", studyTime: etcTime)
             chartLog.studyLog.category.append(etcCategory)
         
         return chartLog

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -34,6 +34,9 @@ struct DailyChartView: View {
                                 }
                         }
                     }
+                    .chartForegroundStyleScale(domain: viewModel.dailyChartLog.studyLog.category.compactMap({ category in
+                        category.subject
+                    }), range: getColorArray(categories: viewModel.dailyChartLog.studyLog.category))
                     .frame(height: 400 * (UIScreen.main.bounds.size.height / 844))
                     .chartBackground { _ in
                         VStack {
@@ -61,6 +64,17 @@ struct DailyChartView: View {
                 }
             }
         }.padding()
+    }
+    
+    func getColorArray(categories: [Category]) -> [Color] {
+        let colorArray: [Color] = categories.map { category in
+            if let uiColor = UIColor(hexString: category.color) {
+                return Color(uiColor)
+            } else {
+                return Color.gray
+            }
+        }
+        return colorArray
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -19,33 +19,34 @@ struct DailyChartView: View {
     var body: some View {
         VStack {
             CustomCalenderView(selectedDate: $selectedDate, viewModel: viewModel)
-            if #available(iOS 17.0, *) {
-                Chart {
-                    ForEach(viewModel.dailyChartLog.studyLog.category, id: \.subject) { category in
-                        SectorMark(angle: .value("시간", category.studyTime ?? 0), innerRadius: .ratio(0.65), angularInset: 3.0)
-                            .foregroundStyle(by: .value("카테고리", category.subject))
-                            .cornerRadius(10.0)
-                            .annotation(position: .overlay) {
-                                if category.studyTime != 0 {
-                                    Text("\(category.studyTime ?? 0)")
-                                        .font(.headline)
+            ScrollView(.vertical) {
+                if #available(iOS 17.0, *) {
+                    Chart {
+                        ForEach(viewModel.dailyChartLog.studyLog.category, id: \.subject) { category in
+                            SectorMark(angle: .value("시간", category.studyTime ?? 0), innerRadius: .ratio(0.65), angularInset: 3.0)
+                                .foregroundStyle(by: .value("카테고리", category.subject))
+                                .cornerRadius(10.0)
+                                .annotation(position: .overlay) {
+                                    if category.studyTime != 0 {
+                                        Text("\(category.studyTime ?? 0)")
+                                            .font(.headline)
+                                    }
                                 }
-                            }
+                        }
                     }
-                }
-                .frame(height: 400 * (UIScreen.main.bounds.size.height / 844))
-                .chartBackground { _ in
-                    VStack {
-                        Text("총 학습 시간").font(.callout)
-                            .foregroundStyle(.secondary)
-                        Text("\(viewModel.dailyChartLog.studyLog.totalTime.secondsToStringTime())").font(.system(size: 36))}
-                    .padding(.bottom, 20)
-                }
-            } else if #available(iOS 16.0, *) {
+                    .frame(height: 400 * (UIScreen.main.bounds.size.height / 844))
+                    .chartBackground { _ in
+                        VStack {
+                            Text("총 학습 시간").font(.callout)
+                                .foregroundStyle(.secondary)
+                            Text("\(viewModel.dailyChartLog.studyLog.totalTime.secondsToStringTime())").font(.system(size: 36))}
+                        .padding(.bottom, 20)
+                    }
+                } else if #available(iOS 16.0, *) {
                     Text("총 학습 시간").font(.callout)
                         .foregroundStyle(.secondary)
                     Text("\(viewModel.dailyChartLog.studyLog.totalTime.secondsToStringTime())").font(.system(size: 36))
-        
+                    
                     Chart {
                         ForEach(viewModel.dailyChartLog.studyLog.category, id: \.subject) { category in
                             BarMark(x: .value("시간", Float(category.studyTime ?? 0) / 60), y: .value("카테고리", category.subject))
@@ -55,8 +56,9 @@ struct DailyChartView: View {
                     .chartLegend(.hidden)
                     .frame(height: 360 * (UIScreen.main.bounds.size.height / 844))
                     .chartXAxisLabel("분 (m)")
-            } else {
-                Text("iOS 16.0 이상 버전부터 차트 기능 사용 가능")
+                } else {
+                    Text("iOS 16.0 이상 버전부터 차트 기능 사용 가능")
+                }
             }
         }.padding()
     }


### PR DESCRIPTION

close #344 
## 완료된 기능

일일 통계 페이지 카테고리 색상 반영

## 고민과 해결과정

SwiftUI 대단하군요, `chartforegroundstylescale` method로 손쉽게 범주의 색상을 변경할 수 있었습니다.
Category의 color string을 [Color] Array로 변환하는 함수 구현하여 반영했습니다.