### PR TITLE
[iOS#367] 마이페이지 탭 바 가리면서 올라가기 및 기타 수정

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/Flow/MyPageFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/Flow/MyPageFlowCoordinator.swift
@@ -17,6 +17,7 @@ final class MyPageFlowCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
     weak var parentCoordinator: Coordinator?
     private weak var navigationController: UINavigationController?
+    private var myPageNavigationController: UINavigationController!
     private var dependencies: MyPageFlowCoordinatorDependencies
     
     init(dependencies: MyPageFlowCoordinatorDependencies, navigationController: UINavigationController?) {
@@ -27,12 +28,19 @@ final class MyPageFlowCoordinator: Coordinator {
     func start() {
         let actions = MyPageViewModelActions(
             showProfileSettingsView: showProfileSettingsView,
-            viewDidFinish: releaseViewFromMemory
+            viewDidFinish: dismissView
             )
         let myPageViewControlelr = dependencies.makeMyPageViewController(actions: actions)
-        navigationController?.pushViewController(myPageViewControlelr, animated: true)
+        myPageNavigationController = UINavigationController(rootViewController: myPageViewControlelr)
+        myPageNavigationController.modalPresentationStyle = .fullScreen
+     
+        navigationController?.present(myPageNavigationController, animated: true)
     }
     
+    private func dismissView() {
+        navigationController?.dismiss(animated: true)
+        releaseViewFromMemory()
+    }
     private func releaseViewFromMemory() {
         parentCoordinator?.childDidFinish(self)
     }
@@ -42,7 +50,8 @@ final class MyPageFlowCoordinator: Coordinator {
             didFinishSignUp: didFinishSignUp
         )
         let profileSettingsViewControlelr = dependencies.makeProfileSettingsViewController(actions: actions)
-        navigationController?.pushViewController(profileSettingsViewControlelr, animated: true)
+        myPageNavigationController.pushViewController(profileSettingsViewControlelr, animated: true)
+//        navigationController?.pushViewController(profileSettingsViewControlelr, animated: true)
     }
     
     private func didFinishSignUp() {

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -10,6 +10,14 @@ import Combine
 
 final class MyPageViewController: BaseViewController {
     // MARK: - View Properties
+    private lazy var dismissButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("닫기", for: .normal)
+        button.setTitleColor(.label, for: .normal)
+        button.addTarget(self, action: #selector(dismissButtonDidTapped), for: .touchUpInside)
+        return button
+    }()
+    
     private lazy var myPageTableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)
         tableView.register(
@@ -42,10 +50,6 @@ final class MyPageViewController: BaseViewController {
         fatalError("can't use this, no storyboard")
     }
     
-    deinit {
-        viewModel.viewEnded()
-    }
-    
     // MARK: - View LifeCycles
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -54,8 +58,6 @@ final class MyPageViewController: BaseViewController {
     
     // MARK: - UI Configurations
     override func configureUI() {
-        title = Constant.title
-        
         let subviews = [
             myPageTableView
         ]
@@ -77,6 +79,9 @@ final class MyPageViewController: BaseViewController {
         
         self.navigationController?.navigationBar.tintColor = .label
         self.navigationController?.navigationBar.topItem?.title = ""
+        
+        navigationItem.title = Constant.title
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: dismissButton)
     }
     
     // MARK: - Binding
@@ -111,6 +116,14 @@ final class MyPageViewController: BaseViewController {
                 FMLogger.general.error("에러 발생 : \(error)")
             }
             .store(in: &cancellables)
+    }
+}
+
+// MARK: - Objc func
+private extension MyPageViewController {
+    @objc
+    func dismissButtonDidTapped() {
+        viewModel.dismissButtonDidTapped()
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
@@ -16,8 +16,8 @@ struct MyPageViewModelActions {
 protocol MyPageViewModelInput {
     func viewReady()
     func profileSettingsViewButtonTapped()
+    func dismissButtonDidTapped()
     func signOutButtonTapped()
-    func viewEnded()
 }
 
 protocol MyPageViewModelOutput {
@@ -70,7 +70,7 @@ final class MyPageViewModel: MyPageViewModelProtocol {
         // TODO: 코디네이터가 담당해야 할 것 같다...? 뷰의 이동이기 때문,,
     }
     
-    func viewEnded() {
+    func dismissButtonDidTapped() {
         actions?.viewDidFinish()
     }
     

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialDetailViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialDetailViewController.swift
@@ -32,7 +32,6 @@ final class SocialDetailViewController: BaseViewController {
         static let profileImageWidth: CGFloat = 50
         
         static let nicknameLabelLeading: CGFloat = 8
-        static let nicknameLabelWidth: CGFloat = 80
         static let nicknameLabelHeight: CGFloat = 25
         
         static let unfollowButtonTrailing: CGFloat = -20
@@ -97,7 +96,7 @@ final class SocialDetailViewController: BaseViewController {
         
         label.font = FlipMateFont.mediumBold.font
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textAlignment = .center
+        label.textAlignment = .left
         
         return label
     }()
@@ -266,7 +265,7 @@ final class SocialDetailViewController: BaseViewController {
             
             nickNameLabel.centerYAnchor.constraint(equalTo: profileImageView.centerYAnchor),
             nickNameLabel.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: LayoutConstant.nicknameLabelLeading),
-            nickNameLabel.widthAnchor.constraint(equalToConstant: LayoutConstant.nicknameLabelWidth),
+            nickNameLabel.trailingAnchor.constraint(equalTo: unfollowButton.leadingAnchor),
             nickNameLabel.heightAnchor.constraint(equalToConstant: LayoutConstant.nicknameLabelHeight),
             
             unfollowButton.centerYAnchor.constraint(equalTo: profileImageView.centerYAnchor),

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
@@ -133,25 +133,9 @@ final class SocialViewController: BaseViewController {
     }
     
     override func bind() {
-        viewModel.viewDidLoad()
+        bindFriendsRelatedPublisher()
         
-        viewModel.freindsPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] friends in
-                guard let self = self else { return }
-                var snapshot = Snapshot()
-                snapshot.appendSections([.main])
-                snapshot.appendItems(friends.map { Friend(
-                    id: $0.id,
-                    nickName: $0.nickName,
-                    profileImageURL: $0.profileImageURL,
-                    totalTime: $0.totalTime,
-                    startedTime: $0.startedTime,
-                    isStuding: $0.isStuding)}
-                )
-                self.diffableDataSource.apply(snapshot, animatingDifferences: true)
-            }
-            .store(in: &cancellables)
+        viewModel.viewDidLoad()
         
         viewModel.nicknamePublisher
             .receive(on: DispatchQueue.main)
@@ -171,13 +155,32 @@ final class SocialViewController: BaseViewController {
             }
             .store(in: &cancellables)
         
-        
         viewModel.totalTimePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] totalTime in
                 guard let self = self else { return }
                 guard let header = findHeader() else { return }
                 header.update(learningTime: totalTime)
+            }
+            .store(in: &cancellables)
+    }
+    
+    func bindFriendsRelatedPublisher() {
+        viewModel.freindsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] friends in
+                guard let self = self else { return }
+                var snapshot = Snapshot()
+                snapshot.appendSections([.main])
+                snapshot.appendItems(friends.map { Friend(
+                    id: $0.id,
+                    nickName: $0.nickName,
+                    profileImageURL: $0.profileImageURL,
+                    totalTime: $0.totalTime,
+                    startedTime: $0.startedTime,
+                    isStuding: $0.isStuding)}
+                )
+                self.diffableDataSource.apply(snapshot, animatingDifferences: true)
             }
             .store(in: &cancellables)
         

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
@@ -50,7 +50,7 @@ final class SocialViewModel: SocialViewModelProtocol {
     private let socialUseCase: SocialUseCase
     private var timerState: TimerState = .notStarted
     private var friendStatusPollingManager: FriendStatusPollingManageable
-    private lazy var timerManager: TimerManager = .init(timeInterval: .seconds(5), handler: fetchFriendStatus)
+    private lazy var timerManager: TimerManager = .init(timeInterval: .seconds(4), handler: fetchFriendStatus)
     
     // MARK: - init
     init(actions: SocialViewModelActions? = nil, socialUseCase: SocialUseCase, friendStatusPollingManager: FriendStatusPollingManageable) {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -85,12 +85,14 @@ final class TimerViewController: BaseViewController {
         timerViewModel.viewWillAppear()
     }
     
+    // swiftlint:disable notification_center_detachment
     override func viewDidDisappear(_ animated: Bool) {
         deviceMotionManager.stopDeviceMotion()
         timerViewModel.viewDidDisappear()
         UIDevice.current.isProximityMonitoringEnabled = false
         NotificationCenter.default.removeObserver(self)
     }
+    // swiftlint:enable notification_center_detachment
     
     // MARK: - setup UI
     override func configureUI() {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
@@ -69,7 +69,11 @@ final class TimerViewModel: TimerViewModelProtocol {
     private lazy var timerManager = TimerManager(timeInterval: .seconds(1), handler: increaseTotalTime)
     
     // MARK: - init
-    init(timerUseCase: TimerUseCase, userInfoUserCase: StudyLogUseCase, studingPingUseCase: StudingPingUseCase, actions: TimerViewModelActions? = nil, categoryManager: CategoryManageable) {
+    init(timerUseCase: TimerUseCase,
+         userInfoUserCase: StudyLogUseCase,
+         studingPingUseCase: StudingPingUseCase,
+         actions: TimerViewModelActions? = nil,
+         categoryManager: CategoryManageable) {
         self.timerUseCase = timerUseCase
         self.userInfoUserCase = userInfoUserCase
         self.studingPingUseCase = studingPingUseCase

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/SignOutManager.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/SignOutManager.swift
@@ -24,6 +24,7 @@ final class SignOutManager: SignOutManagerProtocol {
         try? KeychainManager.deleteAccessToken()
         UserInfoStorage.nickname = ""
         UserInfoStorage.profileImageURL = ""
+        UserInfoStorage.totalTime = 0
         signOutSubject.send(true)
     }
 }


### PR DESCRIPTION
close #367 

## 완료된 기능
- 마이페이지 탭 바 가리면서 올라가기
- 시간 설정
- 팔로우 취소 화면 닉네임 라벨 길이 늘리기
- 린터 적용
- 폴링 시간 조정

## 고민과 해결과정
