### PR TITLE
[BE#453] auth type null문제, GET요청에 body를 query로

### DIFF
--- a/BE/src/auth/google.strategy.ts
+++ b/BE/src/auth/google.strategy.ts
@@ -22,6 +22,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   ): Promise<any> {
     const user = {
       email: email.emails[0].value,
+      auth_type: 'google',
     };
     done(null, user);
   }

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -33,23 +33,23 @@ export class MatesController {
   @ApiCreatedResponse({
     description: 'OK',
   })
-  @ApiBody({
-    schema: {
-      properties: {
-        date: {
-          type: 'datetime',
-          example: '2023-11-22T14:00:00+09:00',
-          description: '날짜',
-        },
-      },
-    },
+  @ApiQuery({
+    name: 'date',
+    example: '2023-11-22',
+    description: '날짜',
+  })
+  @ApiQuery({
+    name: 'timezone',
+    example: '+09:00',
+    description: '타임존',
   })
   @ApiOperation({ summary: '모든 친구들 조회하기 (완)' })
   getMates(
     @User('id') user_id: number,
-    @Body('date') date: string,
+    @Query('date') date: string,
+    @Query('timezone') timezone: string,
   ): Promise<object> {
-    return this.matesService.getMates(user_id, date);
+    return this.matesService.getMates(user_id, date, timezone);
   }
 
   @Get('/status')

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -34,7 +34,7 @@ export class MatesController {
     description: 'OK',
   })
   @ApiQuery({
-    name: 'date',
+    name: 'datetime',
     example: '2023-11-22',
     description: '날짜',
   })
@@ -46,10 +46,10 @@ export class MatesController {
   @ApiOperation({ summary: '모든 친구들 조회하기 (완)' })
   getMates(
     @User('id') user_id: number,
-    @Query('date') date: string,
+    @Query('datetime') datetime: string,
     @Query('timezone') timezone: string,
   ): Promise<object> {
-    return this.matesService.getMates(user_id, date, timezone);
+    return this.matesService.getMates(user_id, datetime, timezone);
   }
 
   @Get('/status')

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -35,7 +35,7 @@ export class MatesController {
   })
   @ApiQuery({
     name: 'datetime',
-    example: '2023-11-22',
+    example: '2023-11-22T14:00:00',
     description: '날짜',
   })
   @ApiQuery({

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -53,8 +53,15 @@ export class MatesService {
     };
   }
 
-  async getMates(user_id: number, date: string): Promise<object[]> {
-    const offset = date.split(/\d\d:\d\d:\d\d/)[1];
+  async getMates(
+    user_id: number,
+    date: string,
+    timezone: string,
+  ): Promise<object[]> {
+    if (!user_id || !date || !timezone) {
+      throw new BadRequestException('인자의 형식이 잘못되었습니다.');
+    }
+    const offset = timezone[0] === ' ' ? `+${timezone.trim()}` : timezone;
 
     const nowUserTime = moment(date)
       .utcOffset(offset)

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -55,15 +55,15 @@ export class MatesService {
 
   async getMates(
     user_id: number,
-    date: string,
+    datetime: string,
     timezone: string,
   ): Promise<object[]> {
-    if (!user_id || !date || !timezone) {
+    if (!user_id || !datetime || !timezone) {
       throw new BadRequestException('인자의 형식이 잘못되었습니다.');
     }
     const offset = timezone[0] === ' ' ? `+${timezone.trim()}` : timezone;
 
-    const nowUserTime = moment(date)
+    const nowUserTime = moment(`${datetime}${timezone}`)
       .utcOffset(offset)
       .format('YYYY-MM-DD HH:mm:ss');
 


### PR DESCRIPTION
<img width="337" alt="스크린샷 2023-12-13 오후 8 39 37" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/4ea62faf-c75b-444f-b858-4b1f0ac3480a">
auth_type 문제는 브라우저로그인시에만 발생해서 이렇게 넣어주어 해결


<img width="584" alt="스크린샷 2023-12-13 오후 8 40 13" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/20ef7323-50ea-464a-b690-e5398fa964e5">
timezone 추가로 받아서 이를 띄어쓰기 여부를 통해 파악하여 해결