### PR TITLE
[iOS#423] 이미지 업로드 시 에러 처리

### DIFF
--- a/iOS/FlipMate/FlipMate/NetworkService/Provider.swift
+++ b/iOS/FlipMate/FlipMate/NetworkService/Provider.swift
@@ -40,7 +40,7 @@ struct Provider: Providable {
                         
                         let errorResult = try JSONDecoder().decode(StatusResponseWithErrorDTO.self, from: data)
                         FMLogger.general.error("에러 코드 : \(errorResult.statusCode)\n내용 : \(errorResult.message)")
-                        throw NetworkError.statusCodeError(statusCode: response.statusCode, message: errorResult.message)
+                        throw APIError.errorResponse(errorResult)
                     }
                     
                     guard !data.isEmpty else {
@@ -102,6 +102,13 @@ struct Provider: Providable {
     }
 }
 
-enum APIError: Error {
+enum APIError: LocalizedError {
     case errorResponse(StatusResponseWithErrorDTO)
+    
+    var errorDescription: String? {
+        switch self {
+        case .errorResponse(let response):
+            return response.message
+        }
+    }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -194,12 +194,9 @@ final class SignUpViewController: BaseViewController {
             .store(in: &cancellables)
         
         viewModel.imageNotSafePublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                let alert = UIAlertController(title: "이 이미지는 사용할 수 없습니다.", message: "이미지 유해성이 확인되었습니다. 다른 이미지를 선택해 주세요.", preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "확인", style: .default))
-                DispatchQueue.main.async {
-                    self?.present(alert, animated: true)
-                }
+                self?.showErrorAlert(title: Constant.imageNotSafeTitle, message: Constant.imageNotSafeMessage)
             }
             .store(in: &cancellables)
         
@@ -207,9 +204,7 @@ final class SignUpViewController: BaseViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
                 self?.doneButton.isEnabled = false
-                let alert = UIAlertController(title: "오류 발생", message: "\(error.localizedDescription)", preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "확인", style: .cancel))
-                self?.present(alert, animated: true)
+                self?.showErrorAlert(title: Constant.errorOccurred, message: "\(error)")
                 FMLogger.general.error("SignUpViewModel에서 에러: \(error)")
             }
             .store(in: &cancellables)
@@ -236,6 +231,12 @@ final class SignUpViewController: BaseViewController {
                 self.doneButton.isEnabled = false
             }
         }
+    }
+    
+    private func showErrorAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: Constant.okTitle, style: .default))
+        present(alert, animated: true)
     }
 }
 
