### PR TITLE
[iOS/#321] 이미지 유해성 검사 기능 구현

### DIFF
--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/StatusResponseWithErrorDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/StatusResponseWithErrorDTO.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 struct StatusResponseWithErrorDTO: Decodable {
+    let statusCode: Int
     let message: String
     let error: String
-    let statusCode: Int
+    let path: String
+    let timestamp: String
 }

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultProfileSettingsRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultProfileSettingsRepository.swift
@@ -20,12 +20,6 @@ final class DefaultProfileSettingsRepository: ProfileSettingsRepository {
         return !response.isUnique
     }
     
-    // API 필요
-    func checkProfileImageSafety(_ imageData: Data) async throws -> Bool {
-        FMLogger.general.error("API 미구현, 항상 true 반환")
-        return true
-    }
-    
     func setupNewProfileInfo(nickName: String, profileImageData: Data) async throws -> UserInfo {
         let endpoint = SignUpEndpoints.userSignUp(nickName: nickName, profileImageData: profileImageData)
         let response = try await provider.request(with: endpoint)

--- a/iOS/FlipMate/FlipMate/Domain/Repositories/ProfileSettingsRepository.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Repositories/ProfileSettingsRepository.swift
@@ -9,6 +9,5 @@ import Foundation
 
 protocol ProfileSettingsRepository {
     func checkIfNickNameIsDuplicated(_ nickName: String) async throws -> Bool
-    func checkProfileImageSafety(_ imageData: Data) async throws -> Bool
     func setupNewProfileInfo(nickName: String, profileImageData: Data) async throws -> UserInfo
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultProfileSettingsUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultProfileSettingsUseCase.swift
@@ -18,20 +18,8 @@ final class DefaultProfileSettingsUseCase: ProfileSettingsUseCase {
     }
     
     func isNickNameValid(_ nickName: String) async throws -> NickNameValidationState {
-        let isDuplicated = try await repository.checkIfNickNameIsDuplicated(nickName)
-        guard !isDuplicated else {
-            return .duplicated
-        }
         let validationState = validator.checkNickNameValidationState(nickName)
         return validationState
-    }
-    
-    func isNickNameDuplicated(_ nickName: String) async throws -> Bool {
-        return try await repository.checkIfNickNameIsDuplicated(nickName)
-    }
-    
-    func isSafeProfileImage(_ imageData: Data) async throws -> Bool {
-        return try await repository.checkProfileImageSafety(imageData)
     }
     
     func setupProfileInfo(nickName: String, profileImageData: Data) async throws -> UserInfo {

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/ProfileSettingsUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/ProfileSettingsUseCase.swift
@@ -9,6 +9,5 @@ import Foundation
 
 protocol ProfileSettingsUseCase {
     func isNickNameValid(_ nickName: String) async throws -> NickNameValidationState
-    func isSafeProfileImage(_ imageData: Data) async throws -> Bool
     func setupProfileInfo(nickName: String, profileImageData: Data) async throws -> UserInfo
 }

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -96,7 +96,6 @@ final class ProfileSettingsViewController: BaseViewController {
     
     private let viewModel: ProfileSettingsViewModelProtocol
     private var cancellables = Set<AnyCancellable>()
-    private var typingTimer: Timer?
     
     init(viewModel: ProfileSettingsViewModelProtocol) {
         self.viewModel = viewModel
@@ -253,25 +252,6 @@ private extension ProfileSettingsViewController {
         doneButton.isEnabled = false
         guard let text = sender.text else {
             FMLogger.user.log("닉네임 텍스트필드 내용 없음")
-            return
-        }
-        
-        if typingTimer != nil {
-            typingTimer?.invalidate()
-            typingTimer = nil
-        }
-        
-        typingTimer = Timer.scheduledTimer(
-            timeInterval: 2,
-            target: self,
-            selector: #selector(waitedTwoSeconds(_:)),
-            userInfo: text,
-            repeats: false)
-    }
-    
-    @objc
-    func waitedTwoSeconds(_ sender: Timer) {
-        guard let text = sender.userInfo as? String else {
             return
         }
         viewModel.nickNameChanged(text)

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -207,6 +207,16 @@ final class ProfileSettingsViewController: BaseViewController {
             }
             .store(in: &cancellables)
         
+        viewModel.imageNotSafePublisher
+            .sink { [weak self] in
+                let alert = UIAlertController(title: "이 이미지는 사용할 수 없습니다.", message: "이미지 유해성이 확인되었습니다. 다른 이미지를 선택해 주세요.", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "확인", style: .default))
+                DispatchQueue.main.async {
+                    self?.present(alert, animated: true)
+                }
+            }
+            .store(in: &cancellables)
+        
         viewModel.isSignUpCompletedPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -96,6 +96,7 @@ final class ProfileSettingsViewController: BaseViewController {
     
     private let viewModel: ProfileSettingsViewModelProtocol
     private var cancellables = Set<AnyCancellable>()
+    private var currentNicknameState: NickNameValidationState?
     
     init(viewModel: ProfileSettingsViewModelProtocol) {
         self.viewModel = viewModel
@@ -198,8 +199,10 @@ final class ProfileSettingsViewController: BaseViewController {
         
         viewModel.isProfileImageChangedPublisher
             .sink { [weak self] _ in
-                DispatchQueue.main.async {
-                    self?.doneButton.isEnabled = true
+                if self?.currentNicknameState == nil || self?.currentNicknameState == .valid {
+                    DispatchQueue.main.async {
+                        self?.doneButton.isEnabled = true
+                    }
                 }
             }
             .store(in: &cancellables)
@@ -222,6 +225,7 @@ final class ProfileSettingsViewController: BaseViewController {
     }
     
     private func configureNickNameTextField(_ state: NickNameValidationState) {
+        self.currentNicknameState = state
         DispatchQueue.main.async {
             switch state {
             case .valid:

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/ProfileSettingsViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/ProfileSettingsViewModel.swift
@@ -90,6 +90,20 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
                 DispatchQueue.main.async {
                     self.actions?.didFinishSignUp()
                 }
+            } catch let errorBody as APIError {
+                switch errorBody {
+                case .errorResponse(let response):
+                    switch response.statusCode {
+                        // 닉네임 중복
+                    case 40000:
+                        isValidNickNameSubject.send(.duplicated)
+                        // 이미지 유해함
+                    case 40001:
+                        break
+                    default:
+                        break
+                    }
+                }
             } catch let error {
                 errorSubject.send(error)
             }

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/ProfileSettingsViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/ProfileSettingsViewModel.swift
@@ -24,6 +24,7 @@ protocol ProfileSettingsViewModelOutput {
     var imageDataPublisher: AnyPublisher<Data, Never> { get }
     var isValidNickNamePublisher: AnyPublisher<NickNameValidationState, Never> { get }
     var isProfileImageChangedPublisher: AnyPublisher<Void, Never> { get }
+    var imageNotSafePublisher: AnyPublisher<Void, Never> { get }
     var isSignUpCompletedPublisher: AnyPublisher<Void, Never> { get }
     var errorPublisher: AnyPublisher<Error, Never> { get }
 }
@@ -39,6 +40,7 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
     private var imageDataSubject = PassthroughSubject<Data, Never>()
     private var isValidNickNameSubject = PassthroughSubject<NickNameValidationState, Never>()
     private var isProfileImageChangedSubject = PassthroughSubject<Void, Never>()
+    private var imageNotSafeSubject = PassthroughSubject<Void, Never>()
     private var isSignUpCompletedSubject = PassthroughSubject<Void, Never>()
     private var errorSubject = PassthroughSubject<Error, Never>()
     private let actions: ProfileSettingsViewModelActions?
@@ -99,7 +101,7 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
                         isValidNickNameSubject.send(.duplicated)
                         // 이미지 유해함
                     case 40001:
-                        break
+                        imageNotSafeSubject.send()
                     default:
                         break
                     }
@@ -118,6 +120,7 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
     var imageDataPublisher: AnyPublisher<Data, Never> {
         return imageDataSubject.eraseToAnyPublisher()
     }
+    
     var isValidNickNamePublisher: AnyPublisher<NickNameValidationState, Never> {
         return isValidNickNameSubject
             .eraseToAnyPublisher()
@@ -125,6 +128,11 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
     
     var isProfileImageChangedPublisher: AnyPublisher<Void, Never> {
         return isProfileImageChangedSubject
+            .eraseToAnyPublisher()
+    }
+    
+    var imageNotSafePublisher: AnyPublisher<Void, Never> {
+        return imageNotSafeSubject
             .eraseToAnyPublisher()
     }
     


### PR DESCRIPTION
close #321 

## 완료된 기능
- 회원가입 및 프로필 설정 뷰 이미지 유해성 검사 결과 반영
- 닉네임 중복 검사를 유저 프로필 설정 API 요청 결과로 확인, 유저 사용성 개선

## 고민과 해결과정
### Error인 경우 Body를 어떻게 전달받을까?
- 현재 로직은 올바른 값이 왔을 때만 Response DTO를 통해 전달받는다.
- 잘못된 요청에 대한 응답의 response body를 활용하려면?
- enum의 associated value 활용
- Error를 준수하는 APIError 열거형 타입을 만들고, StatusResponseWithErrorDTO 타입을 associated value로 가지는 errorResponse 케이스를 작성
```swift
enum APIError: Error {
    case errorResponse(StatusResponseWithErrorDTO)
}
```
- 올바른 응답이 아닌 경우 StatusResponseWithErrorDTO로 디코딩, 그 값을 Error로 throw.
```swift
 guard 200..<300 ~= response.statusCode else {
  do {
      if response.statusCode == 401 {
          FMLogger.general.error("토큰이 만료되어 로그인 화면으로 이동합니다.")
          signOutManager?.signOut()
      }
      
      let errorResult = try JSONDecoder().decode(StatusResponseWithErrorDTO.self, from: data)
      FMLogger.general.error("에러 코드 : \(errorResult.statusCode)\n내용 : \(errorResult.message)")
      throw APIError.errorResponse(errorResult)
  } catch let error as APIError {
      throw error
  } catch {
      FMLogger.general.error("에러 코드 : \(response.statusCode)\n내용 : \(HTTPURLResponse.localizedString(forStatusCode: response.statusCode))")
      throw NetworkError.statusCodeError
  }
}
```
- throw 받은 error를 catch해서 switch case로 처리
```swift
do {
    let userInfo = try await useCase.setupProfileInfo(nickName: userName, profileImageData: profileImageData)
    isSignUpCompletedSubject.send()
    UserInfoStorage.nickname = userInfo.name
    UserInfoStorage.profileImageURL = userInfo.profileImageURL ?? ""
    DispatchQueue.main.async {
        self.actions?.didFinishSignUp()
    }
} catch let errorBody as APIError {
    switch errorBody {
    case .errorResponse(let response):
        switch response.statusCode {
        // 닉네임 중복
        case 40000:
            isValidNickNameSubject.send(.duplicated)
        // 이미지 유해함
        case 40001:
            imageNotSafeSubject.send()
        default:
            break
        }
    }
} catch let error {
    errorSubject.send(error)
}
```
- 더 좋은 방법이 있을까...?