### PR TITLE
[iOS#431] 다국어 지원 미흡한 부분 처리

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -69,7 +69,7 @@ final class ChartViewController: BaseViewController {
             segmentedControl.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
             segmentedControl.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 15),
             segmentedControl.heightAnchor.constraint(equalToConstant: 50),
-            segmentedControl.widthAnchor.constraint(equalToConstant: 140)
+            segmentedControl.widthAnchor.constraint(equalToConstant: 180)
         ])
         NSLayoutConstraint.activate([
             dailyChartView.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor, constant: 30),

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -12,7 +12,7 @@ final class MyPageViewController: BaseViewController {
     // MARK: - View Properties
     private lazy var dismissButton: UIButton = {
         let button = UIButton()
-        button.setTitle("닫기", for: .normal)
+        button.setTitle(Constant.close, for: .normal)
         button.setTitleColor(.label, for: .normal)
         button.addTarget(self, action: #selector(dismissButtonDidTapped), for: .touchUpInside)
         return button
@@ -220,5 +220,7 @@ extension MyPageViewController: UITableViewDelegate {
 private extension MyPageViewController {
     enum Constant {
         static let title = NSLocalizedString("myPage", comment: "")
+        static let close = NSLocalizedString("close", comment: "")
+        
     }
 }

--- a/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
@@ -51,7 +51,7 @@
 // MARK: - TimerFinish Scene
 "yes" = "예";
 "no" = "아니요";
-"TimerFinishTitle" = "예";
+"TimerFinishTitle" = "타이머 종료";
 "learningTitle" = "공부한 시간을 저장하시겠습니까?";
 
 // MARK: - SocialDetail Scene


### PR DESCRIPTION
closed #431 
## 완료된 기능
- 타이머 종료 Alert Title 한국어 대응
- 통계화면 UISegmentedControl 영어일 때 너비 대응
- 마이페이지 닫기 버튼 다국어 대응

## 실행 결과

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/337739da-27fd-4dcf-b620-cef8f38fe7db

