### PR TITLE
[iOS/#326] swiftLint 강제 언래핑 룰 적용

### DIFF
--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -83,7 +83,11 @@ export class AuthController {
     if (file) {
       const isNomal = await this.usersService.isNormalImage(file);
       if (!isNomal) {
-        throw new BadRequestException('유해한 이미지 입니다!!');
+        throw new BadRequestException({
+          statusCode: 40001,
+          message: '유해한 이미지입니다.',
+          error: 'Bad Request',
+        });
       }
       image_url = await this.usersService.s3Upload(file);
     }

--- a/BE/src/categories/categories.entity.ts
+++ b/BE/src/categories/categories.entity.ts
@@ -40,10 +40,11 @@ export class Categories {
   })
   @IsString()
   @Length(1, 8)
-  @Matches(/^[0-9A-F]{1,8}$/i, {message: '올바른 색상 코드가 아닙니다.'})
+  @Matches(/^[0-9A-F]{1,8}$/i, { message: '올바른 색상 코드가 아닙니다.' })
   color_code: string;
 
   @ManyToOne(() => UsersModel, (user) => user.categories, {
+    eager: true,
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'user_id' })

--- a/BE/src/categories/categories.service.ts
+++ b/BE/src/categories/categories.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Injectable,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -75,11 +76,20 @@ export class CategoriesService {
     categoriesData: CategoryUpdateDto,
     id: number,
   ): Promise<CategoryDto> {
-    // todo - user_id를 검증
+    if (!user_id || !categoriesData || !id) {
+      throw new BadRequestException('인자의 형식이 잘못되었습니다.');
+    }
     const category = await this.categoriesRepository.findOne({
       where: { id },
-      relations: ['user_id'],
     });
+    if (!category) {
+      throw new NotFoundException('해당 카테고리가 존재하지 않습니다.');
+    }
+    if (category.user_id.id !== user_id) {
+      throw new UnauthorizedException(
+        '해당 유저가 카테고리를 소유하고 있지 않습니다.',
+      );
+    }
     category.name = categoriesData.name;
     category.color_code = categoriesData.color_code;
     const updatedCategory = await this.categoriesRepository.save(category);
@@ -87,11 +97,20 @@ export class CategoriesService {
   }
 
   async remove(user_id: number, id: number): Promise<void> {
-    // todo - user_id를 검증
-    const result = await this.categoriesRepository.delete(id);
-    if (result.affected === 0) {
+    if (!user_id || !id) {
+      throw new BadRequestException('인자의 형식이 잘못되었습니다.');
+    }
+    const record = await this.categoriesRepository.findOne({ where: { id } });
+    if (!record) {
       throw new NotFoundException('해당 카테고리가 존재하지 않습니다.');
     }
+    if (record.user_id.id !== user_id) {
+      throw new UnauthorizedException(
+        '해당 유저가 카테고리를 소유하고 있지 않습니다.',
+      );
+    }
+
+    const result = await this.categoriesRepository.delete(id);
   }
 
   entityToDto(category: Categories): CategoryDto {

--- a/BE/src/common/config/multer.config.ts
+++ b/BE/src/common/config/multer.config.ts
@@ -9,8 +9,11 @@ export const multerConfig = (): MulterOptions => {
     const ext = path.extname(file.originalname);
     if (ext !== '.jpg' && ext !== '.jpeg' && ext !== '.png') {
       return callback(
-        new BadRequestException('jpg/jpeg/png 파일만 업로드 가능합니다!'),
-        false,
+        new BadRequestException({
+          statusCode: 40002,
+          message: 'jpg/jpeg/png 파일만 업로드 가능합니다!',
+          error: 'Bad Request',
+        }),
       );
     }
     return callback(null, true);

--- a/BE/src/common/exception-filter/http-exception-filter.ts
+++ b/BE/src/common/exception-filter/http-exception-filter.ts
@@ -21,7 +21,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
       : `0ms`;
 
     const errorResponse = {
-      statusCode: status,
+      statusCode: exception.getResponse()['statusCode'] || status,
       message: exception?.message,
       error: exception?.getResponse()['error'],
       path: request.url,

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -29,9 +29,11 @@ export class UsersService {
       return await this.usersRepository.save(userObject);
     } catch (error) {
       if (error.code === 'ER_DUP_ENTRY' || error.errno === 1062) {
-        throw new BadRequestException(
-          '닉네임 또는 이메일이 이미 사용 중입니다.',
-        );
+        throw new BadRequestException({
+          statusCode: 40000,
+          message: '닉네임 또는 이메일이 이미 사용 중입니다.',
+          error: 'Bad request',
+        });
       }
       throw error;
     }
@@ -66,7 +68,11 @@ export class UsersService {
       return updatedUser;
     } catch (error) {
       if (error.code === 'ER_DUP_ENTRY' || error.errno === 1062) {
-        throw new BadRequestException('닉네임이 이미 사용 중입니다.');
+        throw new BadRequestException({
+          statusCode: 40000,
+          message: '닉네임이 이미 사용 중입니다.',
+          error: 'Bad request',
+        });
       }
       throw error;
     }
@@ -104,7 +110,11 @@ export class UsersService {
     const result = response.images[0].result;
     const message = response.images[0].message;
     if (message !== 'SUCCESS') {
-      throw new BadRequestException('이미지 인식 실패');
+      throw new BadRequestException({
+        statusCode: 40002,
+        message: '이미지 인식 실패',
+        error: 'Bad request',
+      });
     }
     const normalScore = result.normal.confidence;
     const isNormal = normalScore > THRESHOLD ? true : false;
@@ -140,7 +150,11 @@ export class UsersService {
 
       return response.json();
     } catch (error) {
-      throw new BadRequestException('이미지 검사 요청 실패');
+      throw new BadRequestException({
+        statusCode: 40002,
+        message: '이미지 인식 실패',
+        error: 'Bad request',
+      });
     }
   }
 

--- a/BE/test/load-performance/loadtest-social.js
+++ b/BE/test/load-performance/loadtest-social.js
@@ -1,7 +1,6 @@
 import { SharedArray } from 'k6/data';
 import http from 'k6/http';
-import { check, sleep, group } from 'k6';
-import { setInterval, setTimeout, clearInterval } from 'k6/experimental/timers';
+import { check, sleep } from 'k6';
 import moment from 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js';
 import faker from 'https://cdnjs.cloudflare.com/ajax/libs/Faker/3.1.0/faker.min.js';
 

--- a/BE/test/load-performance/loadtest-stats.js
+++ b/BE/test/load-performance/loadtest-stats.js
@@ -1,0 +1,76 @@
+import { SharedArray } from 'k6/data';
+import http from 'k6/http';
+import { sleep, group } from 'k6';
+import moment from 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js';
+
+const HOST = 'http://localhost:3000';
+const start_date = moment('2023-11-30');
+
+const tokens = new SharedArray('possible tokens', function () {
+  const mock_users = JSON.parse(open('./loadtest-mock.json'));
+  return mock_users.map(({ access_token }) => access_token);
+});
+
+export const options = {
+  //10초만에 사용자 200명 까지 증가했다가 2분동안 유지함
+  scenarios: {
+    statsDaily: {
+      executor: 'ramping-vus',
+      startVUs: 10,
+      stages: [
+        { duration: '10s', target: 100 },
+        { duration: '2m', target: 100 },
+      ],
+      exec: 'statsDaily',
+    },
+    statsWeekly: {
+      executor: 'ramping-vus',
+      startVUs: 10,
+      stages: [
+        { duration: '10s', target: 100 },
+        { duration: '2m', target: 100 },
+      ],
+      exec: 'statsWeekly',
+    },
+  },
+  thresholds: {
+    http_req_duration: ['avg<200', 'p(95)<500', 'max<1000'],
+  },
+};
+
+function getParams() {
+  const token = tokens[__VU % tokens.length];
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+}
+
+export function statsDaily() {
+  const params = getParams();
+  group('일간 조회 7번', () => {
+    let date = start_date;
+    for (let i = 0; i < 7; i++) {
+      //오늘, 1일전, 2일전, 3일전, 4일전, 5일전, 6일전 데이터 1초마다 조회
+      http.get(
+        `${HOST}/study-logs/stats?date=${date.format('YYYY-MM-DD')}`,
+        params,
+      );
+      date = date.subtract(1, 'd');
+      sleep(1);
+    }
+  });
+}
+
+export function statsWeekly() {
+  const params = getParams();
+  group('일주일간 조회', () => {
+    //일주일 동안의 데이터 조회
+    http.get(
+      `${HOST}/study-logs/stats/weekly?date=${start_date.format('YYYY-MM-DD')}`,
+      params,
+    );
+    sleep(1);
+  });
+}

--- a/BE/test/mock-repo/mock-categories-repo.ts
+++ b/BE/test/mock-repo/mock-categories-repo.ts
@@ -19,4 +19,28 @@ export class MockCategoriesRepository {
     );
     return Promise.resolve(categories);
   }
+
+  findOne({ where: { id } }): Promise<object> {
+    const category = this.data.find((category) => category.id === id);
+    if (!category) {
+      return Promise.resolve(null);
+    }
+    const result = {
+      ...category,
+      user_id: { id: category.user_id },
+    };
+    return Promise.resolve(result);
+  }
+
+  delete(id): Promise<object> {
+    const category = this.data.find((category) => category.id === id);
+    return Promise.resolve(category);
+  }
+
+  count({ where: { user_id } }): Promise<number> {
+    const categories = this.data.filter(
+      (category) => category.user_id === user_id.id,
+    );
+    return Promise.resolve(categories.length);
+  }
 }

--- a/BE/test/mock-table/categories.json
+++ b/BE/test/mock-table/categories.json
@@ -15,6 +15,60 @@
     "id": 3,
     "name": "수학",
     "color_code": "CCCCCC",
-    "user_id": 4
+    "user_id": 3
+  },
+  {
+    "id": 4,
+    "name": "영어",
+    "color_code": "DDDDDD",
+    "user_id": 3
+  },
+  {
+    "id": 5,
+    "name": "국어",
+    "color_code": "EEEEEE",
+    "user_id": 3
+  },
+  {
+    "id": 6,
+    "name": "사회",
+    "color_code": "FFFFFF",
+    "user_id": 3
+  },
+  {
+    "id": 7,
+    "name": "과학",
+    "color_code": "FFFFFF",
+    "user_id": 3
+  },
+  {
+    "id": 8,
+    "name": "수학",
+    "color_code": "CCCCCC",
+    "user_id": 3
+  },
+  {
+    "id": 9,
+    "name": "영어",
+    "color_code": "DDDDDD",
+    "user_id": 3
+  },
+  {
+    "id": 10,
+    "name": "국어",
+    "color_code": "EEEEEE",
+    "user_id": 3
+  },
+  {
+    "id": 11,
+    "name": "사회",
+    "color_code": "FFFFFF",
+    "user_id": 3
+  },
+  {
+    "id": 12,
+    "name": "과학",
+    "color_code": "FFFFFF",
+    "user_id": 3
   }
 ]

--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0A814BC3CFA46D0501C8B894 /* Pods_FlipMate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288FECD685A9C6B6E481147C /* Pods_FlipMate.framework */; };
+		2C1F2BBB2B20D8D60026C30B /* SocialUserInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F2BBA2B20D8D60026C30B /* SocialUserInfoHeaderView.swift */; };
+		2C1F2BBD2B20DA770026C30B /* ProfileHeaderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F2BBC2B20DA770026C30B /* ProfileHeaderItem.swift */; };
 		2C2F216E2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F216D2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift */; };
 		2C2F21702B0F429800B45BA8 /* StudyLogResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F216F2B0F429800B45BA8 /* StudyLogResponseDTO.swift */; };
 		2C2F21762B0F440D00B45BA8 /* StudyLogEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F21752B0F440D00B45BA8 /* StudyLogEndpoints.swift */; };
