### PR TITLE
[iOS#350] 소셜 화면 사용자 프로필 CollectionView Header로 수정

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0A814BC3CFA46D0501C8B894 /* Pods_FlipMate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288FECD685A9C6B6E481147C /* Pods_FlipMate.framework */; };
+		2C1F2BBB2B20D8D60026C30B /* SocialUserInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F2BBA2B20D8D60026C30B /* SocialUserInfoHeaderView.swift */; };
+		2C1F2BBD2B20DA770026C30B /* ProfileHeaderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F2BBC2B20DA770026C30B /* ProfileHeaderItem.swift */; };
 		2C2F216E2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F216D2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift */; };
 		2C2F21702B0F429800B45BA8 /* StudyLogResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F216F2B0F429800B45BA8 /* StudyLogResponseDTO.swift */; };
 		2C2F21762B0F440D00B45BA8 /* StudyLogEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F21752B0F440D00B45BA8 /* StudyLogEndpoints.swift */; };
@@ -44,13 +46,13 @@
 		2C801D832B04C64F00A7ABAE /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C801D822B04C64F00A7ABAE /* TimerManager.swift */; };
 		2C87C2772B1C789A00A26313 /* FriendStatusPollingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2762B1C789A00A26313 /* FriendStatusPollingManager.swift */; };
 		2C87C2792B1C794000A26313 /* UpdateFriend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2782B1C794000A26313 /* UpdateFriend.swift */; };
-		2C87C28E2B1E316800A26313 /* SignOutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C28D2B1E316800A26313 /* SignOutManager.swift */; };
 		2C87C27B2B1DF11000A26313 /* UserInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C27A2B1DF11000A26313 /* UserInfoResponseDTO.swift */; };
 		2C87C27D2B1DF1C300A26313 /* DefaultUserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C27C2B1DF1C300A26313 /* DefaultUserInfoRepository.swift */; };
 		2C87C27F2B1DF2A800A26313 /* UserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C27E2B1DF2A800A26313 /* UserInfoRepository.swift */; };
 		2C87C2812B1DF2C000A26313 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2802B1DF2C000A26313 /* UserInfo.swift */; };
 		2C87C2832B1DF30E00A26313 /* UserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2822B1DF30E00A26313 /* UserInfoUseCase.swift */; };
 		2C87C2852B1DF32A00A26313 /* DefaultUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2842B1DF32A00A26313 /* DefaultUserInfoUseCase.swift */; };
+		2C87C28E2B1E316800A26313 /* SignOutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C28D2B1E316800A26313 /* SignOutManager.swift */; };
 		2C87C2912B1F212200A26313 /* ImageDownLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2902B1F212200A26313 /* ImageDownLoader.swift */; };
 		2C87C2932B1F344500A26313 /* UIImageView++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2922B1F344500A26313 /* UIImageView++Extension.swift */; };
 		2C87C2952B1F345800A26313 /* ImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C87C2942B1F345800A26313 /* ImageFetcher.swift */; };
