### PR TITLE
[iOS#349] 마이페이지 닉네임, 프로필 사진 수정 로직 수정

### DIFF
--- a/iOS/FlipMate/FlipMate/Common/UserDefault/UserDefault.swift
+++ b/iOS/FlipMate/FlipMate/Common/UserDefault/UserDefault.swift
@@ -12,6 +12,7 @@ import Combine
 struct UserDefault<T> {
     private let key: String
     private let defaultValue: T
+    private let subject = PassthroughSubject<T, Never>()
     
     init(key: String, defaultValue: T) {
         self.key = key
@@ -23,11 +24,12 @@ struct UserDefault<T> {
             return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
         }
         set {
+            subject.send(newValue)
             UserDefaults.standard.set(newValue, forKey: key)
         }
     }
     
     var projectedValue: AnyPublisher<T, Never> {
-        return Just(wrappedValue).eraseToAnyPublisher()
+        return subject.eraseToAnyPublisher()
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -111,18 +111,18 @@ final class MyPageViewController: BaseViewController {
     // MARK: - Binding
     override func bind() {
         viewModel.nicknamePublisher
-            .sink { nickname in
-                DispatchQueue.main.async {
-                    self.userNicknameLabel.text = nickname
-                }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] nickname in
+                guard let self = self else { return }
+                self.userNicknameLabel.text = nickname
             }
             .store(in: &cancellables)
         
-        viewModel.imageDataPublisher
-            .sink { imageData in
-                DispatchQueue.main.async {
-                    self.profileImageView.image = UIImage(data: imageData)
-                }
+        viewModel.imageURLPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] imageURL in
+                guard let self = self else { return }
+                self.profileImageView.setImage(url: imageURL)
             }
             .store(in: &cancellables)
         

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -175,33 +175,34 @@ final class ProfileSettingsViewController: BaseViewController {
     // MARK: - Viewmodel Binding
     override func bind() {
         viewModel.nicknamePublisher
-            .sink { name in
-                DispatchQueue.main.async {
-                    self.nickNameTextField.text = name
-                }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] name in
+                guard let self = self else { return }
+                self.nickNameTextField.text = name
             }
             .store(in: &cancellables)
         
-        viewModel.imageDataPublisher
-            .sink { imageData in
-                DispatchQueue.main.async {
-                    self.profileImageView.image = UIImage(data: imageData)
-                }
+        viewModel.imageURLPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] imageURL in
+                guard let self = self else { return }
+                self.profileImageView.setImage(url: imageURL)
             }
             .store(in: &cancellables)
         
         viewModel.isValidNickNamePublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
+                guard let self = self else { return }
                 FMLogger.general.log("닉네임 유효성 상태 : \(state.message)")
-                self?.configureNickNameTextField(state)
+                self.configureNickNameTextField(state)
             }
             .store(in: &cancellables)
         
         viewModel.isProfileImageChangedPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                DispatchQueue.main.async {
-                    self?.doneButton.isEnabled = true
-                }
+                self?.doneButton.isEnabled = true
             }
             .store(in: &cancellables)
         

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
@@ -15,7 +15,7 @@ protocol MyPageViewModelInput {
 protocol MyPageViewModelOutput {
     var tableViewDataSourcePublisher: AnyPublisher<[[String]], Never> { get }
     var nicknamePublisher: AnyPublisher<String, Never> { get }
-    var imageDataPublisher: AnyPublisher<Data, Never> { get }
+    var imageURLPublisher: AnyPublisher<String, Never> { get }
     var errorPublisher: AnyPublisher<Error, Never> { get }
 }
 
@@ -31,25 +31,16 @@ final class MyPageViewModel: MyPageViewModelProtocol {
     
     private lazy var tableViewDataSourceSubject = CurrentValueSubject<[[String]], Never>(myPageDataSource)
     private var nicknameSubject = PassthroughSubject<String, Never>()
-    private var imageDataSubject = PassthroughSubject<Data, Never>()
+    private var imageURLSubject = PassthroughSubject<String, Never>()
     private var errorSubject = PassthroughSubject<Error, Never>()
     
     // MARK: - Input
     func viewReady() {
         tableViewDataSourceSubject.send(myPageDataSource)
         let nickname = UserInfoStorage.nickname
+        let imageURL = UserInfoStorage.profileImageURL
         nicknameSubject.send(nickname)
-        guard let url = URL(string: UserInfoStorage.profileImageURL) else {
-            return
-        }
-        DispatchQueue.global().async {
-            do {
-                let data = try Data(contentsOf: url)
-                self.imageDataSubject.send(data)
-            } catch let error {
-                self.errorSubject.send(error)
-            }
-        }
+        imageURLSubject.send(imageURL)
     }
     
     // MARK: - Output
@@ -61,8 +52,8 @@ final class MyPageViewModel: MyPageViewModelProtocol {
         return nicknameSubject.eraseToAnyPublisher()
     }
     
-    var imageDataPublisher: AnyPublisher<Data, Never> {
-        return imageDataSubject.eraseToAnyPublisher()
+    var imageURLPublisher: AnyPublisher<String, Never> {
+        return imageURLSubject.eraseToAnyPublisher()
     }
     
     var errorPublisher: AnyPublisher<Error, Never> {

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/ProfileSettingsViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/ProfileSettingsViewModel.swift
@@ -21,7 +21,7 @@ protocol ProfileSettingsViewModelInput {
 
 protocol ProfileSettingsViewModelOutput {
     var nicknamePublisher: AnyPublisher<String, Never> { get }
-    var imageDataPublisher: AnyPublisher<Data, Never> { get }
+    var imageURLPublisher: AnyPublisher<String, Never> { get }
     var isValidNickNamePublisher: AnyPublisher<NickNameValidationState, Never> { get }
     var isProfileImageChangedPublisher: AnyPublisher<Void, Never> { get }
     var isSignUpCompletedPublisher: AnyPublisher<Void, Never> { get }
@@ -36,7 +36,7 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
     
     // MARK: - Subjects
     private var nameSubject = PassthroughSubject<String, Never>()
-    private var imageDataSubject = PassthroughSubject<Data, Never>()
+    private var imageURLSubject = PassthroughSubject<String, Never>()
     private var isValidNickNameSubject = PassthroughSubject<NickNameValidationState, Never>()
     private var isProfileImageChangedSubject = PassthroughSubject<Void, Never>()
     private var isSignUpCompletedSubject = PassthroughSubject<Void, Never>()
@@ -51,18 +51,9 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
     // MARK: - Input
     func viewReady() {
         let nickname = UserInfoStorage.nickname
+        let imageURL = UserInfoStorage.profileImageURL
         nameSubject.send(nickname)
-        guard let url = URL(string: UserInfoStorage.profileImageURL) else {
-            return
-        }
-        DispatchQueue.global().async {
-            do {
-                let data = try Data(contentsOf: url)
-                self.imageDataSubject.send(data)
-            } catch let error {
-                self.errorSubject.send(error)
-            }
-        }
+        imageURLSubject.send(imageURL)
     }
     
     func nickNameChanged(_ newNickName: String) {
@@ -101,8 +92,8 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
         return nameSubject.eraseToAnyPublisher()
     }
     
-    var imageDataPublisher: AnyPublisher<Data, Never> {
-        return imageDataSubject.eraseToAnyPublisher()
+    var imageURLPublisher: AnyPublisher<String, Never> {
+        return imageURLSubject.eraseToAnyPublisher()
     }
     var isValidNickNamePublisher: AnyPublisher<NickNameValidationState, Never> {
         return isValidNickNameSubject

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
@@ -160,6 +160,7 @@ private extension SocialViewModel {
     
     func getUserProfile() {
         UserInfoStorage.$nickname
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] nickName in
                 guard let self = self else { return }
                 self.nicknameSubject.send(nickName)
@@ -167,6 +168,7 @@ private extension SocialViewModel {
             .store(in: &cancellables)
         
         UserInfoStorage.$profileImageURL
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] profileImageURL in
                 guard let self = self else { return }
                 self.profileImageSubject.send(profileImageURL)


### PR DESCRIPTION
closed #349 

## 완료된 기능
- 마이페이지에서 프로필 설정 시 소셜 화면에 반영
- 마이페이지 사용자 이미지 캐싱된 이미지 가져오도록 수정
- 프로필 수정 이미지 캐싱된 이미지 가져오도록 수정

## 실행 결과

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/9734cfa5-dcc4-422f-ad83-9d290f49ff06


## 고민과 해결과정
### UserDefault 프로퍼티 래퍼 수정
기존에 프로퍼티래퍼의 profjectValue을 통해서 UserDefault의 value을 바인딩해줬었는데
값이 바뀔때마다 새로운 profjectValue을 통해서 접근할 때마다 새로운 publisher 생기던 문제가 있어서
값이 바뀌는 경우에 새로운 값이 데이터 스트림에 보내지는게 아니라 새로운 값이 담긴 새로운 데이터 스트림이 생겼습니다.
그래서 내부에 subject을 생성해 해당 값을 읽을 때마다 subject을 통해 바인딩하도록 수정했습니다~~

``` swift
@propertyWrapper
struct UserDefault<T> {
    private let key: String
    private let defaultValue: T
    private let subject = PassthroughSubject<T, Never>() // 추가
    
    init(key: String, defaultValue: T) {
        self.key = key
        self.defaultValue = defaultValue
    }

    var wrappedValue: T {
        get {
            return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
        }
        set {
            subject.send(newValue) // 추가
            UserDefaults.standard.set(newValue, forKey: key)
        }
    }
    
    var projectedValue: AnyPublisher<T, Never> {
        return subject.eraseToAnyPublisher() // 수정
    }
}

```

