### PR TITLE
[iOS#421] 프로필 설정에서 이모티콘 입력 제한하기

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -214,23 +214,29 @@ final class SignUpViewController: BaseViewController {
         DispatchQueue.main.async {
             switch state {
             case .valid:
-                self.nickNameValidationStateLabel.text = state.message
-                self.nickNameValidationStateLabel.textColor = FlipMateColor.approveGreen.color
-                self.doneButton.isEnabled = true
+                self.approveNickName()
             case .lengthViolation:
-                self.nickNameValidationStateLabel.text = state.message
-                self.nickNameValidationStateLabel.textColor = FlipMateColor.warningRed.color
-                self.doneButton.isEnabled = false
+                self.invalidNickName(state)
             case .emptyViolation:
-                self.nickNameValidationStateLabel.text = state.message
-                self.nickNameValidationStateLabel.textColor = FlipMateColor.warningRed.color
-                self.doneButton.isEnabled = false
+                self.invalidNickName(state)
             case .duplicated:
-                self.nickNameValidationStateLabel.text = state.message
-                self.nickNameValidationStateLabel.textColor = FlipMateColor.warningRed.color
-                self.doneButton.isEnabled = false
+                self.invalidNickName(state)
+            case .emojiContained:
+                self.invalidNickName(state)
             }
         }
+    }
+    
+    private func approveNickName() {
+        self.nickNameValidationStateLabel.text = NickNameValidationState.valid.message
+        self.nickNameValidationStateLabel.textColor = FlipMateColor.approveGreen.color
+        self.doneButton.isEnabled = true
+    }
+    
+    private func invalidNickName(_ state: NickNameValidationState) {
+        self.nickNameValidationStateLabel.text = state.message
+        self.nickNameValidationStateLabel.textColor = FlipMateColor.warningRed.color
+        self.doneButton.isEnabled = false
     }
     
     private func showErrorAlert(title: String, message: String) {

--- a/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -104,23 +104,3 @@ final class SignUpViewModel: SignUpViewModelProtocol {
             .eraseToAnyPublisher()
     }
 }
-
-enum NickNameValidationState {
-    case valid
-    case lengthViolation
-    case emptyViolation
-    case duplicated
-    
-    var message: String {
-        switch self {
-        case .valid:
-            return NSLocalizedString("available", comment: "")
-        case .lengthViolation:
-            return NSLocalizedString("lengthViolation", comment: "")
-        case .emptyViolation:
-            return NSLocalizedString("emptyViolation", comment: "")
-        case .duplicated:
-            return NSLocalizedString("duplicated", comment: "")
-        }
-    }
-}

--- a/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/MyPageScene/ViewController/ProfileSettingsViewController.swift
@@ -251,23 +251,29 @@ final class ProfileSettingsViewController: BaseViewController {
         DispatchQueue.main.async {
             switch state {
             case .valid:
-                self.nickNameValidationStateLabel.text = state.message
-                self.nickNameValidationStateLabel.textColor = FlipMateColor.approveGreen.color
-                self.doneButton.isEnabled = true
+                self.approveNickName()
             case .lengthViolation:
-                self.nickNameValidationStateLabel.text = state.message
-                self.nickNameValidationStateLabel.textColor = FlipMateColor.warningRed.color
-                self.doneButton.isEnabled = false
+                self.invalidNickName(state)
             case .emptyViolation:
-                self.nickNameValidationStateLabel.text = state.message
-                self.nickNameValidationStateLabel.textColor = FlipMateColor.warningRed.color
-                self.doneButton.isEnabled = false
+                self.invalidNickName(state)
             case .duplicated:
-                self.nickNameValidationStateLabel.text = state.message
-                self.nickNameValidationStateLabel.textColor = FlipMateColor.warningRed.color
-                self.doneButton.isEnabled = false
+                self.invalidNickName(state)
+            case .emojiContained:
+                self.invalidNickName(state)
             }
         }
+    }
+    
+    private func approveNickName() {
+        self.nickNameValidationStateLabel.text = NickNameValidationState.valid.message
+        self.nickNameValidationStateLabel.textColor = FlipMateColor.approveGreen.color
+        self.doneButton.isEnabled = true
+    }
+    
+    private func invalidNickName(_ state: NickNameValidationState) {
+        self.nickNameValidationStateLabel.text = state.message
+        self.nickNameValidationStateLabel.textColor = FlipMateColor.warningRed.color
+        self.doneButton.isEnabled = false
     }
     
     private func showErrorAlert(title: String, message: String) {
@@ -354,7 +360,7 @@ extension ProfileSettingsViewController: PHPickerViewControllerDelegate {
             }
         }
     }