@@ -247,6 +249,8 @@
 		22B8C8EC4954AA20D64D3139 /* Pods-FlipMate.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipMate.release.xcconfig"; path = "Target Support Files/Pods-FlipMate/Pods-FlipMate.release.xcconfig"; sourceTree = "<group>"; };
 		288FECD685A9C6B6E481147C /* Pods_FlipMate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B285F39D7D27E5C564F4D31 /* Pods_FlipMateTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMateTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C1F2BBA2B20D8D60026C30B /* SocialUserInfoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialUserInfoHeaderView.swift; sourceTree = "<group>"; };
+		2C1F2BBC2B20DA770026C30B /* ProfileHeaderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeaderItem.swift; sourceTree = "<group>"; };
 		2C2F216D2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStudyLogUseCase.swift; sourceTree = "<group>"; };
 		2C2F216F2B0F429800B45BA8 /* StudyLogResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyLogResponseDTO.swift; sourceTree = "<group>"; };
 		2C2F21752B0F440D00B45BA8 /* StudyLogEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyLogEndpoints.swift; sourceTree = "<group>"; };
@@ -284,13 +288,13 @@
 		2C801D822B04C64F00A7ABAE /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
 		2C87C2762B1C789A00A26313 /* FriendStatusPollingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendStatusPollingManager.swift; sourceTree = "<group>"; };
 		2C87C2782B1C794000A26313 /* UpdateFriend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateFriend.swift; sourceTree = "<group>"; };
-		2C87C28D2B1E316800A26313 /* SignOutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SignOutManager.swift; path = FlipMate/Presentation/Utils/SignOutManager.swift; sourceTree = SOURCE_ROOT; };
 		2C87C27A2B1DF11000A26313 /* UserInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoResponseDTO.swift; sourceTree = "<group>"; };
 		2C87C27C2B1DF1C300A26313 /* DefaultUserInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultUserInfoRepository.swift; sourceTree = "<group>"; };
 		2C87C27E2B1DF2A800A26313 /* UserInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRepository.swift; sourceTree = "<group>"; };
 		2C87C2802B1DF2C000A26313 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		2C87C2822B1DF30E00A26313 /* UserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoUseCase.swift; sourceTree = "<group>"; };
 		2C87C2842B1DF32A00A26313 /* DefaultUserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultUserInfoUseCase.swift; sourceTree = "<group>"; };
+		2C87C28D2B1E316800A26313 /* SignOutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SignOutManager.swift; path = FlipMate/Presentation/Utils/SignOutManager.swift; sourceTree = SOURCE_ROOT; };
 		2C87C2902B1F212200A26313 /* ImageDownLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownLoader.swift; sourceTree = "<group>"; };
 		2C87C2922B1F344500A26313 /* UIImageView++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView++Extension.swift"; sourceTree = "<group>"; };
 		2C87C2942B1F345800A26313 /* ImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFetcher.swift; sourceTree = "<group>"; };
@@ -643,6 +647,14 @@
 			path = FriendStatusPollingManager;
 			sourceTree = "<group>";
 		};
+		2C87C28C2B1E315600A26313 /* SignOutManager */ = {
+			isa = PBXGroup;
+			children = (
+				2C87C28D2B1E316800A26313 /* SignOutManager.swift */,
+			);
+			path = SignOutManager;
+			sourceTree = "<group>";
+		};
 		2C87C28F2B1F210F00A26313 /* ImageDownloader */ = {
 			isa = PBXGroup;
 			children = (
@@ -651,14 +663,6 @@
 				2C87C2962B1F346700A26313 /* ImageDownLoaderError.swift */,
 			);
 			path = ImageDownloader;
-            sourceTree = "<group>";
-        };
-		2C87C28C2B1E315600A26313 /* SignOutManager */ = {
-			isa = PBXGroup;
-			children = (
-				2C87C28D2B1E316800A26313 /* SignOutManager.swift */,
-			);
-			path = SignOutManager;
 			sourceTree = "<group>";
 		};
 		2C88DCF72B1242C7000B4686 /* Flows */ = {
@@ -817,6 +821,7 @@
 				2CDCD0662B18D0330080DCDE /* FriendUser.swift */,
 				2CDCD0682B18D0D10080DCDE /* FriendSearchItem.swift */,
 				2C87C2782B1C794000A26313 /* UpdateFriend.swift */,
+				2C1F2BBC2B20DA770026C30B /* ProfileHeaderItem.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1327,6 +1332,7 @@
 				ED6865C02B1E3B48001A2AAD /* WeeklyChartView.swift */,
 				ED6865BE2B1E2FA6001A2AAD /* ChartSegmentedControl.swift */,
 				ED6865D72B1F32EF001A2AAD /* CustomCalenderView.swift */,
+				2C1F2BBA2B20D8D60026C30B /* SocialUserInfoHeaderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1764,12 +1770,14 @@
 				2C87C2772B1C789A00A26313 /* FriendStatusPollingManager.swift in Sources */,
 				2C87C2912B1F212200A26313 /* ImageDownLoader.swift in Sources */,
 				ED6865C62B1E438B001A2AAD /* ChartEndpoints.swift in Sources */,
+				2C1F2BBD2B20DA770026C30B /* ProfileHeaderItem.swift in Sources */,
 				2C88DD0F2B14C22C000B4686 /* TimerFinishViewModel.swift in Sources */,
 				2C4D55B32B035484006D7C26 /* DeviceOrientation.swift in Sources */,
 				ED3842272B0F1E0C001E2803 /* GoogleAuthUseCase.swift in Sources */,
 				ED6865C42B1E4303001A2AAD /* DailyChartLogResponseDTO.swift in Sources */,
 				ED6865A22B162B8F001A2AAD /* SocialChartView.swift in Sources */,
 				2C88DCF22B124238000B4686 /* AppFlowCoordinator.swift in Sources */,
+				2C1F2BBB2B20D8D60026C30B /* SocialUserInfoHeaderView.swift in Sources */,
 				2C9F62112B17363400AE63F9 /* DefaultFriendUseCase.swift in Sources */,
 				2CDCD0642B18CEDF0080DCDE /* FriendsResponseDTO.swift in Sources */,
 				ED1B3F292B1F8AA300FB9DBC /* WeeklyChartLogResponseDTO.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/SocialUserInfoHeaderView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/SocialUserInfoHeaderView.swift
@@ -1,0 +1,128 @@
+//
+//  SocialUserInfoHeaderView.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/07.
+//
+
+import UIKit
+
+final class SocialUserInfoHeaderView: UICollectionReusableView {
+      
+    // MARK: - Constant
+    private enum Constant {
+        static let defaultNickName = "닉네임"
+        static let defaultTime = "00:00:00"
+    }
+    
+    private enum ProfileImageViewConstant {
+        static var width: CGFloat = 90
+        static var height: CGFloat = 90
+        static var top: CGFloat = 32
+    }
+    
+    private enum UserNameLabelConstant {
+        static var bottom: CGFloat = 8
+        static var title = "닉네임"
+    }
+    
+    private enum LearningTimeLabelConstant {
+        static var bottom: CGFloat = 8
+        static var title = "00:00:00"
+    }
+    
+    private enum DividerConstant {
+        static var bottom: CGFloat = 24
+        static var height: CGFloat = 1
+    }
+    
+    // MARK: UI Components
+    private lazy var profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.image = UIImage(resource: .defaultProfile)
+        imageView.clipsToBounds = true
+        imageView.bounds = CGRect(x: 0, y: 0, width: ProfileImageViewConstant.width, height: ProfileImageViewConstant.height)
+        imageView.layer.cornerRadius = imageView.bounds.height / 2
+        imageView.isUserInteractionEnabled = true
+        return imageView
+    }()
+    
+    private lazy var userNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = FlipMateFont.mediumBold.font
+        label.text = Constant.defaultNickName
+        label.textColor = .label
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private lazy var learningTimeLabel: UILabel = {
+        let label = UILabel()
+        label.font = FlipMateFont.mediumBold.font
+        label.text = Constant.defaultTime
+        label.textColor = .label
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private lazy var divider: UIView = {
+        let divider = UIView()
+        divider.backgroundColor = .gray
+        return divider
+    }()
+        
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Don't use storyboard")
+    }
+    
+    func update(nickname: String) {
+        userNameLabel.text = nickname
+    }
+    
+    func update(profileImageURL: String) {
+        profileImageView.setImage(url: profileImageURL)
+    }
+    
+    func update(learningTime: Int) {
+        learningTimeLabel.text = learningTime.secondsToStringTime()
+    }
+}
+
+// MARK: - UI Setting
+private extension SocialUserInfoHeaderView {
+    func configureUI() {
+        [ profileImageView, userNameLabel, learningTimeLabel, divider ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            self.addSubview($0)
+        }
+        
+        NSLayoutConstraint.activate([
+            profileImageView.topAnchor.constraint(equalTo: self.topAnchor, constant: ProfileImageViewConstant.top),
+            profileImageView.widthAnchor.constraint(equalToConstant: ProfileImageViewConstant.width),
+            profileImageView.heightAnchor.constraint(equalToConstant: ProfileImageViewConstant.height),
+            profileImageView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            
+            userNameLabel.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: UserNameLabelConstant.bottom),
+            userNameLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            userNameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            userNameLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            
+            learningTimeLabel.topAnchor.constraint(equalTo: userNameLabel.bottomAnchor, constant: LearningTimeLabelConstant.bottom),
+            learningTimeLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            learningTimeLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            learningTimeLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            
+            divider.topAnchor.constraint(equalTo: learningTimeLabel.bottomAnchor, constant: DividerConstant.bottom),
+            divider.leadingAnchor.constraint(equalTo: leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: trailingAnchor),
+            divider.heightAnchor.constraint(equalToConstant: DividerConstant.height)
+        ])
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/ProfileHeaderItem.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/ProfileHeaderItem.swift
@@ -1,0 +1,14 @@
+//
+//  ProfileHeaderItem.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/07.
+//
+
+import Foundation
+
+struct ProfileHeaderItem {
+    let nickname: String
+    let profileImageURL: String?
+    let learningTime: Int
+}

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -15,13 +15,14 @@ protocol TabBarFlowCoordinatorDependencies {
     func makeChartDIContainer() -> ChartDIContainer
 }
 
-final class TabBarFlowCoordinator: Coordinator {
+final class TabBarFlowCoordinator: NSObject, Coordinator {
     var childCoordinators: [Coordinator] = []
     weak var parentCoordinator: Coordinator?
     
     weak var navigationController: UINavigationController?
     private weak var tabBarViewController: UITabBarController?
     private let dependencies: TabBarFlowCoordinatorDependencies
+    private var socialViewController: UINavigationController?
     
     init(navigationController: UINavigationController?, dependencies: TabBarFlowCoordinatorDependencies) {
         self.navigationController = navigationController
@@ -30,8 +31,9 @@ final class TabBarFlowCoordinator: Coordinator {
     
     func start() {
         let tabBarController = dependencies.makeTabBarController()
+        tabBarController.delegate = self
         tabBarController.setViewControllers(
-            [makeSocialViewController(), makeTimerViewContorller(), makeChartViewController()],
+            [setSocialViewController(), makeTimerViewContorller(), makeChartViewController()],
             animated: false
         )
         navigationController?.isNavigationBarHidden = true
@@ -64,6 +66,14 @@ final class TabBarFlowCoordinator: Coordinator {
         return navigationViewController
     }
     
+    private func setSocialViewController() -> UINavigationController {
+        let navigationViewController = UINavigationController()
+        navigationViewController.tabBarItem.image = UIImage(
+            systemName: Constant.socialNomalImageName)
+        navigationViewController.tabBarItem.selectedImage = UIImage(
+            systemName: Constant.socialSelectedImageName)
+        return navigationViewController
+    }
     private func makeChartViewController() -> UINavigationController {
         let navigationViewController = UINavigationController()
         navigationViewController.tabBarItem.image = UIImage(
@@ -81,5 +91,19 @@ final class TabBarFlowCoordinator: Coordinator {
         static let socialSelectedImageName = "person.3.fill"
         static let chartNomalImageName = "chart.bar"
         static let chartSelectedImageName = "chart.bar.fill"
+    }
+}
+
+extension TabBarFlowCoordinator: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        if let index = tabBarController.viewControllers?.firstIndex(of: viewController) {
+            if index == 0 && socialViewController == nil {
+                socialViewController = makeSocialViewController()
+                guard let socialViewController else { return }
+                tabBarController.viewControllers?[index] = socialViewController
+            } else {
+                return
+            }
+        }
     }
 }


### PR DESCRIPTION
closed #350 

## 완료된 기능
- 소셜 탭 선택 시 메모리에 올라가도록 수정 
- SocialUserInfoHeaderView 구현
- 소셜 화면 header 뷰 추가 및 바인딩

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/dbe947af-fe94-4021-b719-3e75a9d583f1


## 고민과 해결과정
### TabBarController selectedIndex 이슈
현재 TabBarFlowCoordinator에서 setViewControllers() 메소드로 순서대로 [소셜,  타이머, 차트] 이렇게 설정해주고
selectedIndex를 1로 변경하여 타이머 화면으로 전환하도록 되어있는데 소셜 화면의 collectionView을 바인딩하다가
viewDidLoad 메소드가 앱이 시작될 시에 타이머 화면이 보이지만 실행되는 것을 확인했습니다.....

기본설정되어있는 tabBar의 selectedIndex가 0이었기 때문에 소셜 ViewController가 메모리에 올라간 뒤에 타이머 ViewController로
화면이 전환되는 것으로 판단되어 갖가지 방법을 찾아서 소셜 ViewController가 메모리에 로드되지 않도록 시도했습니다.

결과적으로 초기에 flowCoordinator에서 TabBarController의 viewController을 설정할 떄 빈 navigationController을 할당하고
그 뒤에 소셜 탭이 선택되었을 때 소셜 ViewController을 생성하여 보여주는 방식으로 수정했습니다. 

tabBarController의 viewControllers의 배열 가장 처음에 있는 ViewControiller만 메모리에 올라가기 때문에
index가 1인경우에만 처리해줬습니다!

``` swift
extension TabBarFlowCoordinator: UITabBarControllerDelegate {
    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
        if let index = tabBarController.viewControllers?.firstIndex(of: viewController) {
            if index == 0 && socialViewController == nil {
                socialViewController = makeSocialViewController()
                guard let socialViewController else { return }
                tabBarController.viewControllers?[index] = socialViewController
            } else {
                return
            }
        }
    }
}
```

### 그리고 현재 마이페이지와 프로필 설정 화면에서 이전 화면으로 pop될때 메모리에서 해제되지 않는 문제가 있습니다~~

