### PR TITLE
[iOS#451] 친구 검색 로직 수정

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0A814BC3CFA46D0501C8B894 /* Pods_FlipMate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288FECD685A9C6B6E481147C /* Pods_FlipMate.framework */; };
 		2C1F2BBB2B20D8D60026C30B /* SocialUserInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F2BBA2B20D8D60026C30B /* SocialUserInfoHeaderView.swift */; };
 		2C1F2BBD2B20DA770026C30B /* ProfileHeaderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F2BBC2B20DA770026C30B /* ProfileHeaderItem.swift */; };
+		2C2C7CB92B29CEC300C733D5 /* FriendSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2C7CB82B29CEC300C733D5 /* FriendSearchResult.swift */; };
 		2C2F216E2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F216D2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift */; };
 		2C2F21702B0F429800B45BA8 /* StudyLogResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F216F2B0F429800B45BA8 /* StudyLogResponseDTO.swift */; };
 		2C2F21762B0F440D00B45BA8 /* StudyLogEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F21752B0F440D00B45BA8 /* StudyLogEndpoints.swift */; };
@@ -258,6 +259,7 @@
 		2B285F39D7D27E5C564F4D31 /* Pods_FlipMateTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMateTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C1F2BBA2B20D8D60026C30B /* SocialUserInfoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialUserInfoHeaderView.swift; sourceTree = "<group>"; };
 		2C1F2BBC2B20DA770026C30B /* ProfileHeaderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeaderItem.swift; sourceTree = "<group>"; };
+		2C2C7CB82B29CEC300C733D5 /* FriendSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSearchResult.swift; sourceTree = "<group>"; };
 		2C2F216D2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStudyLogUseCase.swift; sourceTree = "<group>"; };
 		2C2F216F2B0F429800B45BA8 /* StudyLogResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyLogResponseDTO.swift; sourceTree = "<group>"; };
 		2C2F21752B0F440D00B45BA8 /* StudyLogEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyLogEndpoints.swift; sourceTree = "<group>"; };
@@ -1193,6 +1195,7 @@
 				2C5E34BD2B1B51CB00FD481B /* FriendStatus.swift */,
 				ED6865B92B1CEA0F001A2AAD /* SocialChart.swift */,
 				2C87C2802B1DF2C000A26313 /* UserInfo.swift */,
+				2C2C7CB82B29CEC300C733D5 /* FriendSearchResult.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -1832,6 +1835,7 @@
 				ED6865A72B17932F001A2AAD /* SocialDetailRequestDTO.swift in Sources */,
 				2C3430B12B0DE3D0008CBC85 /* Date++Extension.swift in Sources */,
 				ED6865D02B1F1429001A2AAD /* ChartDIContainer.swift in Sources */,