@@ -338,6 +339,7 @@ private extension SignUpViewController {
         static let imageNotSafeTitle = NSLocalizedString("imageNotSafeTitle", comment: "")
         static let imageNotSafeMessage = NSLocalizedString("imageNotSafeMessage", comment: "")
         static let okTitle = NSLocalizedString("ok", comment: "")
+        static let errorOccurred = NSLocalizedString("errorOccurred", comment: "")
         static let maxLength = 10
     }
     

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -74,7 +74,7 @@ final class SignUpViewModel: SignUpViewModelProtocol {
                     case 40001:
                         imageNotSafeSubject.send()
                     default:
-                        break
+                        errorSubject.send(errorBody)
                     }
                 }
             } catch let error {

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -310,7 +310,7 @@ private extension ProfileSettingsViewController {
     func signUpButtonTapped() {
         doneButton.isEnabled = false
         let userName = nickNameTextField.text ?? ""
-        guard let imageData = profileImageView.image?.jpegData(compressionQuality: 1) else {
+        guard let imageData = profileImageView.image?.jpegData(compressionQuality: 0.6) else {
             FMLogger.general.error("no profile image selected")
             return
         }

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -193,8 +193,13 @@ final class ProfileSettingsViewController: BaseViewController {
         viewModel.errorPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
-                FMLogger.general.error("SignUpViewModel에서 에러: \(error)")
                 self?.doneButton.isEnabled = false
+                let alert = UIAlertController(title: "오류 발생", message: "\(error.localizedDescription)", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "확인", style: .cancel))
+                DispatchQueue.main.async {
+                    self?.present(alert, animated: true)
+                }
+                FMLogger.general.error("SignUpViewModel에서 에러: \(error)")
             }
             .store(in: &cancellables)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -196,9 +196,7 @@ final class ProfileSettingsViewController: BaseViewController {
                 self?.doneButton.isEnabled = false
                 let alert = UIAlertController(title: "오류 발생", message: "\(error.localizedDescription)", preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "확인", style: .cancel))
-                DispatchQueue.main.async {
-                    self?.present(alert, animated: true)
-                }
+                self?.present(alert, animated: true)
                 FMLogger.general.error("SignUpViewModel에서 에러: \(error)")
             }
             .store(in: &cancellables)
@@ -233,7 +231,6 @@ final class ProfileSettingsViewController: BaseViewController {
             .store(in: &cancellables)
         
         viewModel.isProfileImageChangedPublisher
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 if self?.currentNicknameState == nil || self?.currentNicknameState == .valid {
                     DispatchQueue.main.async {
@@ -244,12 +241,11 @@ final class ProfileSettingsViewController: BaseViewController {
             .store(in: &cancellables)
         
         viewModel.imageNotSafePublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 let alert = UIAlertController(title: Constant.imageNotSafeTitle, message: Constant.imageNotSafeMessage, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: Constant.okTitle, style: .default))
-                DispatchQueue.main.async {
-                    self?.present(alert, animated: true)
-                }
+                self?.present(alert, animated: true)
             }
             .store(in: &cancellables)
     }
@@ -357,7 +353,7 @@ extension ProfileSettingsViewController: PHPickerViewControllerDelegate {
         }
     }
                 
-    func removedOrientationImage(_ image: UIImage) -> UIImage {
+    private func removedOrientationImage(_ image: UIImage) -> UIImage {
         guard image.imageOrientation != .up else { return image }
         
         UIGraphicsBeginImageContextWithOptions(image.size, false, image.scale)

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -350,10 +350,22 @@ extension ProfileSettingsViewController: PHPickerViewControllerDelegate {
                     FMLogger.general.error("ERROR: 이미지 저장 실패")
                     return
                 }
-                self.profileImageView.image = image
+                let normalizedImage = self.removedOrientationImage(image)
+                self.profileImageView.image = normalizedImage
                 self.viewModel.profileImageChanged()
             }
         }
+    }
+                
+    func removedOrientationImage(_ image: UIImage) -> UIImage {
+        guard image.imageOrientation != .up else { return image }
+        
+        UIGraphicsBeginImageContextWithOptions(image.size, false, image.scale)
+        image.draw(in: CGRect(origin: .zero, size: image.size))
+        let normalizedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return normalizedImage ?? image
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -194,9 +194,7 @@ final class ProfileSettingsViewController: BaseViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
                 self?.doneButton.isEnabled = false
-                let alert = UIAlertController(title: "오류 발생", message: "\(error.localizedDescription)", preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "확인", style: .cancel))
-                self?.present(alert, animated: true)
+                self?.showErrorAlert(title: Constant.errorOccurred, message: "\(error.localizedDescription)")
                 FMLogger.general.error("SignUpViewModel에서 에러: \(error)")
             }
             .store(in: &cancellables)
@@ -243,9 +241,7 @@ final class ProfileSettingsViewController: BaseViewController {
         viewModel.imageNotSafePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                let alert = UIAlertController(title: Constant.imageNotSafeTitle, message: Constant.imageNotSafeMessage, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: Constant.okTitle, style: .default))
-                self?.present(alert, animated: true)
+                self?.showErrorAlert(title: Constant.imageNotSafeTitle, message: Constant.imageNotSafeMessage)
             }
             .store(in: &cancellables)
     }
@@ -272,6 +268,12 @@ final class ProfileSettingsViewController: BaseViewController {
                 self.doneButton.isEnabled = false
             }
         }
+    }
+    
+    private func showErrorAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: Constant.okTitle, style: .default))
+        present(alert, animated: true)
     }
 }
 
