### PR TITLE
[iOS#303] 선택된 카테고리 다시 선택 시 해제되도록 수정

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -286,6 +286,18 @@ extension TimerViewController: UICollectionViewDelegateFlowLayout {
 }
 
 extension TimerViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? CategoryListCollectionViewCell else { return true }
+        if cell.isSelected {
+            collectionView.deselectItem(at: indexPath, animated: true)
+            cell.updateShadow()
+            timerViewModel.categoryDidDeselected()
+            return false
+        } else {
+            return true
+        }
+    }
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? CategoryListCollectionViewCell else { return }
         guard let item = dataSource?.itemIdentifier(for: indexPath) else { return }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
@@ -30,6 +30,7 @@ protocol TimerViewModelInput {
     func categorySettingButtoneDidTapped()
     func categoryDidSelected(category: Category)
     func appendStudyEndLog(studyEndLog: StudyEndLog)
+    func categoryDidDeselected()
 }
 
 protocol TimerViewModelOutput {
@@ -152,6 +153,11 @@ final class TimerViewModel: TimerViewModelProtocol {
     func categoryDidSelected(category: Category) {
         FMLogger.timer.debug("\(category.subject)가 선택되었습니다.")
         selectedCategory = category
+    }
+    
+    func categoryDidDeselected() {
+        FMLogger.timer.debug("선택된 카테고리가 해제되었습니다.")
+        selectedCategory = nil
     }
     
     func appendStudyEndLog(studyEndLog: StudyEndLog) {


### PR DESCRIPTION
closed #303 
## 완료된 기능
- 선택된 카테고리 다시 선택 시 해제되도록 수정

## 실행 결과

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/aff0eb4f-12ba-4512-9134-e07c792715dc



## 고민과 해결과정
### shouldSelectItemAt
shouldSelectedItemAt 메소드가 didSelectItemAt 메소드보다 일찍 호출된다는 것을 이용하여
해당 IndexPath의 Cell이 이미 선택되었는지 아닌지 isSelected값을 통해 이미 선택된 cell이라면 선택을 해제시켜주도록 구현했습니다 ~