-                
+    
     private func removedOrientationImage(_ image: UIImage) -> UIImage {
         guard image.imageOrientation != .up else { return image }
         

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/NickNameValidator/NickNameValidator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/NickNameValidator/NickNameValidator.swift
@@ -18,6 +18,10 @@ final class NickNameValidator: NickNameValidatable {
             static let minLength = 2
         }
         
+        if nickName.containsEmoji {
+            return NickNameValidationState.emojiContained
+        }
+        
         if nickName.count > Constant.maxLenght {
             return NickNameValidationState.lengthViolation
         }
@@ -28,5 +32,47 @@ final class NickNameValidator: NickNameValidatable {
         
         // TODO: FlipMate 서비스에 맞는 다양한  닉네임 제약조건 검사
         return NickNameValidationState.valid
+    }
+}
+
+enum NickNameValidationState {
+    case valid
+    case lengthViolation
+    case emptyViolation
+    case duplicated
+    case emojiContained
+    
+    var message: String {
+        switch self {
+        case .valid:
+            return NSLocalizedString("available", comment: "")
+        case .lengthViolation:
+            return NSLocalizedString("lengthViolation", comment: "")
+        case .emptyViolation:
+            return NSLocalizedString("emptyViolation", comment: "")
+        case .duplicated:
+            return NSLocalizedString("duplicated", comment: "")
+        case .emojiContained:
+            return NSLocalizedString("emojiContained", comment: "")
+        }
+    }
+}
+
+extension Character {
+    var isSimpleEmoji: Bool {
+        guard let firstScalar = unicodeScalars.first else {
+            return false
+        }
+        return firstScalar.properties.isEmoji && firstScalar.value > 0x238C
+    }
+    var isCombinedIntoEmoji: Bool {
+        unicodeScalars.count > 1 && unicodeScalars.first?.properties.isEmoji ?? false
+    }
+    var isEmoji: Bool { isSimpleEmoji || isCombinedIntoEmoji }
+}
+
+extension String {
+    var containsEmoji: Bool {
+        return contains { $0.isEmoji }
     }
 }

--- a/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
@@ -44,6 +44,7 @@
 "lengthViolation" = "Nickname exceeds 20 characters.";
 "emptyViolation" = "Nickname must contain at least 2 characters.";
 "duplicated" = "Nickname has been duplicated.";
+"emojiContained" = "Nickname cannot contain emojis.";
 
 // MARK: - Friend Add Scene
 "addFriend" = "Add Friend";

--- a/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
@@ -44,6 +44,7 @@
 "lengthViolation" = "ニックネームが20文字を超えました。";
 "emptyViolation" = "ニックネームは2文字以上入力する必要があります。";
 "duplicated" = "重複したニックネームです。";
+"emojiContained" = "ニックネームに絵文字を含めることはできません";
 
 // MARK: - Friend Add Scene
 

--- a/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
@@ -44,6 +44,7 @@
 "lengthViolation" = "닉네임이 20자를 초과했습니다.";
 "emptyViolation" = "닉네임은 2자 이상 입력해야 합니다.";
 "duplicated" = "중복된 닉네임 입니다.";
+"emojiContained" = "이모티콘을 포함할 수 없습니다.";
 
 // MARK: - Friend Add Scene
 "addFriend" = "친구 추가";


### PR DESCRIPTION
close #421 

## 완료된 기능
- 프로필 수정 및 회원가입 화면에서 이모티콘 입력 제한

## 고민과 해결과정
### 카테고리도 이모티콘을 제한해야 하는가?
- 카테고리 기능에서는 이모티콘을 사용하고 싶어하는 사용자도 있을 것으로 생각
- 닉네임과는 다르게 사용해도 무방
- DB의 설정을 변경해서 사용할 수 있도록 할 예정

### 이모티콘 포함되어있는지 여부 확인 방법
- unicodeScalar 활용
- [참고](https://betterprogramming.pub/understanding-swift-strings-characters-and-scalars-a4b82f2d8fde)