### PR TITLE
[iOS#436] 다크모드일 때 스크롤시 탭바 색상 변하는 이슈 해결

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/ViewController/TabBarViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/ViewController/TabBarViewController.swift
@@ -58,9 +58,13 @@ private extension TabBarViewController {
     }
     
     func configureTabBar() {
+        let tabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.configureWithOpaqueBackground()
+        tabBarAppearance.backgroundColor = FlipMateColor.tabBarColor.color
         tabBar.layer.borderWidth = Constant.borderWidth
         tabBar.layer.borderColor = FlipMateColor.tabBarLayerColor.color?.cgColor
-        tabBar.layer.backgroundColor = FlipMateColor.tabBarColor.color?.cgColor
+        tabBar.backgroundColor = FlipMateColor.tabBarColor.color
+        tabBar.standardAppearance = tabBarAppearance
         view.addSubview(timerButton)
     }
 


### PR DESCRIPTION
# 이슈번호-작업이름

## 완료된 기능
- 다크모드 일 때 스크롤시 탭바 색상 변하는 이슈 해결

## 실행 결과
https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/7f4ab1eb-67a7-46a1-b203-eaf873eb83af

## 고민과 해결과정
스크롤시에 tabBar 뒤쪽에 어떠한 뷰가 있는 경우 불투명하게 backgroundColor가 바뀌는 문제가 있었습니다. 
iOS13이상부터 UITabBarAppearance을 통해 tabBar의 속성을 지정할 수 있는데 해당 appearance을 통해 backgroundColor을 지정해서 해결하였습ㄴ디ㅏ.
