### PR TITLE
[iOS/#425] 차트 페이지 UI 개선

### DIFF
--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultChartUseCase.swift
@@ -23,7 +23,7 @@ final class DefaultChartUseCase: ChartUseCase {
         
         etcTime = chartLog.studyLog.totalTime - etcTime
         
-        let etcCategory = Category(id: 0, color: "888888FF", subject: "기타", studyTime: etcTime)
+        let etcCategory = Category(id: 0, color: "888888FF", subject: NSLocalizedString("etc", comment: ""), studyTime: etcTime)
             chartLog.studyLog.category.append(etcCategory)
         
         return chartLog

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -11,6 +11,7 @@ import Charts
 struct DailyChartView: View {
     @ObservedObject var viewModel: ChartViewModel
     @State private var selectedDate = Date()
+    @Environment(\.colorScheme) var colorScheme
     
     init(viewModel: ChartViewModel) {
         self.viewModel = viewModel
@@ -28,7 +29,8 @@ struct DailyChartView: View {
                                 .cornerRadius(10.0)
                                 .annotation(position: .overlay) {
                                     if getRatio(time: category.studyTime ?? 0, sum: viewModel.dailyChartLog.studyLog.totalTime) > 0.05 {
-                                        DailyChartView.StrokeText(text: "\(category.studyTime ?? 0)", width: 0.3, color: .white)
+                                        DailyChartView.StrokeText(text: "\(category.studyTime ?? 0)",
+                                                                  width: 0.3, color: colorScheme == .dark ? .black : .white)
                                         .font(.headline)
                                     }
                                 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -27,7 +27,7 @@ struct DailyChartView: View {
                                 .foregroundStyle(by: .value(Constant.category, category.subject))
                                 .cornerRadius(10.0)
                                 .annotation(position: .overlay) {
-                                    if category.studyTime != 0 {
+                                    if getRatio(time: category.studyTime ?? 0, sum: viewModel.dailyChartLog.studyLog.totalTime) > 0.05 {
                                         Text("\(category.studyTime ?? 0)")
                                             .font(.headline)
                                     }
@@ -69,7 +69,7 @@ struct DailyChartView: View {
         }
     }
     
-    func getColorArray(categories: [Category]) -> [Color] {
+    private func getColorArray(categories: [Category]) -> [Color] {
         let colorArray: [Color] = categories.map { category in
             if let uiColor = UIColor(hexString: category.color) {
                 return Color(uiColor)
@@ -78,6 +78,10 @@ struct DailyChartView: View {
             }
         }
         return colorArray
+    }
+    
+    private func getRatio(time: Int, sum: Int) -> Float {
+        return Float(time) / Float(sum)
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/DailyChartView.swift
@@ -28,8 +28,8 @@ struct DailyChartView: View {
                                 .cornerRadius(10.0)
                                 .annotation(position: .overlay) {
                                     if getRatio(time: category.studyTime ?? 0, sum: viewModel.dailyChartLog.studyLog.totalTime) > 0.05 {
-                                        Text("\(category.studyTime ?? 0)")
-                                            .font(.headline)
+                                        DailyChartView.StrokeText(text: "\(category.studyTime ?? 0)", width: 0.3, color: .white)
+                                        .font(.headline)
                                     }
                                 }
                         }
@@ -92,5 +92,24 @@ private extension DailyChartView {
         static let totalTime = NSLocalizedString("totalTime", comment: "")
         static let category = NSLocalizedString("category", comment: "")
         static let min = NSLocalizedString("date", comment: "")
+    }
+    
+    struct StrokeText: View {
+        let text: String
+        let width: CGFloat
+        let color: Color
+        
+        var body: some View {
+            ZStack {
+                ZStack {
+                    Text(text).offset(x: width, y: width)
+                    Text(text).offset(x: -width, y: width)
+                    Text(text).offset(x: width, y: -width)
+                    Text(text).offset(x: -width, y: -width)
+                }
+                .foregroundColor(color)
+                Text(text)
+            }
+        }
     }
 }

--- a/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
@@ -78,7 +78,7 @@
 // MARK: - DailyChartView
 "time" = "Time";
 "totalTime" = "Total Time";
-"etc" = "etc;
+"etc" = "etc";
 
 // MARK: - WeeklyChartView
 "day" = "day";

--- a/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 // MARK: - DailyChartView
 "time" = "Time";
 "totalTime" = "Total Time";
+"etc" = "etc;
 
 // MARK: - WeeklyChartView
 "day" = "day";

--- a/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
@@ -79,6 +79,7 @@
 // MARK: - DailyChartView
 "time" = "時間";
 "totalTime" = "総学習時間";
+"etc" = "その他";
 
 // MARK: - WeeklyChartView
 "day" = "曜日";

--- a/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
@@ -76,6 +76,7 @@
 "totalTime" = "총 학습 시간";
 "day" = "요일";
 "weeklyLearingChart" = "주간 학습 추이";
+"etc" = "기타";
 
 // MARK: - Login Scene
 "logoSubTitle" = "우리들이 공부하는 시간";


### PR DESCRIPTION
# 이슈번호-작업이름
close #425

## 완료된 기능

- 비율 계산하여 5% 미만의 카테고리 항목은 라벨을 제외하기로 하였습니다.
- 흑색 색상 위 흑색 라벨이 보이지 않는 것 해결하기 위해 흰색 외곽선있는 Text를 적용하였습니다.

## 고민과 해결과정

- 비율 계산 과정 Naive하게 코드에 작성 중... Body에 추론할 타입이 너무 많다고 컴파일러가 맛가는 오류가 있었습니다... 별도 함수 만들어서 TypeCasting 줄여주니 해결되긴 했네요. 당황했습니다.
