### PR TITLE
[iOS#403] TimerManager 추상화 및 의존성 관리

### DIFF
--- a/iOS/FlipMate/FlipMate/Application/DIContainer/SocialDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/SocialDIContainer.swift
@@ -33,7 +33,7 @@ final class SocialDIContainer: SocialFlowCoordinatorDependencies {
                 socialUseCase: DefaultSocialUseCase(
                     repsoitory: DefaultSocialRepository(
                         provider: dependencies.provider)),
-                friendStatusPollingManager: FriendStatusPollingManager(),
+                friendStatusPollingManager: FriendStatusPollingManager(timerManager: TimerManager()),
                 userInfoManager: dependencies.userInfoManager,
                 timerManager: TimerManager(timeInterval: .seconds(4))
             )

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/SocialDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/SocialDIContainer.swift
@@ -34,7 +34,8 @@ final class SocialDIContainer: SocialFlowCoordinatorDependencies {
                     repsoitory: DefaultSocialRepository(
                         provider: dependencies.provider)),
                 friendStatusPollingManager: FriendStatusPollingManager(),
-                userInfoManager: dependencies.userInfoManager
+                userInfoManager: dependencies.userInfoManager,
+                timerManager: TimerManager(timeInterval: .seconds(4))
             )
         )
     }

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
@@ -45,7 +45,8 @@ final class TimerSceneDIContainer: TimerFlowCoordinatorDependencies {
             userInfoUseCase: makeUserInfoUseCase(),
             actions: actions,
             categoryManager: dependencies.categoryManager,
-            userInfoManager: dependencies.userInfoManager
+            userInfoManager: dependencies.userInfoManager,
+            timerManager: TimerManager()
         )
     }
     

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
@@ -48,18 +48,20 @@ final class SocialViewModel: SocialViewModelProtocol {
     
     // MARK: - Managers
     private var friendStatusPollingManager: FriendStatusPollingManageable
-    private lazy var timerManager: TimerManager = .init(timeInterval: .seconds(4), handler: fetchFriendStatus)
+    private let timerManager: TimerManagerProtocol
     private let userInfoManager: UserInfoManagerProtocol
     
     // MARK: - init
     init(actions: SocialViewModelActions? = nil, 
          socialUseCase: SocialUseCase,
          friendStatusPollingManager: FriendStatusPollingManageable,
-         userInfoManager: UserInfoManagerProtocol) {
+         userInfoManager: UserInfoManagerProtocol,
+         timerManager: TimerManagerProtocol) {
         self.actions = actions
         self.socialUseCase = socialUseCase
         self.friendStatusPollingManager = friendStatusPollingManager
         self.userInfoManager = userInfoManager
+        self.timerManager = timerManager
     }
     
     // MARK: - Output

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
@@ -44,7 +44,6 @@ final class SocialViewModel: SocialViewModelProtocol {
     private var cancellables = Set<AnyCancellable>()
     private let actions: SocialViewModelActions?
     private let socialUseCase: SocialUseCase
-    private var timerState: TimerState = .notStarted
     
     // MARK: - Managers
     private var friendStatusPollingManager: FriendStatusPollingManageable

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
@@ -60,7 +60,6 @@ final class TimerViewModel: TimerViewModelProtocol {
     // MARK: Properties
     private var proximity: Bool?
     private var orientation: DeviceOrientation = .unknown
-    private var timerState: TimerState = .notStarted
     private var cancellables = Set<AnyCancellable>()
     private var increaseTime: Int = -1
     private var selectedCategory: Category?
@@ -208,7 +207,7 @@ private extension TimerViewModel {
             isDeviceFaceDownSubject.send(true)
             startTimer()
         } else {
-            guard timerState == .resumed else { return }
+            guard timerManager.state == .resumed else { return }
             FMLogger.user.debug("디바이스가 face up 상태입니다.")
             isDeviceFaceDownSubject.send(false)
             stopTimer()
@@ -240,7 +239,6 @@ private extension TimerViewModel {
                 guard let self = self else { return }
                 self.increaseTime = -1
                 self.timerManager.start(completion: increaseTotalTime)
-                self.timerState = .resumed
             }
             .store(in: &cancellables)
     }
@@ -250,7 +248,6 @@ private extension TimerViewModel {
         let studyEndLog = StudyEndLog(learningTime: increaseTime, endDate: Date(), categoryId: selectedCategory?.id)
         deviceSettingEnabledSubject.send(false)
         actions?.showTimerFinishViewController(studyEndLog)
-        timerState = .cancled
     }
     
     func increaseTotalTime() {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
@@ -68,7 +68,7 @@ final class TimerViewModel: TimerViewModelProtocol {
     
     // MARK: - Managers
     private let categoryManager: CategoryManageable
-    private lazy var timerManager = TimerManager(timeInterval: .seconds(1), handler: increaseTotalTime)
+    private let timerManager: TimerManagerProtocol
     private let userInfoManager: UserInfoManagerProtocol
     
     // MARK: - init
@@ -78,7 +78,8 @@ final class TimerViewModel: TimerViewModelProtocol {
          userInfoUseCase: UserInfoUseCase,
          actions: TimerViewModelActions? = nil,
          categoryManager: CategoryManageable,
-         userInfoManager: UserInfoManagerProtocol) {
+         userInfoManager: UserInfoManagerProtocol,
+         timerManager: TimerManagerProtocol) {
         self.timerUseCase = timerUseCase
         self.studyLogUseCase = studyLogUseCase
         self.studingPingUseCase = studingPingUseCase
@@ -86,6 +87,7 @@ final class TimerViewModel: TimerViewModelProtocol {
         self.actions = actions
         self.categoryManager = categoryManager
         self.userInfoManager = userInfoManager
+        self.timerManager = timerManager
     }
     
     // MARK: Output

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/FriendStatusPollingManager/FriendStatusPollingManager.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/FriendStatusPollingManager/FriendStatusPollingManager.swift
@@ -25,7 +25,6 @@ protocol FriendStatusPollingManageable {
 final class FriendStatusPollingManager: FriendStatusPollingManageable {
     private var preFriendStatusArray: [FriendStatus] = []
     private var updateFriendArray: [UpdateFriend] = []
-    private var timerState: TimerState = .notStarted
     private let timerManager: TimerManagerProtocol
     
     private var updateLearningFriends = PassthroughSubject<[UpdateFriend], Never>()
@@ -157,13 +156,11 @@ final class FriendStatusPollingManager: FriendStatusPollingManageable {
     
     private func startTimer() {
         if updateFriendArray.isEmpty { return }
-        if timerState == .resumed { return }
+        if timerManager.state == .resumed { return }
         timerManager.start(completion: increaseLearningTime)
-        timerState = .resumed
     }
     
     private func stopTimer() {
         timerManager.cancel()
-        timerState = .cancled
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/FriendStatusPollingManager/FriendStatusPollingManager.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/FriendStatusPollingManager/FriendStatusPollingManager.swift
@@ -26,7 +26,7 @@ final class FriendStatusPollingManager: FriendStatusPollingManageable {
     private var preFriendStatusArray: [FriendStatus] = []
     private var updateFriendArray: [UpdateFriend] = []
     private var timerState: TimerState = .notStarted
-    private lazy var timerManager = TimerManager(timeInterval: .seconds(1), handler: increaseLearningTime)
+    private let timerManager: TimerManagerProtocol
     
     private var updateLearningFriends = PassthroughSubject<[UpdateFriend], Never>()
     private var updateStopFriends = PassthroughSubject<[StopFriend], Never>()
@@ -37,6 +37,10 @@ final class FriendStatusPollingManager: FriendStatusPollingManageable {
     
     var updateStopFriendsPublisher: AnyPublisher<[StopFriend], Never> {
         return updateStopFriends.eraseToAnyPublisher()
+    }
+    
+    init(timerManager: TimerManagerProtocol) {
+        self.timerManager = timerManager
     }
     
     func update(preFriendStatusArray: [FriendStatus]) {

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/TimerManager/TimerManager.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/TimerManager/TimerManager.swift
@@ -9,6 +9,8 @@ import Foundation
 import OSLog
 
 protocol TimerManagerProtocol {
+    var state: TimerState { get }
+    
     func start(completion: (() -> Void)?)
     func resume()
     func suspend()
@@ -18,9 +20,9 @@ protocol TimerManagerProtocol {
 /// 타이머를 관리해주는 객체
 final class TimerManager: TimerManagerProtocol {
     // MARK: - Properties
-    private var state: TimerState = .suspended
     private var handler: (() -> Void)?
     private var timeInterval: DispatchTimeInterval
+    var state: TimerState = .suspended
     
     private lazy var timer: DispatchSourceTimer = {
         let timer = DispatchSource.makeTimerSource(

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/TimerManager/TimerManager.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/TimerManager/TimerManager.swift
@@ -8,8 +8,15 @@
 import Foundation
 import OSLog
 
+protocol TimerManagerProtocol {
+    func start(completion: (() -> Void)?)
+    func resume()
+    func suspend()
+    func cancel()
+}
+
 /// 타이머를 관리해주는 객체
-final class TimerManager {
+final class TimerManager: TimerManagerProtocol {
     // MARK: - Properties
     private var state: TimerState = .suspended
     private var handler: (() -> Void)?
@@ -29,7 +36,7 @@ final class TimerManager {
         return timer
     }()
     
-    init(timeInterval: DispatchTimeInterval = .microseconds(100), handler: (() -> Void)? = nil) {
+    init(timeInterval: DispatchTimeInterval = .seconds(1), handler: (() -> Void)? = nil) {
         self.handler = handler
         self.timeInterval = timeInterval
     }
@@ -42,7 +49,7 @@ final class TimerManager {
     }
     
     /// 타이머를 시작합니다.
-    func start(startTime: Date = Date(), completion: (() -> Void)? = nil) {
+    func start(completion: (() -> Void)? = nil) {
 
         guard let completion else {
             resume()
@@ -54,7 +61,7 @@ final class TimerManager {
     }
     
     /// 타이머를 재개합니다.
-    func resume(resumeTime: Date = Date()) {
+    func resume() {
         guard state == .suspended else { return }
         state = .resumed
         timer.resume()


### PR DESCRIPTION
closed #403 

## 완료된 기능
- TimerManagerProtocol 구현
- ViewModel에서 TimerManager 주입받도록 수정
- ViewModel에서 Timer 상태 값 관리하던 것 TimerManager로 수정

## 고민과 해결과정
이전에는 TimerManager가 필요한 ViewModel에서 생성해줘서 사용해줘서 ViewModel이 TimerManager에게 의존하는 관계였습니다.
그래서 TimerManager을 추상화하여 각각의 DI Container에서 주입받도록 수정하여 의존성을 관리해주었습니다.

또한 각각의 ViewModel에서도 Timer의 상태 값을 알기 위해서 TimerState을 가지고 있었는데 TimerManager의 TimerState을 통해서 관리하는 것으로 수정해서 불필요한 코드를 줄였습니다.