### PR TITLE
[BE#439] fix: 소셜 화면 타임존 이슈 해결

### DIFF
--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -124,4 +124,25 @@ export class AuthController {
       ),
     };
   }
+
+  @Patch('timezone')
+  @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: '유저 타임존 설정 (완)' })
+  @ApiResponse({ status: 200, description: '타임존 설정 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 요청' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  @ApiBearerAuth()
+  async patchTimezone(
+    @User('id') user_id: number,
+    @Body('timezone') timezone: string,
+  ): Promise<any> {
+    const updatedUser = await this.usersService.updateTimezone(
+      user_id,
+      timezone,
+    );
+    return {
+      statusCode: 200,
+      message: '타임존 설정 성공',
+    };
+  }
 }

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -33,15 +33,21 @@ export class MatesController {
   @ApiCreatedResponse({
     description: 'OK',
   })
-  @ApiQuery({
-    name: 'date',
-    example: '2023-11-22',
-    description: '날짜',
+  @ApiBody({
+    schema: {
+      properties: {
+        date: {
+          type: 'datetime',
+          example: '2023-11-22T14:00:00+09:00',
+          description: '날짜',
+        },
+      },
+    },
   })
   @ApiOperation({ summary: '모든 친구들 조회하기 (완)' })
   getMates(
     @User('id') user_id: number,
-    @Query('date') date: string,
+    @Body('date') date: string,
   ): Promise<object> {
     return this.matesService.getMates(user_id, date);
   }

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -61,8 +61,10 @@ export class MatesService {
     const userTimezone = await this.userRepository.findOne({
       where: { id: user_id },
     });
-    const nowUserTime = moment(now).utcOffset(userTimezone.timezone).format();
-
+    const nowUserTime = moment(now)
+      .utcOffset(userTimezone.timezone)
+      .format('YYYY-MM-DD HH:mm:ss');
+    console.log(nowUserTime);
     const studyTimeByFollowing = await this.userRepository.query(
       `
         SELECT u.id, u.nickname, u.image_url, COALESCE(SUM(s.learning_time), 0) AS total_time

--- a/BE/src/users/entity/users.entity.ts
+++ b/BE/src/users/entity/users.entity.ts
@@ -54,6 +54,13 @@ export class UsersModel {
   })
   auth_type: AuthTypeEnum;
 
+  @Column({
+    type: 'char',
+    default: '+09:00',
+    length: 6,
+  })
+  timezone: string;
+
   @OneToMany(() => StudyLogs, (studyLog) => studyLog.user_id)
   study_logs: StudyLogs[];
 

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -78,6 +78,15 @@ export class UsersService {
     }
   }
 
+  async updateTimezone(user_id: number, timezone: string): Promise<UsersModel> {
+    const selectedUser = await this.usersRepository.findOne({
+      where: { id: user_id },
+    });
+    selectedUser.timezone = timezone;
+    const updatedUser = await this.usersRepository.save(selectedUser);
+    return updatedUser;
+  }
+
   async isUniqueNickname(nickname: string): Promise<object> {
     const isDuplicated = await this.usersRepository.exist({
       where: { nickname },


### PR DESCRIPTION
# 이슈번호-작업이름
close #439

## 완료된 기능
- user 테이블에 timezone 생성
- getMates 메서드에서 요청 온 시각을 각 유저 타임존으로 바꿔 날짜 추출 후 학습 기록 조회하도록 수정


## 고민과 해결과정
```ts
  async getMates(
    user_id: number,
    date: string,
    now = new Date(),
  ): Promise<object[]> {
    const userTimezone = await this.userRepository.findOne({
      where: { id: user_id },
    });
    const nowUserTime = moment(now).utcOffset(userTimezone.timezone).format();

    const studyTimeByFollowing = await this.userRepository.query(
      `
        SELECT u.id, u.nickname, u.image_url, COALESCE(SUM(s.learning_time), 0) AS total_time
        FROM users_model u
        LEFT JOIN mates m ON m.following_id = u.id
        LEFT JOIN study_logs s ON s.user_id = u.id AND s.date = DATE(CONVERT_TZ(?, ?, u.timezone))
        WHERE m.follower_id = ? 
        GROUP BY u.id
        ORDER BY total_time DESC
      `,
      [nowUserTime, userTimezone.timezone, user_id],
    );
```
현재 친구들의 날짜를 알아야 하니까 결국 현재 시각이 필요하더라고요. 그래서 클라이언트에서 시각을 받을까 했는데 현규님 자리에 안계셔서 일단 서버 현재 시각을 이용해서 구현했습니다
바뀐 부분은 `LEFT JOIN study_logs s ON s.user_id = u.id AND s.date = DATE(CONVERT_TZ(?, ?, u.timezone))` 요 부분인데 유저 현재 시각을 입력받아서 `CONVERT_TZ`로 요청 유저 타임존 -> 친구 타임존으로 바꿔서 친구의 현재 날짜를 받아오는겁니다

![image](https://github.com/boostcampwm2023/iOS06-FlipMate/assets/39608452/6a053c6a-5610-4aca-90f3-0d9bc752667e)
위 상황에서
![image](https://github.com/boostcampwm2023/iOS06-FlipMate/assets/39608452/8b59e097-285f-483e-a269-359dc8774606)
학습기록이 이렇게 있으면

![image](https://github.com/boostcampwm2023/iOS06-FlipMate/assets/39608452/7e9d2db3-af0d-4514-91d2-52f075469d60)
12-08 오전 1시 (+09:00 기준) 에 요청을 보내면 (+07:00)은 12-07이라서 3600 결과로 나오는거고
![image](https://github.com/boostcampwm2023/iOS06-FlipMate/assets/39608452/5c005318-ab75-45d5-9a34-f8d50f72e95f)
12-08 오전 2시 (+09:00 기준) 에 요청을 보내면 (+07:00)은 12-08이라서 10800 결과로 나옵니다
