### PR TITLE
[BE#449] 애플 로그인 구현

### DIFF
--- a/BE/src/admin/admin.controller.ts
+++ b/BE/src/admin/admin.controller.ts
@@ -21,7 +21,7 @@ export class AdminController {
   async createMockUsers(@Body('emails') emails: Array<{ email: string }>) {
     const createdUsers = [];
     for (const { email } of emails) {
-      const { access_token } = await this.authService.loginWithGoogle({
+      const { access_token } = await this.authService.loginWithOAuth({
         email,
         auth_type: 'google',
       });

--- a/BE/src/admin/admin.controller.ts
+++ b/BE/src/admin/admin.controller.ts
@@ -31,7 +31,10 @@ export class AdminController {
 
     for (let idx = 0; idx < createdUsers.length; idx++) {
       const email = createdUsers[idx].email;
-      const me = await this.usersService.findUserByEmail(email);
+      const me = await this.usersService.findUserByEmailAndAuthType(
+        email,
+        'google',
+      );
       for (let i = 1; i <= MATES_MAXIMUM; i++) {
         const friendIdx = (idx + i) % createdUsers.length;
         const friendNickname = createdUsers[friendIdx].nickname;

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -30,6 +30,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { ConfigService } from '@nestjs/config';
 import { ENV } from 'src/common/const/env-keys.const';
 import { getImageUrl } from 'src/common/utils/utils';
+import { identity } from 'rxjs';
 
 @ApiTags('로그인 페이지')
 @Controller('auth')
@@ -45,7 +46,7 @@ export class AuthController {
   @ApiExcludeEndpoint()
   googleAuth(@Req() req) {
     const user = req.user;
-    return this.authService.loginWithGoogle(user);
+    return this.authService.loginWithOAuth(user);
   }
 
   @Post('google/app')
@@ -54,7 +55,16 @@ export class AuthController {
   @ApiResponse({ status: 401, description: '인증 실패' })
   async googleAppAuth(@Body('access_token') accessToken: string) {
     const email = await this.authService.getUserInfo(accessToken);
-    return this.authService.loginWithGoogle({ email, auth_type: 'google' });
+    return this.authService.loginWithOAuth({ email, auth_type: 'google' });
+  }
+
+  @Post('apple/app')
+  @ApiOperation({ summary: 'Apple 아이폰용 로그인 (완)' })
+  @ApiResponse({ status: 201, description: '인증 성공' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  async appleAppAuth(@Body('identity_token') identity_token: string) {
+    const email = await this.authService.getAppleUserInfo(identity_token);
+    return this.authService.loginWithOAuth({ email, auth_type: 'apple' });
   }
 
   @Get('logout')

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -115,6 +115,9 @@ export class AuthService {
       });
       return decoded['email'];
     } catch (error) {
+      if (error.message === 'invalid signature') {
+        throw new UnauthorizedException('토큰 검증 실패');
+      }
       throw error;
     }
   }

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -41,13 +41,16 @@ export class AuthService {
       email: user.email,
       nickname: user.nickname,
       type: 'access',
-      auth_type: 'google',
+      auth_type: user.auth_type,
     };
     return this.jwtService.sign(payload);
   }
 
   public async loginWithOAuth(user) {
-    const prevUser = await this.usersService.findUserByEmail(user.email);
+    const prevUser = await this.usersService.findUserByEmailAndAuthType(
+      user.email,
+      user.auth_type,
+    );
     if (!prevUser) {
       const id = user.email.split('@')[0];
       const userEntity = {

--- a/BE/src/auth/guard/bearer-token.guard.ts
+++ b/BE/src/auth/guard/bearer-token.guard.ts
@@ -26,7 +26,10 @@ class BearerTokenGuard implements CanActivate {
 
     const result = this.authService.verifyToken(token);
 
-    const user = await this.usersService.findUserByEmail(result.email);
+    const user = await this.usersService.findUserByEmailAndAuthType(
+      result.email,
+      result.auth_type,
+    );
 
     if (!user) {
       throw new UnauthorizedException('해당 유저는 회원이 아닙니다.');

--- a/BE/src/common/config/typeorm.config.ts
+++ b/BE/src/common/config/typeorm.config.ts
@@ -13,6 +13,7 @@ export const typeormConfig = (config: ConfigService): TypeOrmModuleOptions => ({
   username: config.get<string>(ENV.DATABASE_USERNAME),
   password: config.get<string>(ENV.DATABASE_PASSWORD),
   database: config.get<string>(ENV.DATABASE_NAME),
+  charset: 'utf8mb4_unicode_ci',
   entities: [StudyLogs, Categories, UsersModel, Mates],
   timezone: 'Z',
   synchronize: true,

--- a/BE/src/users/entity/users.entity.ts
+++ b/BE/src/users/entity/users.entity.ts
@@ -29,9 +29,7 @@ export class UsersModel {
     example: 'google_email@email.com',
     description: 'OAuth로 로그인 한 구글 계정 아이디',
   })
-  @Column({
-    unique: true,
-  })
+  @Column()
   @IsString()
   @IsEmail()
   email: string;

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -89,9 +89,13 @@ export class UsersService {
     };
   }
 
-  async findUserByEmail(email: string): Promise<UsersModel> {
+  async findUserByEmailAndAuthType(
+    email: string,
+    auth_type: string,
+  ): Promise<UsersModel> {
+    const authEnumStr = auth_type.toUpperCase();
     const selectedUser = await this.usersRepository.findOne({
-      where: { email },
+      where: { email, auth_type: auth_type[authEnumStr] },
     });
 
     return selectedUser;

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -25,6 +25,7 @@ export class UsersService {
         nickname: user.nickname,
         email: user.email,
         image_url: null,
+        auth_type: user.auth_type,
       });
       return await this.usersRepository.save(userObject);
     } catch (error) {


### PR DESCRIPTION
# 이슈번호-작업이름
close #449 
## 완료된 기능
- 애플 로그인 구현

## 고민과 해결과정
- 공개키를 이용해서 JWT토큰을 검증하는 과정
  - 'https://appleid.apple.com/auth' 에 요청하면 공개 키를 받을 수 있습니다
  - 공개키를 받아서 JWT 헤더의 kid 값과 같은 값을 가진 공개 키를 활용해서 검증합니다.
  - 받은 jwt.verify()에 파라미터로 들어가는 key 값은 pem 형식인데 우리가 받은 공개키는 pem이 아니라서 해당 형식으로 바꿔줘야 합니다.
 
```ts
    const JWK = crypto.createPublicKey({
      format: 'jwk',
      key: {
        kty,
        n,
        e,
      },
    });
    JWK.export({
          type: 'pkcs1',
          format: 'pem',
        });
```
위 코드를 통해서 애플로부터 받은 공개키를 jwk 형태로 바꿔주고, 이를 다시 pem으로 바꿀 수 있습니다. 이 값을 공개키로 활용해 jwt를 검증할 수 있습니다 !

+ 이모지 config 한줄이면 수정 되서 추가했어요 DB 안날려도 되는 것 같습니다