@@ -44,13 +46,13 @@
 		2C801D832B04C64F00A7ABAE /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C801D822B04C64F00A7ABAE /* TimerManager.swift */; };
 		2C87C2772B1C789A00A26313 /* FriendStatusPollingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2762B1C789A00A26313 /* FriendStatusPollingManager.swift */; };
 		2C87C2792B1C794000A26313 /* UpdateFriend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2782B1C794000A26313 /* UpdateFriend.swift */; };
-		2C87C28E2B1E316800A26313 /* SignOutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C28D2B1E316800A26313 /* SignOutManager.swift */; };
 		2C87C27B2B1DF11000A26313 /* UserInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C27A2B1DF11000A26313 /* UserInfoResponseDTO.swift */; };
 		2C87C27D2B1DF1C300A26313 /* DefaultUserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C27C2B1DF1C300A26313 /* DefaultUserInfoRepository.swift */; };
 		2C87C27F2B1DF2A800A26313 /* UserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C27E2B1DF2A800A26313 /* UserInfoRepository.swift */; };
 		2C87C2812B1DF2C000A26313 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2802B1DF2C000A26313 /* UserInfo.swift */; };
 		2C87C2832B1DF30E00A26313 /* UserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2822B1DF30E00A26313 /* UserInfoUseCase.swift */; };
 		2C87C2852B1DF32A00A26313 /* DefaultUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2842B1DF32A00A26313 /* DefaultUserInfoUseCase.swift */; };
+		2C87C28E2B1E316800A26313 /* SignOutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C28D2B1E316800A26313 /* SignOutManager.swift */; };
 		2C87C2912B1F212200A26313 /* ImageDownLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2902B1F212200A26313 /* ImageDownLoader.swift */; };
 		2C87C2932B1F344500A26313 /* UIImageView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2922B1F344500A26313 /* UIImageView++Extension.swift */; };
 		2C87C2952B1F345800A26313 /* ImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2942B1F345800A26313 /* ImageFetcher.swift */; };
