### PR TITLE
[iOS#433] 카테고리 10개인 경우 추가 버튼 처리

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Model/CategorySettingSection.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Model/CategorySettingSection.swift
@@ -38,7 +38,7 @@ extension CategorySettingSection {
     var footerSize: NSCollectionLayoutSize {
         return NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(58))
+            heightDimension: .absolute(130))
     }
     
     var sectionInset: NSDirectionalEdgeInsets {

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/View/CategorySettingFooterView.swift
@@ -26,11 +26,10 @@ final class CategorySettingFooterView: UICollectionReusableView {
         button.layer.borderWidth = Constant.addButtonborderWidth
         button.layer.cornerRadius = Constant.addButtoncornerRedius
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
         return button
     }()
     
-    private lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, 
-                                                                   action: #selector(footerViewSelected))
     private var subject = PassthroughSubject<Void, Never>()
     var cancellable: AnyCancellable?
     
@@ -38,7 +37,6 @@ final class CategorySettingFooterView: UICollectionReusableView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
-        configureGestureRecognizers()
     }
     
     required init?(coder: NSCoder) {
@@ -65,19 +63,14 @@ private extension CategorySettingFooterView {
             addButton.topAnchor.constraint(equalTo: topAnchor),
             addButton.leadingAnchor.constraint(equalTo: leadingAnchor),
             addButton.trailingAnchor.constraint(equalTo: trailingAnchor),
-            addButton.bottomAnchor.constraint(equalTo: bottomAnchor)
+            addButton.heightAnchor.constraint(equalToConstant: 58)
         ])
     }
 }
 
 private extension CategorySettingFooterView {
-    func configureGestureRecognizers() {
-        tapGestureRecognizer.cancelsTouchesInView = false
-        self.addGestureRecognizer(tapGestureRecognizer)
-    }
-    
     @objc
-    func footerViewSelected() {
+    func addButtonTapped() {
         subject.send()
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/CategorySettingViewController.swift
@@ -86,7 +86,14 @@ final class CategorySettingViewController: BaseViewController {
                 showActionSheet(with: category)
             }
             .store(in: &cancellables)
-            
+        
+        viewModel.categoryPullPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                self.showAlert()
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -229,6 +236,15 @@ private extension CategorySettingViewController {
         
         return [deleteAction, cancelAction]
     }
+    
+    func showAlert() {
+        let alertController = UIAlertController(
+            title: Constant.addCategory,
+            message: Constant.categoryAddMessage, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: Constant.okTitle, style: .default)
+        alertController.addAction(okAction)
+        present(alertController, animated: true)
+    }
 }
 
 private extension CategorySettingViewController {
@@ -239,5 +255,8 @@ private extension CategorySettingViewController {
         static let deleteCategory = NSLocalizedString("deleteCategory", comment: "")
         static let modifyCategory = NSLocalizedString("modifyCategory", comment: "")
         static let deleteAlertMessage = NSLocalizedString("deleteAlertMessage", comment: "")
+        static let okTitle = NSLocalizedString("ok", comment: "")
+        static let addCategory = NSLocalizedString("addCategory", comment: "")
+        static let categoryAddMessage = NSLocalizedString("categoryAddMessage", comment: "")
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/CategoryViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/CategoryViewModel.swift
@@ -24,6 +24,7 @@ protocol CategoryViewModelInput {
 protocol CategoryViewModelOutput {
     var categoriesPublisher: AnyPublisher<[Category], Never> { get }
     var selectedCategoryPublisher: AnyPublisher<Category, Never> { get }
+    var categoryPullPublisher: AnyPublisher<Void, Never> { get }
 }
 
 typealias CategoryViewModelProtocol = CategoryViewModelInput & CategoryViewModelOutput
@@ -32,6 +33,7 @@ final class CategoryViewModel: CategoryViewModelProtocol {
     // MARK: properties
     private var categoriesSubject = CurrentValueSubject<[Category], Never>([])
     private var selectedCategorySubject = PassthroughSubject<Category, Never>()
+    private var categoryPullSubject = PassthroughSubject<Void, Never>()
     
     private var categoryMananger: CategoryManageable
     private let useCase: CategoryUseCase
@@ -53,9 +55,18 @@ final class CategoryViewModel: CategoryViewModelProtocol {
         return selectedCategorySubject.eraseToAnyPublisher()
     }
     
+    var categoryPullPublisher: AnyPublisher<Void, Never> {
+        return categoryPullSubject.eraseToAnyPublisher()
+    }
+    
     // MARK: Input
     func createCategoryTapped() {
-        actions?.showModifyCategory(.create, nil)
+        
+        if categoryMananger.numberOfCategory() == 10 {
+            categoryPullSubject.send()
+        } else {
+            actions?.showModifyCategory(.create, nil)
+        }
     }
     
     func updateCategoryTapped(category: Category) {

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/CategoryManager/CategoryManager.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/CategoryManager/CategoryManager.swift
@@ -52,4 +52,8 @@ final class CategoryManager: CategoryManageable {
         guard let targetIndex = categories.firstIndex(of: targetCategory) else { return nil }
         return categories[targetIndex]
     }
+    
+    func numberOfCategory() -> Int {
+        return categories.count
+    }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/Protocols/CategoryManagable.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/Protocols/CategoryManagable.swift
@@ -15,4 +15,5 @@ protocol CategoryManageable {
     func removeCategory(categoryId: Int)
     func append(category: Category)
     func findCategory(categoryId: Int) -> Category?
+    func numberOfCategory() -> Int
 }

--- a/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "deleteAlertMessage" = "Are you sure delete this category?";
 "categoryNamePlaceHolder" = "Please enter the category name";
 "social" = "social";
+"categoryAddMessage" = "You can add up to 10 categories.";
 
 // MARK: - MyPage Scene
 "myPage" = "MyPage";
@@ -35,7 +36,7 @@
 "nicknamePlaceHolder" = "Please enter your nickname";
 "imageNotSafeTitle" = "This image is not available.";
 "imageNotSafeMessage" = "This image has been confirmed to be harmful. Please select the different image.";
-"ok" = "yes";
+"ok" = "OK";
 "available" = "Available nickname.";
 "lengthViolation" = "Nickname exceeds 20 characters.";
 "emptyViolation" = "Nickname must contain at least 2 characters.";

--- a/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "deleteAlertMessage" = "該当カテゴリを本当に削除しますか？";
 "categoryNamePlaceHolder" = "カテゴリ名を入力してください。";
 "social" = "ソーシャル";
+"categoryAddMessage" = "カテゴリは10個まで追加できます。";
 
 // MARK: - MyPage Scene
 "myPage" = "マイページ";

--- a/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "deleteAlertMessage" = "해당 카테고리를 정말 삭제하시겠습니까?";
 "categoryNamePlaceHolder" = "카테고리 이름을 입력해주세요.";
 "social" = "소셜";
+"categoryAddMessage" = "카테고리는 10개까지 추가할 수 있습니다.";
 
 // MARK: - MyPage Scene
 "myPage" = "마이페이지";


### PR DESCRIPTION
closed #433 

## 완료된 기능
- 카테고리가 10개인 경우에 카테고리 추가시 Alert 띄우기
- 카테고리가 많아질 경우 추가 버튼 짤리던 이슈 수정

## 실행 결과
https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/6567ef63-0a90-400e-bf68-82a390a99216

## 고민과 해결과정
### FooterView contentInsets
CompositionalLayout을 통해 구현을 해서 footerView의 contentInsets의 bottom값을 주면 footerView아래에 공백이 생길것으로 예상되었으나 bottom값을 준 만큼 footerView의 높이가 줄어드는 현상이 있었습니다..
따라서 FooterView 자체에 추가 버튼의 높이를 지정해주고 CompositionalLayout을 통해 footerView의 사이즈를 공백이 필요한 만큼 크기를 지정해서 해결하였습니다.


