### PR TITLE
[iOS/#343] 주간 학습 통계 페이지 로직 연결

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/WeeklyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/WeeklyChartView.swift
@@ -17,17 +17,33 @@ struct WeeklyChartView: View {
     
     var body: some View {
         VStack {
-            Text("주간 학습 통계").font(.title).padding(.trailing, 150).padding(.bottom, 30)
+            Text("주간 학습 추이").font(.title).padding(.trailing, 180).padding(.bottom, 30)
             if #available(iOS 16.0, *) {
-                Chart {
-                    ForEach(viewModel.weeklyChartLog.dailyData, id: \.day) { data in
-                        BarMark(x: .value("요일", data.day), y: .value("분", Float(data.studyTime) / 60))
-                            .foregroundStyle(by: .value("", data.day))
+                ScrollView(.vertical) {
+                    Chart {
+                        ForEach(viewModel.weeklyChartLog.dailyData, id: \.day) { data in
+                            BarMark(x: .value("요일", data.day), y: .value("분", Float(data.studyTime) / 60))
+                                .foregroundStyle(by: .value("", data.day))
+                                .annotation {
+                                    Text("\(data.studyTime)")
+                                        .font(.caption)
+                                        .foregroundStyle(.gray)
+                                }
+                        }
                     }
+                    .chartYAxis(.hidden)
+                    .chartLegend(.hidden)
+                    .padding(.top, 10)
+                    .padding(.bottom, 10)
+                    .frame(height: 300 * (UIScreen.main.bounds.size.height / 844))
                 }
-                .frame(height: 400 * (UIScreen.main.bounds.size.height / 844))
             } else {
                 Text("iOS 16.0 이상 버전부터 차트 기능 사용 가능")
+            }
+        }
+        .onAppear {
+            Task {
+                try await viewModel.showWeeklyChart()
             }
         }
     }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
@@ -33,6 +33,10 @@ final class ChartViewModel: ObservableObject {
         let today = Date()
         try await fetchDailyData(date: today)
     }
+    
+    func showWeeklyChart() async throws {
+        try await fetchWeeklyData()
+    }
 }
 
 private extension ChartViewModel {


### PR DESCRIPTION


## 완료된 기능

주간 학습 통계 페이지 로직 연결

<img width="369" alt="image" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/138603822/b745058c-9f8c-46f7-9388-8902501bd0c1">


## 고민과 해결과정

디자인이 떠오르지 않아 그냥 조잡하게 만들었습니다...
다음에 추가할 UI 요소들 같이 얘기 하면 좋을 것 같습니다.