@@ -306,7 +308,7 @@ private extension ProfileSettingsViewController {
     func signUpButtonTapped() {
         doneButton.isEnabled = false
         let userName = nickNameTextField.text ?? ""
-        guard let imageData = profileImageView.image?.jpegData(compressionQuality: 0.6) else {
+        guard let imageData = profileImageView.image?.jpegData(compressionQuality: 1) else {
             FMLogger.general.error("no profile image selected")
             return
         }
@@ -374,6 +376,7 @@ private extension ProfileSettingsViewController {
         static let imageNotSafeTitle = NSLocalizedString("imageNotSafeTitle", comment: "")
         static let imageNotSafeMessage = NSLocalizedString("imageNotSafeMessage", comment: "")
         static let okTitle = NSLocalizedString("ok", comment: "")
+        static let errorOccurred = NSLocalizedString("errorOccurred", comment: "")
         static let maxLength = 10
     }
     

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/ProfileSettingsViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewModel/ProfileSettingsViewModel.swift
@@ -92,7 +92,7 @@ final class ProfileSettingsViewModel: ProfileSettingsViewModelProtocol {
                     case 40001:
                         imageNotSafeSubject.send()
                     default:
-                        break
+                        errorSubject.send(errorBody)
                     }
                 }
             } catch let error {

--- a/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "imageNotSafeTitle" = "This image is not available.";
 "imageNotSafeMessage" = "This image has been confirmed to be harmful. Please select the different image.";
 "ok" = "yes";
+"errorOccurred" = "An Error has Occurred!";
 "available" = "Available nickname.";
 "lengthViolation" = "Nickname exceeds 20 characters.";
 "emptyViolation" = "Nickname must contain at least 2 characters.";

--- a/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "imageNotSafeTitle" = "この画像は使用できません。";
 "imageNotSafeMessage" = "画像の有害性が確認されました。別の画像を選択してください。";
 "ok" = "確認";
+"errorOccurred" = "エラー発生";
 "available" = "利用可能なニックネームです。";
 "lengthViolation" = "ニックネームが20文字を超えました。";
 "emptyViolation" = "ニックネームは2文字以上入力する必要があります。";

--- a/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "imageNotSafeTitle" = "이 이미지는 사용할 수 없습니다.";
 "imageNotSafeMessage" = "이미지 유해성이 확인되었습니다. 다른 이미지를 선택해 주세요.";
 "ok" = "확인";
+"errorOccurred" = "오류 발생!";
 "available" = "사용 가능한 닉네임 입니다.";
 "lengthViolation" = "닉네임이 20자를 초과했습니다.";
 "emptyViolation" = "닉네임은 2자 이상 입력해야 합니다.";


### PR DESCRIPTION
close #423 
close #424 

## 완료된 기능
- 이미지 업로드 중 에러 발생 시 alert 발생
- 이미지 압축 퀄리티 낮춰서 용량 줄이기
- 이미지 회전되어서 업로드되는 에러 수정

## 고민과 해결과정
### 어떤 이미지가 올라가지 않는걸까?
- PHPicker로 가져올 수 있는 .image 종류인 live photo, 일반 이미지, 인물사진 등등 모두 테스트해 보았다.
- 특별히 업로드되지 않는 이미지는 없었다. (.gif도 업로드 되었다)
- 문제는 매우 큰 용량의 이미지 (RAW 파일) 및 internal server error
- 해당 에러들이 있을 때 사용자에게 알려주기 위해서 alert를 구현
- Flie too large 에러 출현 빈도를 낮추기 위해 compression quality 1.0 -> 0.6으로 변경

### 이미지가 회전되어서 업로드되는 오류
- 이미지 정보에 함께 기록되는 메타 정보(EXIF)에 이미지 방향이 기록되어 있다. [공식문서] (https://developer.apple.com/documentation/uikit/uiimage/1624141-imageorientation)
- 디버깅 결과 사용자 이미지의 회전 메타 정보가 함께 서버로 올라가고, 서버에서 해당 메타 정보를 이용해서 이미지를 회전시켜서 돌려보내주고 있었다.
- 이를 방지하기 위해 이미지의 회전 메타 정보를 지운 후 서버로 전송해 주었다.
```swift
 private func removedOrientationImage(_ image: UIImage) -> UIImage {
    guard image.imageOrientation != .up else { return image }
    
    UIGraphicsBeginImageContextWithOptions(image.size, false, image.scale)
    image.draw(in: CGRect(origin: .zero, size: image.size))
    let normalizedImage = UIGraphicsGetImageFromCurrentImageContext()
    UIGraphicsEndImageContext()
    
    return normalizedImage ?? image
}
```
[참고](https://ios-development.tistory.com/1556)