@@ -247,6 +249,8 @@
 		22B8C8EC4954AA20D64D3139 /* Pods-FlipMate.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMate.release.xcconfig"; path = "Target Support Files/Pods-FlipMate/Pods-FlipMate.release.xcconfig"; sourceTree = "<group>"; };
 		288FECD685A9C6B6E481147C /* Pods_FlipMate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B285F39D7D27E5C564F4D31 /* Pods_FlipMateTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMateTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C1F2BBA2B20D8D60026C30B /* SocialUserInfoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialUserInfoHeaderView.swift; sourceTree = "<group>"; };
+		2C1F2BBC2B20DA770026C30B /* ProfileHeaderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeaderItem.swift; sourceTree = "<group>"; };
 		2C2F216D2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStudyLogUseCase.swift; sourceTree = "<group>"; };
 		2C2F216F2B0F429800B45BA8 /* StudyLogResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyLogResponseDTO.swift; sourceTree = "<group>"; };
 		2C2F21752B0F440D00B45BA8 /* StudyLogEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyLogEndpoints.swift; sourceTree = "<group>"; };
@@ -284,13 +288,13 @@
 		2C801D822B04C64F00A7ABAE /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
 		2C87C2762B1C789A00A26313 /* FriendStatusPollingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendStatusPollingManager.swift; sourceTree = "<group>"; };
 		2C87C2782B1C794000A26313 /* UpdateFriend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateFriend.swift; sourceTree = "<group>"; };
-		2C87C28D2B1E316800A26313 /* SignOutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SignOutManager.swift; path = FlipMate/Presentation/Utils/SignOutManager.swift; sourceTree = SOURCE_ROOT; };
 		2C87C27A2B1DF11000A26313 /* UserInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoResponseDTO.swift; sourceTree = "<group>"; };
 		2C87C27C2B1DF1C300A26313 /* DefaultUserInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultUserInfoRepository.swift; sourceTree = "<group>"; };
 		2C87C27E2B1DF2A800A26313 /* UserInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRepository.swift; sourceTree = "<group>"; };
 		2C87C2802B1DF2C000A26313 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		2C87C2822B1DF30E00A26313 /* UserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoUseCase.swift; sourceTree = "<group>"; };
 		2C87C2842B1DF32A00A26313 /* DefaultUserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultUserInfoUseCase.swift; sourceTree = "<group>"; };
+		2C87C28D2B1E316800A26313 /* SignOutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SignOutManager.swift; path = FlipMate/Presentation/Utils/SignOutManager.swift; sourceTree = SOURCE_ROOT; };
 		2C87C2902B1F212200A26313 /* ImageDownLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownLoader.swift; sourceTree = "<group>"; };
 		2C87C2922B1F344500A26313 /* UIImageView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView++Extension.swift"; sourceTree = "<group>"; };
 		2C87C2942B1F345800A26313 /* ImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFetcher.swift; sourceTree = "<group>"; };
@@ -643,6 +647,14 @@
 			path = FriendStatusPollingManager;
 			sourceTree = "<group>";
 		};
+		2C87C28C2B1E315600A26313 /* SignOutManager */ = {
+			isa = PBXGroup;
+			children = (
+				2C87C28D2B1E316800A26313 /* SignOutManager.swift */,
+			);
+			path = SignOutManager;
+			sourceTree = "<group>";
+		};
 		2C87C28F2B1F210F00A26313 /* ImageDownloader */ = {
 			isa = PBXGroup;
 			children = (
@@ -651,14 +663,6 @@
 				2C87C2962B1F346700A26313 /* ImageDownLoaderError.swift */,
 			);
 			path = ImageDownloader;
-            sourceTree = "<group>";
-        };
-		2C87C28C2B1E315600A26313 /* SignOutManager */ = {
-			isa = PBXGroup;
-			children = (
-				2C87C28D2B1E316800A26313 /* SignOutManager.swift */,
-			);
-			path = SignOutManager;
 			sourceTree = "<group>";
 		};
 		2C88DCF72B1242C7000B4686 /* Flows */ = {
@@ -817,6 +821,7 @@
 				2CDCD0662B18D0330080DCDE /* FriendUser.swift */,
 				2CDCD0682B18D0D10080DCDE /* FriendSearchItem.swift */,
 				2C87C2782B1C794000A26313 /* UpdateFriend.swift */,
+				2C1F2BBC2B20DA770026C30B /* ProfileHeaderItem.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1327,6 +1332,7 @@
 				ED6865C02B1E3B48001A2AAD /* WeeklyChartView.swift */,
 				ED6865BE2B1E2FA6001A2AAD /* ChartSegmentedControl.swift */,
 				ED6865D72B1F32EF001A2AAD /* CustomCalenderView.swift */,
+				2C1F2BBA2B20D8D60026C30B /* SocialUserInfoHeaderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1764,12 +1770,14 @@
 				2C87C2772B1C789A00A26313 /* FriendStatusPollingManager.swift in Sources */,
 				2C87C2912B1F212200A26313 /* ImageDownLoader.swift in Sources */,
 				ED6865C62B1E438B001A2AAD /* ChartEndpoints.swift in Sources */,
+				2C1F2BBD2B20DA770026C30B /* ProfileHeaderItem.swift in Sources */,
 				2C88DD0F2B14C22C000B4686 /* TimerFinishViewModel.swift in Sources */,
 				2C4D55B32B035484006D7C26 /* DeviceOrientation.swift in Sources */,
 				ED3842272B0F1E0C001E2803 /* GoogleAuthUseCase.swift in Sources */,
 				ED6865C42B1E4303001A2AAD /* DailyChartLogResponseDTO.swift in Sources */,
 				ED6865A22B162B8F001A2AAD /* SocialChartView.swift in Sources */,
 				2C88DCF22B124238000B4686 /* AppFlowCoordinator.swift in Sources */,
+				2C1F2BBB2B20D8D60026C30B /* SocialUserInfoHeaderView.swift in Sources */,
 				2C9F62112B17363400AE63F9 /* DefaultFriendUseCase.swift in Sources */,
 				2CDCD0642B18CEDF0080DCDE /* FriendsResponseDTO.swift in Sources */,
 				ED1B3F292B1F8AA300FB9DBC /* WeeklyChartLogResponseDTO.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
+++ b/iOS/FlipMate/FlipMate/Application/SceneDelegate.swift
@@ -62,7 +62,7 @@ private extension SceneDelegate {
     func receiveSignOut() {
         appDIContainer.signOutManager.signOutPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] isSignOut in
+            .sink { [weak self] _ in
                 guard let self = self else { return }
                 self.resetAppFlowCoordinator()
                 self.appFlowCoordinator?.start()

--- a/iOS/FlipMate/FlipMate/Common/UserDefault/UserDefault.swift
+++ b/iOS/FlipMate/FlipMate/Common/UserDefault/UserDefault.swift
@@ -12,6 +12,7 @@ import Combine
 struct UserDefault<T> {
     private let key: String
     private let defaultValue: T
+    private let subject = PassthroughSubject<T, Never>()
     
     init(key: String, defaultValue: T) {
         self.key = key
@@ -23,11 +24,12 @@ struct UserDefault<T> {
             return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
         }
         set {
+            subject.send(newValue)
             UserDefaults.standard.set(newValue, forKey: key)
         }
     }
     
     var projectedValue: AnyPublisher<T, Never> {
-        return Just(wrappedValue).eraseToAnyPublisher()
+        return subject.eraseToAnyPublisher()
     }
 }

--- a/iOS/FlipMate/FlipMate/Data/Extension/Data++Extension.swift
+++ b/iOS/FlipMate/FlipMate/Data/Extension/Data++Extension.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// swiftlint:disable force_unwrapping
 extension Data {
     static func makeMultiPartRequestBody(userName: String, jpegImageData: Data, boundary: String) -> Data {
         var body = Data()
@@ -27,3 +28,4 @@ extension Data {
         return body
     }
 }
+// swiftlint: enable force_unwrapping

--- a/iOS/FlipMate/FlipMate/Data/Network/ChartEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/ChartEndpoints.swift
@@ -17,6 +17,8 @@ struct ChartEndpoints {
     
     static func fetchWeeklyLog() -> EndPoint<WeeklyChartLogResponseDTO> {
         let date = Date()
-        return EndPoint(baseURL: BaseURL.flipmateDomain, path: Paths.studylogs + "/stats/weekly" + "?date=\(date.dateToString(format: .yyyyMMdd))", method: .get)
+        return EndPoint(
+            baseURL: BaseURL.flipmateDomain,
+            path: Paths.studylogs + "/stats/weekly" + "?date=\(date.dateToString(format: .yyyyMMdd))", method: .get)
     }
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/StatusResponseWithErrorDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/StatusResponseWithErrorDTO.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 struct StatusResponseWithErrorDTO: Decodable {
+    let statusCode: Int
     let message: String
     let error: String
-    let statusCode: Int
+    let path: String
+    let timestamp: String
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/MockURLSession.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/MockURLSession.swift
@@ -27,11 +27,17 @@ class MockURLSession: URLSessionable {
             return Fail(error: URLError(.badURL)).eraseToAnyPublisher()
         }
         
-        let httpResponse = HTTPURLResponse(
-            url: request.url!,
+        guard let url = request.url else {
+            return Fail(error: URLError(.badURL)).eraseToAnyPublisher()
+        }
+        
+        guard let httpResponse = HTTPURLResponse(
+            url: url,
             statusCode: status.statusCode,
             httpVersion: nil,
-            headerFields: nil)!
+            headerFields: nil) else {
+            return Fail(error: URLError(.badURL)).eraseToAnyPublisher()
+        }
         
         guard let data = response.data else { return Just((data: Data(), response: httpResponse))
                 .setFailureType(to: URLError.self)
@@ -48,11 +54,17 @@ class MockURLSession: URLSessionable {
             throw URLError(.badURL)
         }
         
-        let httpResponse = HTTPURLResponse(
-            url: request.url!,
+        guard let url = request.url else {
+            throw NetworkError.invalidURLComponents
+        }
+        
+        guard let httpResponse = HTTPURLResponse(
+            url: url,
             statusCode: status.statusCode,
             httpVersion: nil,
-            headerFields: nil)!
+            headerFields: nil) else {
+            throw NetworkError.invalidResponse
+        }
         
         guard let data = response.data else {
             return ((data: Data(), response: httpResponse))

--- a/iOS/FlipMate/FlipMate/Data/Persistants/KeyChainManager.swift
+++ b/iOS/FlipMate/FlipMate/Data/Persistants/KeyChainManager.swift
@@ -11,10 +11,14 @@ final class KeychainManager {
     private static let serviceName = "FlipMate"
     
     static func saveAccessToken(token: String) throws {
+        guard let tokenData = token.data(using: .utf8) else {
+            throw KeychainError.noToken
+        }
+        
         let query: [String: AnyObject] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: serviceName as AnyObject,
-            kSecValueData as String: token.data(using: .utf8)! as AnyObject
+            kSecValueData as String: tokenData as AnyObject
         ]
         
         let status = SecItemAdd(query as CFDictionary, nil)

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultChartRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultChartRepository.swift
@@ -35,7 +35,11 @@ final class DefaultChartRepository: ChartRepository {
             return DailyData(day: dayOfWeekString, studyTime: studyTime)
         }
         
-        return WeeklyChartLog(totalTime: responseDTO.totalTime, dailyData: transformedDailyData, primaryCategory: responseDTO.primaryCategory, percentage: responseDTO.percentage)
+        return WeeklyChartLog(
+            totalTime: responseDTO.totalTime,
+            dailyData: transformedDailyData,
+            primaryCategory: responseDTO.primaryCategory,
+            percentage: responseDTO.percentage)
     }
 }
 
@@ -44,14 +48,17 @@ private extension DefaultChartRepository {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "EEE"
         let dayOfWeekString = dateFormatter.string(from: date)
-
+        
         return dayOfWeekString
     }
     
     func dateForDayIndex(_ index: Int) -> Date {
-            let calendar = Calendar.current
-            let today = calendar.startOfDay(for: Date())
-            let day = calendar.date(byAdding: .day, value: -index, to: today)!
-            return day
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        guard let day = calendar.date(byAdding: .day, value: -index, to: today) else {
+            FMLogger.general.error("date 계산 실패")
+            return Date()
         }
+        return day
+    }
 }

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultProfileSettingsRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultProfileSettingsRepository.swift
@@ -20,12 +20,6 @@ final class DefaultProfileSettingsRepository: ProfileSettingsRepository {
         return !response.isUnique
     }
     
-    // API 필요
-    func checkProfileImageSafety(_ imageData: Data) async throws -> Bool {
-        FMLogger.general.error("API 미구현, 항상 true 반환")
-        return true
-    }
-    
     func setupNewProfileInfo(nickName: String, profileImageData: Data) async throws -> UserInfo {
         let endpoint = SignUpEndpoints.userSignUp(nickName: nickName, profileImageData: profileImageData)
         let response = try await provider.request(with: endpoint)

--- a/iOS/FlipMate/FlipMate/Domain/Repositories/ProfileSettingsRepository.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Repositories/ProfileSettingsRepository.swift
@@ -9,6 +9,5 @@ import Foundation
 
 protocol ProfileSettingsRepository {
     func checkIfNickNameIsDuplicated(_ nickName: String) async throws -> Bool
-    func checkProfileImageSafety(_ imageData: Data) async throws -> Bool
     func setupNewProfileInfo(nickName: String, profileImageData: Data) async throws -> UserInfo
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
@@ -23,7 +23,7 @@ final class DefaultChartUseCase: ChartUseCase {
         
         etcTime = chartLog.studyLog.totalTime - etcTime
         
-        let etcCategory = Category(id: 0, color: "FFFFFFFF", subject: "기타", studyTime: etcTime)
+        let etcCategory = Category(id: 0, color: "888888FF", subject: "기타", studyTime: etcTime)
             chartLog.studyLog.category.append(etcCategory)
         
         return chartLog

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultProfileSettingsUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultProfileSettingsUseCase.swift
@@ -18,20 +18,8 @@ final class DefaultProfileSettingsUseCase: ProfileSettingsUseCase {
     }
     
     func isNickNameValid(_ nickName: String) async throws -> NickNameValidationState {
-        let isDuplicated = try await repository.checkIfNickNameIsDuplicated(nickName)
-        guard !isDuplicated else {
-            return .duplicated
-        }
         let validationState = validator.checkNickNameValidationState(nickName)
         return validationState
-    }
-    
-    func isNickNameDuplicated(_ nickName: String) async throws -> Bool {
-        return try await repository.checkIfNickNameIsDuplicated(nickName)
-    }
-    
-    func isSafeProfileImage(_ imageData: Data) async throws -> Bool {
-        return try await repository.checkProfileImageSafety(imageData)
     }
     
     func setupProfileInfo(nickName: String, profileImageData: Data) async throws -> UserInfo {

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/ProfileSettingsUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/ProfileSettingsUseCase.swift
@@ -9,6 +9,5 @@ import Foundation
 
 protocol ProfileSettingsUseCase {
     func isNickNameValid(_ nickName: String) async throws -> NickNameValidationState
-    func isSafeProfileImage(_ imageData: Data) async throws -> Bool
     func setupProfileInfo(nickName: String, profileImageData: Data) async throws -> UserInfo
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/Flow/ChartFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/Flow/ChartFlowCoordinator.swift
@@ -29,4 +29,3 @@ final class ChartFlowCoordinator: Coordinator {
         navigationController.viewControllers = [chartViewController]
     }
 }
-

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
@@ -61,6 +61,7 @@ struct CustomCalenderView: View {
     
     @ViewBuilder
     private var dayView: some View {
+        // swiftlint:disable force_unwrapping
         let today = calendar.date(from: Calendar.current.dateComponents([.year, .month], from: selectedDate))!
         
         ScrollView(.horizontal, showsIndicators: false) {
@@ -90,6 +91,7 @@ struct CustomCalenderView: View {
                 }
             }
         }
+        // swiftlint:enable force_unwrapping
     }
     
     private var blurView: some View {

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -19,33 +19,37 @@ struct DailyChartView: View {
     var body: some View {
         VStack {
             CustomCalenderView(selectedDate: $selectedDate, viewModel: viewModel)
-            if #available(iOS 17.0, *) {
-                Chart {
-                    ForEach(viewModel.dailyChartLog.studyLog.category, id: \.subject) { category in
-                        SectorMark(angle: .value("시간", category.studyTime ?? 0), innerRadius: .ratio(0.65), angularInset: 3.0)
-                            .foregroundStyle(by: .value("카테고리", category.subject))
-                            .cornerRadius(10.0)
-                            .annotation(position: .overlay) {
-                                if category.studyTime != 0 {
-                                    Text("\(category.studyTime ?? 0)")
-                                        .font(.headline)
+            ScrollView(.vertical) {
+                if #available(iOS 17.0, *) {
+                    Chart {
+                        ForEach(viewModel.dailyChartLog.studyLog.category, id: \.subject) { category in
+                            SectorMark(angle: .value("시간", category.studyTime ?? 0), innerRadius: .ratio(0.65), angularInset: 3.0)
+                                .foregroundStyle(by: .value("카테고리", category.subject))
+                                .cornerRadius(10.0)
+                                .annotation(position: .overlay) {
+                                    if category.studyTime != 0 {
+                                        Text("\(category.studyTime ?? 0)")
+                                            .font(.headline)
+                                    }
                                 }
-                            }
+                        }
                     }
-                }
-                .frame(height: 400 * (UIScreen.main.bounds.size.height / 844))
-                .chartBackground { _ in
-                    VStack {
-                        Text("총 학습 시간").font(.callout)
-                            .foregroundStyle(.secondary)
-                        Text("\(viewModel.dailyChartLog.studyLog.totalTime.secondsToStringTime())").font(.system(size: 36))}
-                    .padding(.bottom, 20)
-                }
-            } else if #available(iOS 16.0, *) {
+                    .chartForegroundStyleScale(domain: viewModel.dailyChartLog.studyLog.category.compactMap({ category in
+                        category.subject
+                    }), range: getColorArray(categories: viewModel.dailyChartLog.studyLog.category))
+                    .frame(height: 400 * (UIScreen.main.bounds.size.height / 844))
+                    .chartBackground { _ in
+                        VStack {
+                            Text("총 학습 시간").font(.callout)
+                                .foregroundStyle(.secondary)
+                            Text("\(viewModel.dailyChartLog.studyLog.totalTime.secondsToStringTime())").font(.system(size: 36))}
+                        .padding(.bottom, 20)
+                    }
+                } else if #available(iOS 16.0, *) {
                     Text("총 학습 시간").font(.callout)
                         .foregroundStyle(.secondary)
                     Text("\(viewModel.dailyChartLog.studyLog.totalTime.secondsToStringTime())").font(.system(size: 36))
-        
+                    
                     Chart {
                         ForEach(viewModel.dailyChartLog.studyLog.category, id: \.subject) { category in
                             BarMark(x: .value("시간", Float(category.studyTime ?? 0) / 60), y: .value("카테고리", category.subject))
@@ -55,10 +59,22 @@ struct DailyChartView: View {
                     .chartLegend(.hidden)
                     .frame(height: 360 * (UIScreen.main.bounds.size.height / 844))
                     .chartXAxisLabel("분 (m)")
-            } else {
-                Text("iOS 16.0 이상 버전부터 차트 기능 사용 가능")
+                } else {
+                    Text("iOS 16.0 이상 버전부터 차트 기능 사용 가능")
+                }
             }
         }.padding()
+    }
+    
+    func getColorArray(categories: [Category]) -> [Color] {
+        let colorArray: [Color] = categories.map { category in
+            if let uiColor = UIColor(hexString: category.color) {
+                return Color(uiColor)
+            } else {
+                return Color.gray
+            }
+        }
+        return colorArray
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -77,4 +77,3 @@ struct DailyChartView: View {
         return colorArray
     }
 }
-

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/SocialUserInfoHeaderView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/SocialUserInfoHeaderView.swift
@@ -1,0 +1,128 @@
+//
+//  SocialUserInfoHeaderView.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/07.
+//
+
+import UIKit
+
+final class SocialUserInfoHeaderView: UICollectionReusableView {
+      
+    // MARK: - Constant
+    private enum Constant {
+        static let defaultNickName = "닉네임"
+        static let defaultTime = "00:00:00"
+    }
+    
+    private enum ProfileImageViewConstant {
+        static var width: CGFloat = 90
+        static var height: CGFloat = 90
+        static var top: CGFloat = 32
+    }
+    
+    private enum UserNameLabelConstant {
+        static var bottom: CGFloat = 8
+        static var title = "닉네임"
+    }
+    
+    private enum LearningTimeLabelConstant {
+        static var bottom: CGFloat = 8
+        static var title = "00:00:00"
+    }
+    
+    private enum DividerConstant {
+        static var bottom: CGFloat = 24
+        static var height: CGFloat = 1
+    }
+    
+    // MARK: UI Components
+    private lazy var profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.image = UIImage(resource: .defaultProfile)
+        imageView.clipsToBounds = true
+        imageView.bounds = CGRect(x: 0, y: 0, width: ProfileImageViewConstant.width, height: ProfileImageViewConstant.height)
+        imageView.layer.cornerRadius = imageView.bounds.height / 2
+        imageView.isUserInteractionEnabled = true
+        return imageView
+    }()
+    
+    private lazy var userNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = FlipMateFont.mediumBold.font
+        label.text = Constant.defaultNickName
+        label.textColor = .label
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private lazy var learningTimeLabel: UILabel = {
+        let label = UILabel()
+        label.font = FlipMateFont.mediumBold.font
+        label.text = Constant.defaultTime
+        label.textColor = .label
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private lazy var divider: UIView = {
+        let divider = UIView()
+        divider.backgroundColor = .gray
+        return divider
+    }()
+        
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Don't use storyboard")
+    }
+    
+    func update(nickname: String) {
+        userNameLabel.text = nickname
+    }
+    
+    func update(profileImageURL: String) {
+        profileImageView.setImage(url: profileImageURL)
+    }
+    
+    func update(learningTime: Int) {
+        learningTimeLabel.text = learningTime.secondsToStringTime()
+    }
+}
+
+// MARK: - UI Setting
+private extension SocialUserInfoHeaderView {
+    func configureUI() {
+        [ profileImageView, userNameLabel, learningTimeLabel, divider ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            self.addSubview($0)
+        }
+        
+        NSLayoutConstraint.activate([
+            profileImageView.topAnchor.constraint(equalTo: self.topAnchor, constant: ProfileImageViewConstant.top),
+            profileImageView.widthAnchor.constraint(equalToConstant: ProfileImageViewConstant.width),
+            profileImageView.heightAnchor.constraint(equalToConstant: ProfileImageViewConstant.height),
+            profileImageView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            
+            userNameLabel.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: UserNameLabelConstant.bottom),
+            userNameLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            userNameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            userNameLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            
+            learningTimeLabel.topAnchor.constraint(equalTo: userNameLabel.bottomAnchor, constant: LearningTimeLabelConstant.bottom),
+            learningTimeLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            learningTimeLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            learningTimeLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            
+            divider.topAnchor.constraint(equalTo: learningTimeLabel.bottomAnchor, constant: DividerConstant.bottom),
+            divider.leadingAnchor.constraint(equalTo: leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: trailingAnchor),
+            divider.heightAnchor.constraint(equalToConstant: DividerConstant.height)
+        ])
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/WeeklyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/WeeklyChartView.swift
@@ -50,5 +50,9 @@ struct WeeklyChartView: View {
 }
 
 #Preview {
-    WeeklyChartView(viewModel: ChartViewModel(chartUseCase: DefaultChartUseCase(repository: DefaultChartRepository(provider: Provider(urlSession: URLSession.shared)))))
+    WeeklyChartView(
+        viewModel: ChartViewModel(
+            chartUseCase: DefaultChartUseCase(
+                repository: DefaultChartRepository(
+                    provider: Provider(urlSession: URLSession.shared)))))
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/WeeklyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/WeeklyChartView.swift
@@ -17,17 +17,33 @@ struct WeeklyChartView: View {
     
     var body: some View {
         VStack {
-            Text("주간 학습 통계").font(.title).padding(.trailing, 150).padding(.bottom, 30)
+            Text("주간 학습 추이").font(.title).padding(.trailing, 180).padding(.bottom, 30)
             if #available(iOS 16.0, *) {
-                Chart {
-                    ForEach(viewModel.weeklyChartLog.dailyData, id: \.day) { data in
-                        BarMark(x: .value("요일", data.day), y: .value("분", Float(data.studyTime) / 60))
-                            .foregroundStyle(by: .value("", data.day))
+                ScrollView(.vertical) {
+                    Chart {
+                        ForEach(viewModel.weeklyChartLog.dailyData, id: \.day) { data in
+                            BarMark(x: .value("요일", data.day), y: .value("분", Float(data.studyTime) / 60))
+                                .foregroundStyle(by: .value("", data.day))
+                                .annotation {
+                                    Text("\(data.studyTime)")
+                                        .font(.caption)
+                                        .foregroundStyle(.gray)
+                                }
+                        }
                     }
+                    .chartYAxis(.hidden)
+                    .chartLegend(.hidden)
+                    .padding(.top, 10)
+                    .padding(.bottom, 10)
+                    .frame(height: 300 * (UIScreen.main.bounds.size.height / 844))
                 }
-                .frame(height: 400 * (UIScreen.main.bounds.size.height / 844))
             } else {
                 Text("iOS 16.0 이상 버전부터 차트 기능 사용 가능")
+            }
+        }
+        .onAppear {
+            Task {
+                try await viewModel.showWeeklyChart()
             }
         }
     }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -88,7 +88,11 @@ private extension ChartViewController {
     }
     
     func setDailyChart() {
-        let dailyChartView = DailyChartView(viewModel: ChartViewModel(chartUseCase: DefaultChartUseCase(repository: DefaultChartRepository(provider: Provider(urlSession: URLSession.shared))), actions: nil))
+        let dailyChartView = DailyChartView(
+            viewModel: ChartViewModel(
+                chartUseCase: DefaultChartUseCase(
+                    repository: DefaultChartRepository(
+                        provider: Provider(urlSession: URLSession.shared))), actions: nil))
         let hostingController = UIHostingController(rootView: dailyChartView)
         addChild(hostingController)
         guard let newChartView = hostingController.view else { return }
@@ -99,7 +103,12 @@ private extension ChartViewController {
     }
     
     func setWeeklyChart() {
-        let weeklyChartView = WeeklyChartView(viewModel: ChartViewModel(chartUseCase: DefaultChartUseCase(repository: DefaultChartRepository(provider: Provider(urlSession: URLSession.shared))), actions: nil))
+        let weeklyChartView = WeeklyChartView(
+            viewModel: ChartViewModel(
+                chartUseCase: DefaultChartUseCase(
+                    repository: DefaultChartRepository(
+                        provider: Provider(urlSession: URLSession.shared))),
+                actions: nil))
         let hostingController = UIHostingController(rootView: weeklyChartView)
         addChild(hostingController)
         guard let newChartView = hostingController.view else { return }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
@@ -33,6 +33,10 @@ final class ChartViewModel: ObservableObject {
         let today = Date()
         try await fetchDailyData(date: today)
     }
+    
+    func showWeeklyChart() async throws {
+        try await fetchWeeklyData()
+    }
 }
 
 private extension ChartViewModel {

--- a/iOS/FlipMate/FlipMate/Presentation/Mocks/StduyLogMock.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Mocks/StduyLogMock.swift
@@ -34,6 +34,7 @@ let responseData = """
     }
 """
 
+// swiftlint:disable force_unwrapping
 let studyLogMockResponse = MockResponse(
     data: responseData.data(using: .utf8),
     urlResponse: HTTPURLResponse(
@@ -43,3 +44,4 @@ let studyLogMockResponse = MockResponse(
         headerFields: nil),
     error: nil
 )
+// swiftlint:enable force_unwrapping

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -111,18 +111,18 @@ final class MyPageViewController: BaseViewController {
     // MARK: - Binding
     override func bind() {
         viewModel.nicknamePublisher
-            .sink { nickname in
-                DispatchQueue.main.async {
-                    self.userNicknameLabel.text = nickname
-                }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] nickname in
+                guard let self = self else { return }
+                self.userNicknameLabel.text = nickname
             }
             .store(in: &cancellables)
         
-        viewModel.imageDataPublisher
-            .sink { imageData in
-                DispatchQueue.main.async {
-                    self.profileImageView.image = UIImage(data: imageData)
-                }
+        viewModel.imageURLPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] imageURL in
+                guard let self = self else { return }
+                self.profileImageView.setImage(url: imageURL)
             }
             .store(in: &cancellables)
         

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -175,33 +175,34 @@ final class ProfileSettingsViewController: BaseViewController {
     // MARK: - Viewmodel Binding
     override func bind() {
         viewModel.nicknamePublisher
-            .sink { name in
-                DispatchQueue.main.async {
-                    self.nickNameTextField.text = name
-                }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] name in
+                guard let self = self else { return }
+                self.nickNameTextField.text = name
             }
             .store(in: &cancellables)
         
-        viewModel.imageDataPublisher
-            .sink { imageData in
-                DispatchQueue.main.async {
-                    self.profileImageView.image = UIImage(data: imageData)
-                }
+        viewModel.imageURLPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] imageURL in
+                guard let self = self else { return }
+                self.profileImageView.setImage(url: imageURL)
             }
             .store(in: &cancellables)
         
         viewModel.isValidNickNamePublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
+                guard let self = self else { return }
                 FMLogger.general.log("닉네임 유효성 상태 : \(state.message)")
-                self?.configureNickNameTextField(state)
+                self.configureNickNameTextField(state)
             }
             .store(in: &cancellables)
         
         viewModel.isProfileImageChangedPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                DispatchQueue.main.async {
-                    self?.doneButton.isEnabled = true
-                }
+                self?.doneButton.isEnabled = true
             }
             .store(in: &cancellables)
         

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -174,19 +174,32 @@ final class ProfileSettingsViewController: BaseViewController {
     
     // MARK: - Viewmodel Binding
     override func bind() {
+        bindNickNameRelatedPublishers()
+        bindProfileImageRelatedPublishers()
+        
+        viewModel.isSignUpCompletedPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.doneButton.isEnabled = true
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.errorPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] error in
+                FMLogger.general.error("SignUpViewModel에서 에러: \(error)")
+                self?.doneButton.isEnabled = false
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func bindNickNameRelatedPublishers() {
         viewModel.nicknamePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] name in
                 guard let self = self else { return }
                 self.nickNameTextField.text = name
-            }
-            .store(in: &cancellables)
-        
-        viewModel.imageURLPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] imageURL in
-                guard let self = self else { return }
-                self.profileImageView.setImage(url: imageURL)
             }
             .store(in: &cancellables)
         
@@ -196,6 +209,16 @@ final class ProfileSettingsViewController: BaseViewController {
                 guard let self = self else { return }
                 FMLogger.general.log("닉네임 유효성 상태 : \(state.message)")
                 self.configureNickNameTextField(state)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func bindProfileImageRelatedPublishers() {
+        viewModel.imageURLPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] imageURL in
+                guard let self = self else { return }
+                self.profileImageView.setImage(url: imageURL)
             }
             .store(in: &cancellables)
         
@@ -217,22 +240,6 @@ final class ProfileSettingsViewController: BaseViewController {
                 DispatchQueue.main.async {
                     self?.present(alert, animated: true)
                 }
-            }
-            .store(in: &cancellables)
-        
-        viewModel.isSignUpCompletedPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.doneButton.isEnabled = true
-                self?.navigationController?.popViewController(animated: true)
-            }
-            .store(in: &cancellables)
-        
-        viewModel.errorPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] error in
-                FMLogger.general.error("SignUpViewModel에서 에러: \(error)")
-                self?.doneButton.isEnabled = false
             }
             .store(in: &cancellables)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
@@ -15,7 +15,7 @@ protocol MyPageViewModelInput {
 protocol MyPageViewModelOutput {
     var tableViewDataSourcePublisher: AnyPublisher<[[String]], Never> { get }
     var nicknamePublisher: AnyPublisher<String, Never> { get }
-    var imageDataPublisher: AnyPublisher<Data, Never> { get }
+    var imageURLPublisher: AnyPublisher<String, Never> { get }
     var errorPublisher: AnyPublisher<Error, Never> { get }
 }
 
@@ -31,25 +31,16 @@ final class MyPageViewModel: MyPageViewModelProtocol {
     
     private lazy var tableViewDataSourceSubject = CurrentValueSubject<[[String]], Never>(myPageDataSource)
     private var nicknameSubject = PassthroughSubject<String, Never>()
-    private var imageDataSubject = PassthroughSubject<Data, Never>()
+    private var imageURLSubject = PassthroughSubject<String, Never>()
     private var errorSubject = PassthroughSubject<Error, Never>()
     
     // MARK: - Input
     func viewReady() {
         tableViewDataSourceSubject.send(myPageDataSource)
         let nickname = UserInfoStorage.nickname
+        let imageURL = UserInfoStorage.profileImageURL
         nicknameSubject.send(nickname)
-        guard let url = URL(string: UserInfoStorage.profileImageURL) else {
-            return
-        }
-        DispatchQueue.global().async {
-            do {
-                let data = try Data(contentsOf: url)
-                self.imageDataSubject.send(data)
-            } catch let error {
-                self.errorSubject.send(error)
-            }
-        }
+        imageURLSubject.send(imageURL)
     }
     
     // MARK: - Output
@@ -61,8 +52,8 @@ final class MyPageViewModel: MyPageViewModelProtocol {
         return nicknameSubject.eraseToAnyPublisher()
     }
     
-    var imageDataPublisher: AnyPublisher<Data, Never> {
-        return imageDataSubject.eraseToAnyPublisher()
+    var imageURLPublisher: AnyPublisher<String, Never> {
+        return imageURLSubject.eraseToAnyPublisher()
     }
     
     var errorPublisher: AnyPublisher<Error, Never> {

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/ProfileSettingsViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/ProfileSettingsViewModel.swift
@@ -21,7 +21,7 @@ protocol ProfileSettingsViewModelInput {
 
 protocol ProfileSettingsViewModelOutput {
     var nicknamePublisher: AnyPublisher<String, Never> { get }
-    var imageDataPublisher: AnyPublisher<Data, Never> { get }
+    var imageURLPublisher: AnyPublisher<String, Never> { get }
     var isValidNickNamePublisher: AnyPublisher<NickNameValidationState, Never> { get }
     var isProfileImageChangedPublisher: AnyPublisher<Void, Never> { get }
     var isSignUpCompletedPublisher: AnyPublisher<Void, Never> { get }
@@ -36,7 +36,7 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
     
     // MARK: - Subjects
     private var nameSubject = PassthroughSubject<String, Never>()
-    private var imageDataSubject = PassthroughSubject<Data, Never>()
+    private var imageURLSubject = PassthroughSubject<String, Never>()
     private var isValidNickNameSubject = PassthroughSubject<NickNameValidationState, Never>()
     private var isProfileImageChangedSubject = PassthroughSubject<Void, Never>()
     private var isSignUpCompletedSubject = PassthroughSubject<Void, Never>()
@@ -51,18 +51,9 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
     // MARK: - Input
     func viewReady() {
         let nickname = UserInfoStorage.nickname
+        let imageURL = UserInfoStorage.profileImageURL
         nameSubject.send(nickname)
-        guard let url = URL(string: UserInfoStorage.profileImageURL) else {
-            return
-        }
-        DispatchQueue.global().async {
-            do {
-                let data = try Data(contentsOf: url)
-                self.imageDataSubject.send(data)
-            } catch let error {
-                self.errorSubject.send(error)
-            }
-        }
+        imageURLSubject.send(imageURL)
     }
     
     func nickNameChanged(_ newNickName: String) {
@@ -101,8 +92,8 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
         return nameSubject.eraseToAnyPublisher()
     }
     
-    var imageDataPublisher: AnyPublisher<Data, Never> {
-        return imageDataSubject.eraseToAnyPublisher()
+    var imageURLPublisher: AnyPublisher<String, Never> {
+        return imageURLSubject.eraseToAnyPublisher()
     }
     var isValidNickNamePublisher: AnyPublisher<NickNameValidationState, Never> {
         return isValidNickNameSubject

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/Flow/SocialFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/Flow/SocialFlowCoordinator.swift
@@ -37,22 +37,24 @@ final class SocialFlowCoordinator: Coordinator {
     
     private func showFreindAddViewController() {
         let actions = FriendAddViewModelActions(
-            didCancleFriendAdd: dismissFreindAddViewController,
-            didSuccessFriendAdd: dismissFreindAddViewController)
+            didCancleFriendAdd: didTapCancelNavigationButton,
+            didSuccessFriendAdd: didTapCancelNavigationButton)
         let freindAddViewContorller = dependencies.makeFriendAddViewController(actions: actions)
         let firendNavigationController = UINavigationController(rootViewController: freindAddViewContorller)
         firendNavigationController.modalPresentationStyle = .fullScreen
         navigationController?.present(firendNavigationController, animated: true)
     }
     
-    private func dismissFreindAddViewController() {
+    private func didTapCancelNavigationButton() {
         navigationController?.dismiss(animated: true)
     }
     
     func showSocialDetailViewController(friend: Friend) {
-        let actions = SocialDetailViewModelActions(didFinishUnfollow: didFinishUnfollow)
+        let actions = SocialDetailViewModelActions(didCancelSocialDetail: didTapCancelNavigationButton, didFinishUnfollow: didFinishUnfollow)
         let socialDetailViewController = dependencies.makeSocialDetailViewController(actions: actions, friend: friend)
-        navigationController?.pushViewController(socialDetailViewController, animated: true)
+        let socialDetailNavigationController = UINavigationController(rootViewController: socialDetailViewController)
+        socialDetailNavigationController.modalPresentationStyle = .fullScreen
+        navigationController?.present(socialDetailNavigationController, animated: true)
     }
     
     func showMyPageViewController() {

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/ProfileHeaderItem.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/ProfileHeaderItem.swift
@@ -1,0 +1,14 @@
+//
+//  ProfileHeaderItem.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/07.
+//
+
+import Foundation
+
+struct ProfileHeaderItem {
+    let nickname: String
+    let profileImageURL: String?
+    let learningTime: Int
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/SocialChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/SocialChartView.swift
@@ -18,19 +18,22 @@ struct SocialChartView: View {
     }
     
     var body: some View {
-        VStack {
-            if #available(iOS 16.0, *) {
-                Chart(viewModel.userSeries) { series in
-                    ForEach(series.studyTime) { time in
-                        PointMark(x: .value("날짜", time.weekday, unit: .day), y: .value("학습 시간", Float(time.studyTime) / 60))
-                        LineMark(x: .value("날짜", time.weekday, unit: .day), y: .value("학습 시간", Float(time.studyTime) / 60))
+        ScrollView(.vertical) {
+            VStack {
+                if #available(iOS 16.0, *) {
+                    Chart(viewModel.userSeries) { series in
+                        ForEach(series.studyTime) { time in
+                            PointMark(x: .value("날짜", time.weekday, unit: .day), y: .value("학습 시간", Float(time.studyTime) / 60))
+                            LineMark(x: .value("날짜", time.weekday, unit: .day), y: .value("학습 시간", Float(time.studyTime) / 60))
+                        }
+                        .foregroundStyle(by: .value("사용자", series.user))
                     }
-                    .foregroundStyle(by: .value("사용자", series.user))
+                    .frame(height: 360)
+                    .chartYAxisLabel("분 (m)")
+                } else {
+                    Text("iOS 16.0 이상 버전부터 차트 기능 사용 가능")
                 }
-                .chartYAxisLabel("분 (m)")
-            } else {
-                Text("iOS 16.0 이상 버전부터 차트 기능 사용 가능")
-            }
-        }.padding()
+            }.padding()
+        }
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialDetailViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialDetailViewController.swift
@@ -15,11 +15,14 @@ final class SocialDetailViewController: BaseViewController {
         static let dailyStudyLog = "오늘 학습 시간"
         static let weeklyStudyLog = "주간 학습 시간"
         static let primaryCategory = "최근 집중 분야"
+        static let primaryCategoryNil = "없음"
         static let unfollow = "팔로우 취소"
         static let borderWidth: CGFloat = 1
         static let cornerRadius: CGFloat = 8
         static let spacing1: CGFloat = 1
         static let spacing2: CGFloat = 12
+        static let cancelNavigationButton = "닫기"
+        static let navigationTitle = "친구 상세"
     }
     
     private enum LayoutConstant {
@@ -63,6 +66,14 @@ final class SocialDetailViewController: BaseViewController {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
         return imageView
+    }()
+    
+    private lazy var dismissButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(ComponentConstant.cancelNavigationButton, for: .normal)
+        button.setTitleColor(.label, for: .normal)
+        button.addTarget(self, action: #selector(dismissButtonDidTapped), for: .touchUpInside)
+        return button
     }()
     
     private lazy var nickNameLabel: UILabel = {
@@ -175,7 +186,7 @@ final class SocialDetailViewController: BaseViewController {
         label.font = FlipMateFont.mediumBold.font
         label.textAlignment = .right
         label.textColor = FlipMateColor.gray2.color
-        label.text = "없음"
+        label.text = ComponentConstant.primaryCategoryNil
         
         return label
     }()
@@ -216,6 +227,7 @@ final class SocialDetailViewController: BaseViewController {
         setStudyLogStackView()
         setStudyTimeStackView()
         setChart()
+        configureNavigationBar()
         
         [profileImageView, nickNameLabel, unfollowButton, divider, studyLogStackView, studyTimeStackView].forEach {
             view.addSubview($0)
@@ -315,10 +327,19 @@ private extension SocialDetailViewController {
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
         hostingController.didMove(toParent: self)
     }
+    
+    func configureNavigationBar() {
+        navigationItem.title = ComponentConstant.navigationTitle
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: dismissButton)
+    }
 }
 
 private extension SocialDetailViewController {
     @objc func unfollowButtonDidTapped() {
         viewModel.didUnfollowFriend()
+    }
+    
+    @objc func dismissButtonDidTapped() {
+        viewModel.dismissButtonDidTapped()
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialDetailViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialDetailViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import Combine
 
 struct SocialDetailViewModelActions {
+    var didCancelSocialDetail: () -> Void
     var didFinishUnfollow: () -> Void
 }
 
@@ -68,6 +69,10 @@ final class SocialDetailViewModel: ObservableObject {
                 self.actions?.didFinishUnfollow()
             }
             .store(in: &cancellables)
+    }
+    
+    func dismissButtonDidTapped() {
+        actions?.didCancelSocialDetail()
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
@@ -160,6 +160,7 @@ private extension SocialViewModel {
     
     func getUserProfile() {
         UserInfoStorage.$nickname
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] nickName in
                 guard let self = self else { return }
                 self.nicknameSubject.send(nickName)
@@ -167,6 +168,7 @@ private extension SocialViewModel {
             .store(in: &cancellables)
         
         UserInfoStorage.$profileImageURL
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] profileImageURL in
                 guard let self = self else { return }
                 self.profileImageSubject.send(profileImageURL)

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -15,13 +15,14 @@ protocol TabBarFlowCoordinatorDependencies {
     func makeChartDIContainer() -> ChartDIContainer
 }
 
-final class TabBarFlowCoordinator: Coordinator {
+final class TabBarFlowCoordinator: NSObject, Coordinator {
     var childCoordinators: [Coordinator] = []
     weak var parentCoordinator: Coordinator?
     
     weak var navigationController: UINavigationController?
     private weak var tabBarViewController: UITabBarController?
     private let dependencies: TabBarFlowCoordinatorDependencies
+    private var socialViewController: UINavigationController?
     
     init(navigationController: UINavigationController?, dependencies: TabBarFlowCoordinatorDependencies) {
         self.navigationController = navigationController
@@ -30,8 +31,9 @@ final class TabBarFlowCoordinator: Coordinator {
     
     func start() {
         let tabBarController = dependencies.makeTabBarController()
+        tabBarController.delegate = self
         tabBarController.setViewControllers(
-            [makeSocialViewController(), makeTimerViewContorller(), makeChartViewController()],
+            [setSocialViewController(), makeTimerViewContorller(), makeChartViewController()],
             animated: false
         )
         navigationController?.isNavigationBarHidden = true
@@ -64,6 +66,14 @@ final class TabBarFlowCoordinator: Coordinator {
         return navigationViewController
     }
     
+    private func setSocialViewController() -> UINavigationController {
+        let navigationViewController = UINavigationController()
+        navigationViewController.tabBarItem.image = UIImage(
+            systemName: Constant.socialNomalImageName)
+        navigationViewController.tabBarItem.selectedImage = UIImage(
+            systemName: Constant.socialSelectedImageName)
+        return navigationViewController
+    }
     private func makeChartViewController() -> UINavigationController {
         let navigationViewController = UINavigationController()
         navigationViewController.tabBarItem.image = UIImage(
@@ -81,5 +91,19 @@ final class TabBarFlowCoordinator: Coordinator {
         static let socialSelectedImageName = "person.3.fill"
         static let chartNomalImageName = "chart.bar"
         static let chartSelectedImageName = "chart.bar.fill"
+    }
+}
+
+extension TabBarFlowCoordinator: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        if let index = tabBarController.viewControllers?.firstIndex(of: viewController) {
+            if index == 0 && socialViewController == nil {
+                socialViewController = makeSocialViewController()
+                guard let socialViewController else { return }
+                tabBarController.viewControllers?[index] = socialViewController
+            } else {
+                return
+            }
+        }
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
@@ -20,7 +20,8 @@ final class TimerFinishViewController: BaseViewController {
     // MARK: - Properties
     private let viewModel: TimerFinishViewModelProtocol
     private var cancellables = Set<AnyCancellable>()
-    
+    private let deviceMotionManager = DeviceMotionManager.shared
+
     // MARK: - UI Components
     private lazy var backgroundView: UIView = {
         let view = UIView()
@@ -98,6 +99,10 @@ final class TimerFinishViewController: BaseViewController {
     }
     
     // MARK: - Life Cycle
+    override func viewDidDisappear(_ animated: Bool) {
+        deviceMotionManager.startDeviceMotion()
+    }
+    
     override func configureUI() {
         view.backgroundColor = .clear
 

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -80,6 +80,7 @@ final class TimerViewController: BaseViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        UIDevice.current.isProximityMonitoringEnabled = true
         configureNotification()
         timerViewModel.viewWillAppear()
     }
@@ -87,6 +88,8 @@ final class TimerViewController: BaseViewController {
     override func viewDidDisappear(_ animated: Bool) {
         deviceMotionManager.stopDeviceMotion()
         timerViewModel.viewDidDisappear()
+        UIDevice.current.isProximityMonitoringEnabled = false
+        NotificationCenter.default.removeObserver(self)
     }
     
     // MARK: - setup UI
@@ -202,7 +205,6 @@ private extension TimerViewController {
     }
     
     func setDeviceSetting(isEnabled: Bool) {
-        UIDevice.current.isProximityMonitoringEnabled = isEnabled
         if isEnabled {
             deviceMotionManager.startDeviceMotion()
         } else {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -30,6 +30,10 @@ final class TimerViewController: BaseViewController {
         fatalError("Don't use storyboard")
     }
     
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
     /// 오늘 학습한 총 시간 타이머
     private lazy var timerLabel: UILabel = {
         let label = UILabel()
@@ -89,7 +93,6 @@ final class TimerViewController: BaseViewController {
         deviceMotionManager.stopDeviceMotion()
         timerViewModel.viewDidDisappear()
         UIDevice.current.isProximityMonitoringEnabled = false
-        NotificationCenter.default.removeObserver(self)
     }
     
     // MARK: - setup UI

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/TimerManager/TimerManager.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/TimerManager/TimerManager.swift
@@ -109,7 +109,10 @@ private extension TimerManager {
         let diffTime = nowTime - startTime
         // 0.0000 소수점 4번째 자리까지 0이면 수행.
         // TODO: - 너무 라이브하게 구현해서 수정 필요.
-        let fourNumber = String(format: "%.4f", diffTime).split(separator: ".").map { String($0) }.last!
+        guard let fourNumber = String(format: "%.4f", diffTime).split(separator: ".").map({ String($0) }).last else {
+            FMLogger.general.error("timer 형변환 실패")
+            return
+        }
         if fourNumber == "0000" {
             totalTime += 1
             FMLogger.device.debug("경과시간: \(diffTime)")


### PR DESCRIPTION
close #326 

## 완료된 기능
- 강제 언래핑 제거
- 사용하지 않는 변수 _로 대체
- 불필요한 공백 제거

## 고민과 해결과정
### 쉽지 않은 옵셔널 바인딩..
- SwiftUI의 뷰를 반환하는 객체에서 사용되는 강제 언래핑 및 Data 익스텐션에서 멀티파트 데이터를 만들기 위한 강제 언래핑 등 쉽게 없애기 어려운 경우가 있었다.
- 이런 경우는 주석으로 해당 부분만 룰을 해제해 주었다.
- 추후 더 좋은 방법이 생긴다면 고쳐보자..