+				2C2C7CB92B29CEC300C733D5 /* FriendSearchResult.swift in Sources */,
 				60EB7F522B1EFEDA00F8C613 /* MyPageTableViewCell.swift in Sources */,
 				2C9F62152B1736BE00AE63F9 /* DefaultFriendRepository.swift in Sources */,
 				2CDCD0672B18D0330080DCDE /* FriendUser.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/SocialScene/UserProfileResposeDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/SocialScene/UserProfileResposeDTO.swift
@@ -8,9 +8,11 @@
 import Foundation
 
 struct UserProfileResposeDTO: Decodable {
+    let statusCode: Int
     let profileImageURL: String?
     
     private enum CodingKeys: String, CodingKey {
+        case statusCode
         case profileImageURL = "image_url"
     }
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/FriendEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/FriendEndpoints.swift
@@ -27,7 +27,7 @@ struct FriendEndpoints {
     static func searchFriend(at nickname: String) -> EndPoint<UserProfileResposeDTO> {
         return EndPoint(
             baseURL: BaseURL.flipmateDomain,
-            path: Paths.user + "/profile?nickname=\(nickname)",
+            path: Paths.friend + "/search?nickname=\(nickname)",
             method: .get)
     }
     

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultFriendRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultFriendRepository.swift
@@ -8,6 +8,13 @@
 import Foundation
 import Combine
 
+enum FriendSearchStatus: Int {
+    case alreayFriend = 20002
+    case myself = 20001
+    case notFriend = 20000
+    case unknown = 0
+}
+
 final class DefaultFriendRepository: FriendRepository {
     
     private let provider: Providable
@@ -36,11 +43,13 @@ final class DefaultFriendRepository: FriendRepository {
             .eraseToAnyPublisher()
     }
     
-    func search(at nickname: String) -> AnyPublisher<String?, NetworkError> {
+    func search(at nickname: String) -> AnyPublisher<FriendSearchResult, NetworkError> {
         let endPoint = FriendEndpoints.searchFriend(at: nickname)
         return provider.request(with: endPoint)
-            .map { response -> String? in
-                return response.profileImageURL
+            .map { response -> FriendSearchResult in
+                return FriendSearchResult(
+                    status: FriendSearchStatus(rawValue: response.statusCode) ?? .unknown,
+                    imageURL: response.profileImageURL)
             }
             .eraseToAnyPublisher()
     }

--- a/iOS/FlipMate/FlipMate/Domain/Entities/FriendSearchResult.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Entities/FriendSearchResult.swift
@@ -1,0 +1,13 @@
+//
+//  FriendSearchResult.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/13.
+//
+
+import Foundation
+
+struct FriendSearchResult {
+    let status: FriendSearchStatus
+    let imageURL: String?
+}

--- a/iOS/FlipMate/FlipMate/Domain/Repositories/FriendRepository.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Repositories/FriendRepository.swift
@@ -11,6 +11,6 @@ import Combine
 protocol FriendRepository {
     func follow(at nickname: String) -> AnyPublisher<String, NetworkError>
     func unfollow(at id: Int) -> AnyPublisher<String, NetworkError>
-    func search(at nickname: String) -> AnyPublisher<String?, NetworkError>
+    func search(at nickname: String) -> AnyPublisher<FriendSearchResult, NetworkError>
     func loadChart(at id: Int) -> AnyPublisher<SocialChart, NetworkError>
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultFriendUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultFriendUseCase.swift
@@ -23,7 +23,7 @@ final class DefaultFriendUseCase: FriendUseCase {
         return repository.unfollow(at: id)
     }
     
-    func search(at nickname: String) -> AnyPublisher<String?, NetworkError> {
+    func search(at nickname: String) -> AnyPublisher<FriendSearchResult, NetworkError> {
         return repository.search(at: nickname)
     }
     

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/FriendUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/FriendUseCase.swift
@@ -11,6 +11,6 @@ import Combine
 protocol FriendUseCase {
     func follow(at nickname: String) -> AnyPublisher<String, NetworkError>
     func unfollow(at id: Int) -> AnyPublisher<String, NetworkError>
-    func search(at nickname: String) -> AnyPublisher<String?, NetworkError>
+    func search(at nickname: String) -> AnyPublisher<FriendSearchResult, NetworkError>
     func loadChart(at id: Int) -> AnyPublisher<SocialChart, NetworkError>
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/FriendSearchItem.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/Model/FriendSearchItem.swift
@@ -10,4 +10,5 @@ import Foundation
 struct FreindSeacrhItem {
     let nickname: String
     let iamgeURL: String?
+    let status: FriendSearchStatus
 }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
@@ -13,6 +13,8 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
     private enum Constant {
         static let height: CGFloat = 250
         static let cornerRadius: CGFloat = 5
+        static let alreadyFriend = NSLocalizedString("alreadyFriend", comment: "")
+        static let myself = NSLocalizedString("myself", comment: "")
     }
     
     private enum ProfileImageConstant {
@@ -90,10 +92,10 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
         
         switch friendSearchItem.status {
         case .alreayFriend:
-            infomationLabel.text = "이미 친구입니다."
+            infomationLabel.text = Constant.alreadyFriend
             setfollowButtonHidden(isHidden: true)
         case .myself:
-            infomationLabel.text = "자기 자신은 친구 추가할 수 없습니다."
+            infomationLabel.text = Constant.myself
             setfollowButtonHidden(isHidden: true)
         default:
             setfollowButtonHidden(isHidden: false)

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/FriendSearchResultView.swift
@@ -62,6 +62,14 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
         return button
     }()
     
+    private lazy var infomationLabel: UILabel = {
+        let label = UILabel()
+        label.font = FlipMateFont.smallRegular.font
+        label.textColor = .label
+        return label
+    }()
+    
+    
     // MARK: - init
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -79,6 +87,17 @@ final class FriendSearchResultView: UIView, FreindAddResultViewProtocol {
     func updateUI(friendSearchItem: FreindSeacrhItem) {
         nickNameLabel.text = friendSearchItem.nickname
         profileImageView.setImage(url: friendSearchItem.iamgeURL)
+        
+        switch friendSearchItem.status {
+        case .alreayFriend:
+            infomationLabel.text = "이미 친구입니다."
+            setfollowButtonHidden(isHidden: true)
+        case .myself:
+            infomationLabel.text = "자기 자신은 친구 추가할 수 없습니다."
+            setfollowButtonHidden(isHidden: true)
+        default:
+            setfollowButtonHidden(isHidden: false)
+        }
     }
     
     func tapPublisher() -> AnyPublisher<Void, Never> {
@@ -93,7 +112,7 @@ private extension FriendSearchResultView {
         backgroundColor = FlipMateColor.gray3.color
         layer.cornerRadius = Constant.cornerRadius
 
-        [profileImageView, nickNameLabel, followButton].forEach {
+        [profileImageView, nickNameLabel, followButton, infomationLabel].forEach {
             addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
@@ -109,8 +128,16 @@ private extension FriendSearchResultView {
             
             followButton.topAnchor.constraint(equalTo: nickNameLabel.bottomAnchor, constant: FollowButtonConstant.top),
             followButton.widthAnchor.constraint(equalToConstant: FollowButtonConstant.width),
-            followButton.centerXAnchor.constraint(equalTo: centerXAnchor)
+            followButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            
+            infomationLabel.topAnchor.constraint(equalTo: nickNameLabel.bottomAnchor, constant: FollowButtonConstant.top),
+            infomationLabel.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
+    }
+    
+    func setfollowButtonHidden(isHidden: Bool) {
+        followButton.isHidden = isHidden
+        infomationLabel.isHidden = !isHidden
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/FriendAddViewController.swift
@@ -38,6 +38,7 @@ final class FriendAddViewController: BaseViewController {
     private enum Constant {
         static let maxLength = 10
         static let cancel = NSLocalizedString("cancel", comment: "")
+        static let errorMessage = NSLocalizedString("tryAgain", comment: "")
     }
     
     // MARK: - Properties
@@ -168,9 +169,9 @@ final class FriendAddViewController: BaseViewController {
         
         viewModel.followErrorPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] title in
+            .sink { [weak self] _ in
                 guard let self = self else { return }
-                self.showToast(title: title)
+                self.showToast(title: Constant.errorMessage)
             }
             .store(in: &cancellables)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
@@ -105,11 +105,12 @@ final class FriendAddViewModel: FriendAddViewModelProtocol {
                     FMLogger.friend.error("친구 검색 에러 발생 \(error.localizedDescription)")
                     self.searchErrorSubject.send()
                 }
-            } receiveValue: { [weak self] profileimageURL in
+            } receiveValue: { [weak self] friendSearchResult in
                 guard let self = self else { return }
                 self.searchResultSubject.send(FreindSeacrhItem(
                     nickname: friendNickname,
-                    iamgeURL: profileimageURL)
+                    iamgeURL: friendSearchResult.imageURL,
+                    status: friendSearchResult.status)
                 )
             }
             .store(in: &cancellables)

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/FriendAddViewModel.swift
@@ -25,7 +25,7 @@ protocol FriendAddViewModelOutput {
     var searchFreindPublisher: AnyPublisher<FreindSeacrhItem, Never> { get }
     var searchErrorPublisher: AnyPublisher<Void, Never> { get }
     var nicknameCountPublisher: AnyPublisher<Int, Never> { get }
-    var followErrorPublisher: AnyPublisher<String, Never> { get }
+    var followErrorPublisher: AnyPublisher<Void, Never> { get }
 }
 
 typealias FriendAddViewModelProtocol = FriendAddViewModelInput & FriendAddViewModelOutput
@@ -35,7 +35,7 @@ final class FriendAddViewModel: FriendAddViewModelProtocol {
     private var searchResultSubject = PassthroughSubject<FreindSeacrhItem, Never>()
     private var searchErrorSubject = PassthroughSubject<Void, Never>()
     private var nicknameCountSubject = PassthroughSubject<Int, Never>()
-    private var followErrorSubject = PassthroughSubject<String, Never>()
+    private var followErrorSubject = PassthroughSubject<Void, Never>()
     
     // MARK: - Properties
     private var cancellables = Set<AnyCancellable>()
@@ -69,7 +69,7 @@ final class FriendAddViewModel: FriendAddViewModelProtocol {
         return userInfoManger.nicknameChangePublisher
     }
     
-    var followErrorPublisher: AnyPublisher<String, Never> {
+    var followErrorPublisher: AnyPublisher<Void, Never> {
         return followErrorSubject.eraseToAnyPublisher()
     }
 
@@ -84,7 +84,7 @@ final class FriendAddViewModel: FriendAddViewModelProtocol {
                 case .failure(let error):
                     guard let self = self else { return }
                     FMLogger.friend.error("친구 요청 에러 발생 \(error)")
-                    self.followErrorSubject.send(error.localizedDescription)
+                    self.followErrorSubject.send()
                 }
             } receiveValue: { [weak self] _ in
                 guard let self = self else { return }

--- a/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
@@ -52,6 +52,7 @@
 "friendNickname" = "Friend's Nickname";
 "noResult" = "No results were found for your search.";
 "follow" = "Follow";
+"tryAagin" = "Please try again";
 
 // MARK: - TimerFinish Scene
 "yes" = "Yes";

--- a/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
@@ -53,6 +53,8 @@
 "noResult" = "No results were found for your search.";
 "follow" = "Follow";
 "tryAagin" = "Please try again";
+"alreadyFriend" = "This user is already friend.";
+"myself" = "You cannot add yourself";
 
 // MARK: - TimerFinish Scene
 "yes" = "Yes";

--- a/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "friendNickname" = "友達のニックネーム";
 "noResult" = "検索結果がありません。";
 "follow" = "フォロー";
+"tryAagin" = "もう一度お試しください";
 
 // MARK: - TimerFinish Scene
 "yes" = "はい";

--- a/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "noResult" = "検索結果がありません。";
 "follow" = "フォロー";
 "tryAagin" = "もう一度お試しください";
+"alreadyFriend" = "このユーザーはすでに友達です。";
+"myself" = "自分自身は友達として追加できません。";
 
 // MARK: - TimerFinish Scene
 "yes" = "はい";

--- a/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
@@ -53,6 +53,8 @@
 "noResult" = "검색 결과가 없습니다.";
 "follow" = "친구추가";
 "tryAagin" = "다시 시도해주세요.";
+"alreadyFriend" = "이미 친구인 사용자입니다.";
+"myself" = "자기 자신은 친구 추가를 할 수 없습니다.";
 
 // MARK: - TimerFinish Scene
 "yes" = "예";

--- a/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
@@ -52,6 +52,7 @@
 "myNickname" = "내 닉네임";
 "noResult" = "검색 결과가 없습니다.";
 "follow" = "친구추가";
+"tryAagin" = "다시 시도해주세요.";
 
 // MARK: - TimerFinish Scene
 "yes" = "예";


### PR DESCRIPTION
closed #451 

## 완료된 기능
- 친구 검색 시 이미 친구인 친구와, 나 자신을 검색했을 떄 검색 결과에 표시되도록 수정
- 기존의 Toast는 친구 추가시 네트워크 에러 발생시 다시 시도 메시지 띄우는걸로 수정

## 실행 결과
https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/820eb327-a599-4aa1-97a7-1bea3dcf6f84


## 고민과 해결과정
바뀐 요구사항과 서버 API을 토대로 20000, 20001, 20002 상태 코드에 따라 검색 결과를 매핑할 수 있게 FriendSearchStatus 열거형을 만들어 Entity에 포함되게 수정하였습니다. 해당 Status에 따라 검색 결과 View에서 친구 추가 버튼 또는 설명 label이 뜨도록 구현했습니다.
기존에 구현해뒀던 toast 메시지는 지우지 않고 혹여나 친구 추가시에 에러가 발생한 경우 토스트 메시지로 다시 시도해달라고 사용자에게 보여주는 것으로 수정했습니다!
