### PR TITLE
[iOS#447] 사용자 및 사용자간 TimeZone 대응

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		0A814BC3CFA46D0501C8B894 /* Pods_FlipMate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288FECD685A9C6B6E481147C /* Pods_FlipMate.framework */; };
 		2C1F2BBB2B20D8D60026C30B /* SocialUserInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F2BBA2B20D8D60026C30B /* SocialUserInfoHeaderView.swift */; };
 		2C1F2BBD2B20DA770026C30B /* ProfileHeaderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F2BBC2B20DA770026C30B /* ProfileHeaderItem.swift */; };
+		2C2C7CBB2B29DFA600C733D5 /* TimeZoneUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2C7CBA2B29DFA600C733D5 /* TimeZoneUseCase.swift */; };
+		2C2C7CBD2B29DFD900C733D5 /* DefaultTimeZoneUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2C7CBC2B29DFD900C733D5 /* DefaultTimeZoneUseCase.swift */; };
+		2C2C7CBF2B29E0BF00C733D5 /* UserInfoEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2C7CBE2B29E0BF00C733D5 /* UserInfoEndpoints.swift */; };
+		2C2C7CC12B29E18F00C733D5 /* TimeZoneRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2C7CC02B29E18F00C733D5 /* TimeZoneRequestDTO.swift */; };
 		2C2F216E2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F216D2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift */; };
 		2C2F21702B0F429800B45BA8 /* StudyLogResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F216F2B0F429800B45BA8 /* StudyLogResponseDTO.swift */; };
 		2C2F21762B0F440D00B45BA8 /* StudyLogEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F21752B0F440D00B45BA8 /* StudyLogEndpoints.swift */; };
@@ -258,6 +262,10 @@
 		2B285F39D7D27E5C564F4D31 /* Pods_FlipMateTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlipMateTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C1F2BBA2B20D8D60026C30B /* SocialUserInfoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialUserInfoHeaderView.swift; sourceTree = "<group>"; };
 		2C1F2BBC2B20DA770026C30B /* ProfileHeaderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeaderItem.swift; sourceTree = "<group>"; };
+		2C2C7CBA2B29DFA600C733D5 /* TimeZoneUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneUseCase.swift; sourceTree = "<group>"; };
+		2C2C7CBC2B29DFD900C733D5 /* DefaultTimeZoneUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTimeZoneUseCase.swift; sourceTree = "<group>"; };
+		2C2C7CBE2B29E0BF00C733D5 /* UserInfoEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoEndpoints.swift; sourceTree = "<group>"; };
+		2C2C7CC02B29E18F00C733D5 /* TimeZoneRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneRequestDTO.swift; sourceTree = "<group>"; };
 		2C2F216D2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStudyLogUseCase.swift; sourceTree = "<group>"; };
 		2C2F216F2B0F429800B45BA8 /* StudyLogResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyLogResponseDTO.swift; sourceTree = "<group>"; };
 		2C2F21752B0F440D00B45BA8 /* StudyLogEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyLogEndpoints.swift; sourceTree = "<group>"; };
@@ -1088,6 +1096,7 @@
 				2C9F62252B1742D200AE63F9 /* FriendEndpoints.swift */,
 				2CDCD04B2B18899A0080DCDE /* SocialEndpoints.swift */,
 				ED6865C52B1E438B001A2AAD /* ChartEndpoints.swift */,
+				2C2C7CBE2B29E0BF00C733D5 /* UserInfoEndpoints.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1212,6 +1221,7 @@
 				2C87C2842B1DF32A00A26313 /* DefaultUserInfoUseCase.swift */,
 				ED6865CD2B1E49A6001A2AAD /* DefaultChartUseCase.swift */,
 				2CD272F42B21C789000CB9E5 /* DefaultStudingPingUseCase.swift */,
+				2C2C7CBC2B29DFD900C733D5 /* DefaultTimeZoneUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -1230,6 +1240,7 @@
 				2C87C2822B1DF30E00A26313 /* UserInfoUseCase.swift */,
 				ED6865CB2B1E494D001A2AAD /* ChartUseCase.swift */,
 				2CD272F22B21C748000CB9E5 /* StudingPingUseCase.swift */,
+				2C2C7CBA2B29DFA600C733D5 /* TimeZoneUseCase.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1327,6 +1338,7 @@
 				ED3595B62B0C887C00558FAA /* TimerFinishRequestDTO.swift */,
 				ED3595B82B0C88A300558FAA /* TimerFinishResponseDTO.swift */,
 				2C2F216F2B0F429800B45BA8 /* StudyLogResponseDTO.swift */,
+				2C2C7CC02B29E18F00C733D5 /* TimeZoneRequestDTO.swift */,
 			);
 			path = TimerScene;
 			sourceTree = "<group>";
@@ -1684,6 +1696,7 @@
 				2C3430A32B0DA5A5008CBC85 /* HTTPHeader.swift in Sources */,
 				ED6865BA2B1CEA0F001A2AAD /* SocialChart.swift in Sources */,
 				EDC851D22B04EE83009031EA /* CategoryListCollectionViewCell.swift in Sources */,
+				2C2C7CBD2B29DFD900C733D5 /* DefaultTimeZoneUseCase.swift in Sources */,
 				2C9F62222B173AB500AE63F9 /* FriendFollowReqeustDTO.swift in Sources */,
 				60EB7F5B2B1F19D900F8C613 /* ProfileSettingsViewController.swift in Sources */,
 				ED38422C2B0F4531001E2803 /* LoginViewModel.swift in Sources */,
@@ -1695,6 +1708,7 @@
 				2CDCD0422B1873F60080DCDE /* SocialViewModel.swift in Sources */,
 				601EB7452B14F86100C5B216 /* SignUpEndpoints.swift in Sources */,
 				ED3842252B0F1DDA001E2803 /* DefaultAuthenticationUseCase.swift in Sources */,
+				2C2C7CBF2B29E0BF00C733D5 /* UserInfoEndpoints.swift in Sources */,
 				601EB7412B14F39B00C5B216 /* ProfileSettingsRepository.swift in Sources */,
 				2C801D7E2B04B65400A7ABAE /* DefaultTimerUseCase.swift in Sources */,
 				2C88DCFB2B124451000B4686 /* LoginDIContainer.swift in Sources */,
@@ -1781,10 +1795,12 @@
 				2C3430992B0C8427008CBC85 /* Provider.swift in Sources */,
 				2C2F21702B0F429800B45BA8 /* StudyLogResponseDTO.swift in Sources */,
 				2C2F216E2B0F40A100B45BA8 /* DefaultStudyLogUseCase.swift in Sources */,
+				2C2C7CBB2B29DFA600C733D5 /* TimeZoneUseCase.swift in Sources */,
 				ED6865D82B1F32EF001A2AAD /* CustomCalenderView.swift in Sources */,
 				2CE84EF72B0B7F3C00E2FB71 /* CategorySettingSection.swift in Sources */,
 				2C88DD112B14C50F000B4686 /* DefaultTimerFinishUseCase.swift in Sources */,
 				2C3430AD2B0DDF25008CBC85 /* DefaultTimerRepository.swift in Sources */,
+				2C2C7CC12B29E18F00C733D5 /* TimeZoneRequestDTO.swift in Sources */,
 				2C9F61F92B14F33600AE63F9 /* CategoryManagable.swift in Sources */,
 				2C6717F82B0535A8004D118D /* Int++Extension.swift in Sources */,
 				ED3595B92B0C88A300558FAA /* TimerFinishResponseDTO.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TabBarDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TabBarDIContainer.swift
@@ -22,7 +22,7 @@ final class TabBarDIContainer: TabBarFlowCoordinatorDependencies {
         self.dependencies = dependencies
     }
     
-    func makeTabBarController() -> UITabBarController {
+    func makeTabBarController() -> TabBarViewController {
         return TabBarViewController()
     }
     

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/TimerSceneDIContainer.swift
@@ -43,6 +43,7 @@ final class TimerSceneDIContainer: TimerFlowCoordinatorDependencies {
             studyLogUseCase: makeStudyLogUseCase(),
             studingPingUseCase: makeStudingPingUseCase(),
             userInfoUseCase: makeUserInfoUseCase(),
+            timeZoneUseCase: makeTimeZoneUseCase(),
             actions: actions,
             categoryManager: dependencies.categoryManager,
             userInfoManager: dependencies.userInfoManager,
@@ -64,6 +65,10 @@ final class TimerSceneDIContainer: TimerFlowCoordinatorDependencies {
     
     func makeStudingPingUseCase() -> StudingPingUseCase {
         return DefaultStudingPingUseCase(repository: makeStudyLogRespository())
+    }
+    
+    func makeTimeZoneUseCase() -> TimeZoneUseCase {
+        return DefaultTimeZoneUseCase(repository: makeUserInfoRepository())
     }
     
     func makeTimerRepository() -> TimerRepsoitory {

--- a/iOS/FlipMate/FlipMate/Data/Network/BaseComponents.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/BaseComponents.swift
@@ -8,14 +8,15 @@
 import Foundation
 
 enum BaseURL {
-    static let flipmateDomain = "https://flipmate.site:3000"
-    static let developDomain = "https://flipmate.site:3000"
+    static let flipmateDomain = "https://flipmate.site:3333"
+    static let developDomain = "https://flipmate.site:3333"
 }
 
 enum Paths {
     static let categories = "/categories"
     static let googleApp = "/auth/google/app"
     static let studylogs = "/study-logs"
+    static let auth = "/auth"
     static let authInfo = "/auth/info"
     static let nickNameValidation = "/user/nickname-validation"
     static let friend = "/mates"

--- a/iOS/FlipMate/FlipMate/Data/Network/BaseComponents.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/BaseComponents.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 enum BaseURL {
-    static let flipmateDomain = "https://flipmate.site:3333"
-    static let developDomain = "https://flipmate.site:3333"
+    static let flipmateDomain = "https://flipmate.site:3000"
+    static let developDomain = "https://flipmate.site:3000"
 }
 
 enum Paths {

--- a/iOS/FlipMate/FlipMate/Data/Network/DataMapping/TimerScene/TimeZoneRequestDTO.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/DataMapping/TimerScene/TimeZoneRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  TimeZoneRequestDTO.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/13.
+//
+
+import Foundation
+
+struct TimeZoneRequestDTO: Encodable {
+    let timezone: String
+}

--- a/iOS/FlipMate/FlipMate/Data/Network/SignUpEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/SignUpEndpoints.swift
@@ -31,11 +31,5 @@ struct SignUpEndpoints {
             data: body,
             headers: [HTTPHeader(value: contentType, field: "Content-Type")])
     }
-    
-    static func userInfo() -> EndPoint<UserInfoResponseDTO> {
-        return EndPoint(
-            baseURL: BaseURL.flipmateDomain,
-            path: Paths.authInfo,
-            method: .get)
-    }
+
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/SocialEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/SocialEndpoints.swift
@@ -12,7 +12,7 @@ struct SocialEndpoints {
     static func getMyFreinds(date: Date) -> EndPoint<[FriendsResponseDTO]> {
         return EndPoint(
             baseURL: BaseURL.flipmateDomain,
-            path: Paths.friend + "?date=\(date.dateToString(format: .yyyyMMdd))",
+            path: Paths.friend + "?datetime=\(date.dateToString(format: .yyyyMMddTHHmmSS))&timezone=\(date.dateToString(format: .ZZZZZ))",
             method: .get)
         
     }
@@ -20,7 +20,7 @@ struct SocialEndpoints {
     static func fetchMyFriend(date: Date) -> EndPoint<[FriendsResponseDTO]> {
         return EndPoint(
             baseURL: BaseURL.flipmateDomain,
-            path: Paths.friend + "?date=\(date.dateToString(format: .yyyyMMdd))",
+            path: Paths.friend + "?datetime=\(date.dateToString(format: .yyyyMMddTHHmmSS))&timezone=\(date.dateToString(format: .ZZZZZ))",
             method: .get)
     }
 }

--- a/iOS/FlipMate/FlipMate/Data/Network/UserInfoEndpoints.swift
+++ b/iOS/FlipMate/FlipMate/Data/Network/UserInfoEndpoints.swift
@@ -1,0 +1,27 @@
+//
+//  UserInfoEndpoints.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/13.
+//
+
+import Foundation
+
+struct UserInfoEndpoints {
+    static func userInfo() -> EndPoint<UserInfoResponseDTO> {
+        return EndPoint(
+            baseURL: BaseURL.flipmateDomain,
+            path: Paths.authInfo,
+            method: .get)
+    }
+    
+    static func patchTimeZone(with timeZoneRequestDTO: TimeZoneRequestDTO) -> EndPoint<StatusResponseDTO> {
+        let encoder = JSONEncoder()
+        let data = try? encoder.encode(timeZoneRequestDTO)
+        return EndPoint(
+            baseURL: BaseURL.flipmateDomain,
+            path: Paths.auth + "/timezone",
+            method: .patch,
+            data: data)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultTimerRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultTimerRepository.swift
@@ -28,7 +28,7 @@ extension DefaultTimerRepository: TimerRepsoitory {
     -> AnyPublisher<Void, NetworkError> {
         let requestDTO = TimerStartRequestDTO(
             date: startTime.dateToString(format: .yyyyMMdd),
-            createdAt: startTime.dateToString(format: .yyyyMMddhhmmss),
+            createdAt: startTime.dateToString(format: .yyyyMMddhhmmssZZZZZ),
             type: StudyType.start.rawValue,
             learningTime: 0,
             categoryID: categoryId)
@@ -48,7 +48,7 @@ extension DefaultTimerRepository: TimerRepsoitory {
     -> AnyPublisher<Void, NetworkError> {
         let requestDTO = TimerFinishRequestDTO(
             date: endTime.dateToString(format: .yyyyMMdd),
-            createdAt: endTime.dateToString(format: .yyyyMMddhhmmss),
+            createdAt: endTime.dateToString(format: .yyyyMMddhhmmssZZZZZ),
             type: StudyType.finish.rawValue,
             learningTime: learningTime,
             categoryID: categoryId)

--- a/iOS/FlipMate/FlipMate/Data/Repositories/DefaultUserInfoRepository.swift
+++ b/iOS/FlipMate/FlipMate/Data/Repositories/DefaultUserInfoRepository.swift
@@ -16,7 +16,7 @@ final class DefaultUserInfoRepository: UserInfoRepository {
     }
     
     func getUserInfo() -> AnyPublisher<UserInfo, NetworkError> {
-        let endpoint = SignUpEndpoints.userInfo()
+        let endpoint = UserInfoEndpoints.userInfo()
         return provider.request(with: endpoint)
             .map { response -> UserInfo in
                 return UserInfo(
@@ -25,5 +25,11 @@ final class DefaultUserInfoRepository: UserInfoRepository {
                     email: response.email)
             }
             .eraseToAnyPublisher()
+    }
+    
+    func patchTimeZone(date: Date) async throws {
+        let reqeust = TimeZoneRequestDTO(timezone: date.dateToString(format: .ZZZZZ))
+        let endpoint = UserInfoEndpoints.patchTimeZone(with: reqeust)
+        _ = try await provider.request(with: endpoint)
     }
 }

--- a/iOS/FlipMate/FlipMate/Domain/Repositories/UserInfoRepository.swift
+++ b/iOS/FlipMate/FlipMate/Domain/Repositories/UserInfoRepository.swift
@@ -10,4 +10,5 @@ import Combine
 
 protocol UserInfoRepository {
     func getUserInfo() -> AnyPublisher<UserInfo, NetworkError>
+    func patchTimeZone(date: Date) async throws
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultTimeZoneUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/DefaultTimeZoneUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  DefaultTimeZoneUseCase.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/13.
+//
+
+import Foundation
+
+final class DefaultTimeZoneUseCase: TimeZoneUseCase {
+    private let repository: UserInfoRepository
+    
+    init(repository: UserInfoRepository) {
+        self.repository = repository
+    }
+    
+    func patchTimeZone(date: Date) async throws {
+        try await repository.patchTimeZone(date: date)
+    }
+}

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/TimeZoneUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/TimeZoneUseCase.swift
@@ -1,0 +1,12 @@
+//
+//  TimeZoneUseCase.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2023/12/13.
+//
+
+import Foundation
+
+protocol TimeZoneUseCase {
+    func patchTimeZone(date: Date) async throws
+}

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
@@ -60,7 +60,6 @@ final class SocialViewController: BaseViewController {
         super.viewDidLoad()
         configureDiffableDataSource()
         configureNavigationBarItems()
-        configureTimeZoneNotification()
         setSnapshot()
     }
 
@@ -242,17 +241,6 @@ private extension SocialViewController {
     }
 }
 
-// MARK: - TimeZone Notification
-private extension SocialViewController {
-    func configureTimeZoneNotification() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(didChangeTimeZone),
-            name: NSNotification.Name.NSSystemTimeZoneDidChange,
-            object: nil)
-    }
-}
-
 // MARK: - Selector methods
 private extension SocialViewController {
     @objc func myPageButtonTapped() {
@@ -266,11 +254,6 @@ private extension SocialViewController {
     @objc func refreshFreindsStatus() {
         viewModel.didRefresh()
         friendsCollectionView.refreshControl?.endRefreshing()
-    }
-    
-    @objc func didChangeTimeZone() {
-        // MARK: - 타임존 대응
-        FMLogger.device.log("타임존이 바꼈습니다. SocialViewController")
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
@@ -60,6 +60,7 @@ final class SocialViewController: BaseViewController {
         super.viewDidLoad()
         configureDiffableDataSource()
         configureNavigationBarItems()
+        configureTimeZoneNotification()
         setSnapshot()
     }
 
@@ -241,22 +242,35 @@ private extension SocialViewController {
     }
 }
 
+// MARK: - TimeZone Notification
+private extension SocialViewController {
+    func configureTimeZoneNotification() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didChangeTimeZone),
+            name: NSNotification.Name.NSSystemTimeZoneDidChange,
+            object: nil)
+    }
+}
+
 // MARK: - Selector methods
 private extension SocialViewController {
-    @objc
-    func myPageButtonTapped() {
+    @objc func myPageButtonTapped() {
         viewModel.myPageButtonTapped()
     }
     
-    @objc
-    func addFriendButtonTapped() {
+    @objc func addFriendButtonTapped() {
         viewModel.freindAddButtonDidTapped()
     }
     
-    @objc
-    func refreshFreindsStatus() {
+    @objc func refreshFreindsStatus() {
         viewModel.didRefresh()
         friendsCollectionView.refreshControl?.endRefreshing()
+    }
+    
+    @objc func didChangeTimeZone() {
+        // MARK: - 타임존 대응
+        FMLogger.device.log("타임존이 바꼈습니다. SocialViewController")
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewModel/SocialViewModel.swift
@@ -114,7 +114,7 @@ final class SocialViewModel: SocialViewModelProtocol {
     }
     
     func didRefresh() {
-        fetchFriendStatus()
+        getFriendState()
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/Flows/TabBarFlowCoordinator.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol TabBarFlowCoordinatorDependencies {
-    func makeTabBarController() -> UITabBarController
+    func makeTabBarController() -> TabBarViewController
     func makeTimerViewController() -> UIViewController
     func makeTimerDIContainer() -> TimerSceneDIContainer
     func makeSocialDIContainer() -> SocialDIContainer
@@ -32,6 +32,7 @@ final class TabBarFlowCoordinator: NSObject, Coordinator {
     func start() {
         let tabBarController = dependencies.makeTabBarController()
         tabBarController.delegate = self
+        tabBarController.timeZoneDelegate = self
         tabBarController.setViewControllers(
             [setSocialViewController(), makeTimerViewContorller(), makeChartViewController()],
             animated: false
@@ -112,5 +113,13 @@ extension TabBarFlowCoordinator: UITabBarControllerDelegate {
                 return
             }
         }
+    }
+}
+
+extension TabBarFlowCoordinator: TimeZoneDelegate {
+    func didChangeTimeZone() {
+        socialViewController = nil
+        childCoordinators = []
+        start()
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/ViewController/TabBarViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/ViewController/TabBarViewController.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol TimeZoneDelegate: NSObject {
+    func didChangeTimeZone()
+}
+
 final class TabBarViewController: UITabBarController {
     
     // MARK: - Constant
@@ -14,7 +18,13 @@ final class TabBarViewController: UITabBarController {
         static let timerImageName = "timer"
         static let borderWidth: CGFloat = 1.0
         static let timerImageSize: CGFloat = 40
+        static let timeZone = NSLocalizedString("timeZone", comment: "")
+        static let timeZoneMessage = NSLocalizedString("timeZoneMessage", comment: "")
+        static let yes = NSLocalizedString("yes", comment: "")
     }
+    
+    // MARK: - Properties
+    weak var timeZoneDelegate: TimeZoneDelegate?
     
     // MARK: - UI Components
     lazy var timerButton: UIButton = {
@@ -106,15 +116,19 @@ private extension TabBarViewController {
     
     @objc func didChangeTimeZone() {
         // MARK: - 타임존 대응
-        FMLogger.device.log("타임존이 바뀌었습니다.")
+        FMLogger.device.log("타임존이 바뀌었습니다")
         showAlert()
     }
     
     func showAlert() {
         let alertController = UIAlertController(
-            title: "타임존 설정",
-            message: "현재 타임존이 바뀌었기 때문에 화면을 새로고침합니다.", preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "확인", style: .default)
+            title: Constant.timeZone,
+            message: Constant.timeZoneMessage, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: Constant.yes, style: .default) { [weak self] _ in
+            guard let self = self else { return }
+            self.timeZoneDelegate?.didChangeTimeZone()
+        }
+        
         alertController.addAction(okAction)
         present(alertController, animated: true)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/TabBar/ViewController/TabBarViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TabBar/ViewController/TabBarViewController.swift
@@ -9,12 +9,14 @@ import UIKit
 
 final class TabBarViewController: UITabBarController {
     
+    // MARK: - Constant
     private enum Constant {
         static let timerImageName = "timer"
         static let borderWidth: CGFloat = 1.0
         static let timerImageSize: CGFloat = 40
     }
     
+    // MARK: - UI Components
     lazy var timerButton: UIButton = {
         let button = UIButton()
         button.layer.borderWidth = Constant.borderWidth
@@ -38,6 +40,7 @@ final class TabBarViewController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureTabBar()
+        configureTimeZoneNotification()
     }
     
     override func viewDidLayoutSubviews() {
@@ -83,6 +86,14 @@ private extension TabBarViewController {
             timerButton.topAnchor.constraint(equalTo: view.bottomAnchor, constant: -tabBarHeight * 1.5)
         ])
     }
+    
+    func configureTimeZoneNotification() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didChangeTimeZone),
+            name: NSNotification.Name.NSSystemTimeZoneDidChange,
+            object: nil)
+    }
 }
 
 // MARK: - objc function
@@ -91,5 +102,20 @@ private extension TabBarViewController {
         selectedIndex = 1
         timerButton.imageView?.tintColor = FlipMateColor.tabBarIconSelected.color
         FeedbackManager.shared.startTabBarItemTapFeedback()
+    }
+    
+    @objc func didChangeTimeZone() {
+        // MARK: - 타임존 대응
+        FMLogger.device.log("타임존이 바뀌었습니다.")
+        showAlert()
+    }
+    
+    func showAlert() {
+        let alertController = UIAlertController(
+            title: "타임존 설정",
+            message: "현재 타임존이 바뀌었기 때문에 화면을 새로고침합니다.", preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "확인", style: .default)
+        alertController.addAction(okAction)
+        present(alertController, animated: true)
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -77,11 +77,12 @@ final class TimerViewController: BaseViewController {
         super.viewDidLoad()
         setDataSource()
         setSnapshot()
+        configureTimeZoneNotification()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         UIDevice.current.isProximityMonitoringEnabled = true
-        configureNotification()
+        configureProximityNotification()
         timerViewModel.viewWillAppear()
     }
     
@@ -90,7 +91,7 @@ final class TimerViewController: BaseViewController {
         deviceMotionManager.stopDeviceMotion()
         timerViewModel.viewDidDisappear()
         UIDevice.current.isProximityMonitoringEnabled = false
-        NotificationCenter.default.removeObserver(self)
+        removeProximityNotification()
     }
     // swiftlint:enable notification_center_detachment
     
@@ -222,7 +223,7 @@ private extension TimerViewController {
 
 // MARK: Detecting FaceDown Method
 private extension TimerViewController {
-    func configureNotification() {
+    func configureProximityNotification() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(proximityDidChange(_:)),
@@ -230,9 +231,27 @@ private extension TimerViewController {
             object: nil)
     }
     
+    func removeProximityNotification() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIDevice.proximityStateDidChangeNotification,
+            object: nil)
+    }
+    
     func handleOrientationChange(_ orientation: UIDeviceOrientation) {
         guard let deviceOrientation = DeviceOrientation(rawValue: orientation.rawValue) else { return }
         timerViewModel.deviceOrientationDidChange(deviceOrientation)
+    }
+}
+
+// MARK: - TimeZone Notification
+private extension TimerViewController {
+    func configureTimeZoneNotification() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didChangeTimeZone),
+            name: NSNotification.Name.NSSystemTimeZoneDidChange,
+            object: nil)
     }
 }
 
@@ -246,6 +265,11 @@ private extension TimerViewController {
     
     @objc func categorySettingButtonDidTapped() {
         timerViewModel.categorySettingButtoneDidTapped()
+    }
+    
+    @objc func didChangeTimeZone() {
+        // MARK: - 타임존 대응
+        FMLogger.device.log("타임존이 바꼈습니다. TimerViewController")
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerViewController.swift
@@ -77,7 +77,6 @@ final class TimerViewController: BaseViewController {
         super.viewDidLoad()
         setDataSource()
         setSnapshot()
-        configureTimeZoneNotification()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -244,17 +243,6 @@ private extension TimerViewController {
     }
 }
 
-// MARK: - TimeZone Notification
-private extension TimerViewController {
-    func configureTimeZoneNotification() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(didChangeTimeZone),
-            name: NSNotification.Name.NSSystemTimeZoneDidChange,
-            object: nil)
-    }
-}
-
 // MARK: objc function
 private extension TimerViewController {
     @objc func proximityDidChange(_ notification: Notification) {
@@ -265,11 +253,6 @@ private extension TimerViewController {
     
     @objc func categorySettingButtonDidTapped() {
         timerViewModel.categorySettingButtoneDidTapped()
-    }
-    
-    @objc func didChangeTimeZone() {
-        // MARK: - 타임존 대응
-        FMLogger.device.log("타임존이 바꼈습니다. TimerViewController")
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewModel/TimerViewModel.swift
@@ -49,6 +49,7 @@ final class TimerViewModel: TimerViewModelProtocol {
     private var studyLogUseCase: StudyLogUseCase
     private var studingPingUseCase: StudingPingUseCase
     private var userInfoUseCase: UserInfoUseCase
+    private var timeZoneUseCase: TimeZoneUseCase
     
     // MARK: Subject
     private var isDeviceFaceDownSubject = PassthroughSubject<Bool, Never>()
@@ -75,6 +76,7 @@ final class TimerViewModel: TimerViewModelProtocol {
          studyLogUseCase: StudyLogUseCase,
          studingPingUseCase: StudingPingUseCase,
          userInfoUseCase: UserInfoUseCase,
+         timeZoneUseCase: TimeZoneUseCase,
          actions: TimerViewModelActions? = nil,
          categoryManager: CategoryManageable,
          userInfoManager: UserInfoManagerProtocol,
@@ -83,6 +85,7 @@ final class TimerViewModel: TimerViewModelProtocol {
         self.studyLogUseCase = studyLogUseCase
         self.studingPingUseCase = studingPingUseCase
         self.userInfoUseCase = userInfoUseCase
+        self.timeZoneUseCase = timeZoneUseCase
         self.actions = actions
         self.categoryManager = categoryManager
         self.userInfoManager = userInfoManager
@@ -132,6 +135,7 @@ final class TimerViewModel: TimerViewModelProtocol {
     func viewDidLoad() {
         updateStudyLog()
         updateUserInfo()
+        patchTimeZone()
     }
     
     func viewWillAppear() {
@@ -212,6 +216,12 @@ private extension TimerViewModel {
                 self.userInfoManager.updateProfileImage(at: userInfo.profileImageURL)
             }
             .store(in: &cancellables)
+    }
+    
+    func patchTimeZone() {
+        Task {
+            try await timeZoneUseCase.patchTimeZone(date: Date())
+        }
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/Date++Extension.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/Extensions/Date++Extension.swift
@@ -10,7 +10,9 @@ import Foundation
 extension Date {
     enum FMDateFormmat: String {
         case yyyyMMdd = "yyyy-MM-dd"
-        case yyyyMMddhhmmss = "yyyy-MM-dd HH:mm:ssZZZZZ"
+        case yyyyMMddTHHmmSS = "yyyy-MM-dd'T'HH:mm:ss"
+        case yyyyMMddhhmmssZZZZZ = "yyyy-MM-dd HH:mm:ssZZZZZ"
+        case ZZZZZ = "ZZZZZ"
     }
     
     /// 파라미터로 전달받은 format의 타입으로 Date을 문자열로 변환하여 리턴합니다.

--- a/iOS/FlipMate/FlipMate/Presentation/Utils/FriendStatusPollingManager/FriendStatusPollingManager.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/Utils/FriendStatusPollingManager/FriendStatusPollingManager.swift
@@ -62,7 +62,7 @@ final class FriendStatusPollingManager: FriendStatusPollingManageable {
         for id in learningFriendsBeforeLearning {
             guard let friend = friendsStatus.filter({ $0.id == id }).first else { return }
             guard let startedTime = friend.startedTime else { continue }
-            guard let date = startedTime.stringToDate(.yyyyMMddhhmmss) else { continue }
+            guard let date = startedTime.stringToDate(.yyyyMMddhhmmssZZZZZ) else { continue }
             let currentLearningTime = Int(Date().timeIntervalSince(date)) - 1
             updateFriendArray.append(UpdateFriend(id: friend.id, currentLearningTime: currentLearningTime))
         }
@@ -74,7 +74,7 @@ final class FriendStatusPollingManager: FriendStatusPollingManageable {
         for id in learningFriendsBeforeStop {
             guard let friend = friendsStatus.filter({ $0.id == id }).first else { return }
             guard let startedTime = friend.startedTime else { continue }
-            guard let date = startedTime.stringToDate(.yyyyMMddhhmmss) else { continue }
+            guard let date = startedTime.stringToDate(.yyyyMMddhhmmssZZZZZ) else { continue }
             let currentLearningTime = Int(Date().timeIntervalSince(date)) - 1
             updateFriendArray.append(UpdateFriend(id: friend.id, currentLearningTime: currentLearningTime))
         }

--- a/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
@@ -97,3 +97,8 @@
 
 // MARK: - Sign Up Scene
 "signUp" = "Sign Up";
+
+// MARK: - TimeZone
+"timeZone" = "TimeZone";
+"timeZoneMessage" = "Refresh the screen because the time zone has changed.";
+

--- a/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
@@ -98,3 +98,7 @@
 
 // MARK: - Sign Up Scene
 "signUp" = "会員登録";
+
+// MARK: - TimeZone
+"timeZone" = "タイムゾーン";
+"timeZoneMessage" = "タイムゾーンが変更されたため、画面をリフレッシュしています。";

--- a/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
@@ -91,3 +91,7 @@
 
 // MARK: - Sign Up Scene
 "signUp" = "회원가입";
+
+// MARK: - TimeZone
+"timeZone" = "시간대";
+"timeZoneMessage" = "시간대가 변경되어 화면을 새로고침합니다.";


### PR DESCRIPTION
closed #447 

## 완료된 기능
- 사용자 TimeZone이 바뀐경우 화면 새로고침되도록 구현
- 사용자간 TimeZone에 대응할 수 있도록 TimeZone patch API 요청

## 실행 결과

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/9124b26d-f6d9-4409-8259-24dab194dc4d



hi의 날짜가 바뀐다하더라도 hello의 오늘 공부 시간은 변하지 않음

## 고민과 해결과정
### 사용자의 TimeZone이 바뀐 경우

사용자의 TimeZone이 변경되었을 경우 기존에는 이전 데이터가 그대로 보여주고 있었다. 여기서 문제가 발생했는데 만약 사용자가 마지막으로 앱을 사용했던 날짜와 TimeZone이 바뀌고 난 뒤 앱을 사용했던 날짜가 다르게 된다면 동기화문제가 발생하게 된다.

마지막으로 12일의 데이터를 보고 있던 사용자는 TimeZone이 바뀌고 13일이 되었음에도 불구하고 12일 데이터를 보는 상황이 생기게 된다. 그래서 사용자의 디바이스 TimeZone이 바뀌었을 경우를 감지하여 바뀔 때마다 화면을 새로고침해줘서 데이터 동기화를 해결했다.

다행히 `NSSystemTimeZoneDidChange` SystemNotification이 존재하여 비교적 간단하게 TimeZone이 바뀐지 여부를 확인할 수 있었고
TabBarController에서 TimeZoneDidChange Notification을 등록해줘서 감지를 하게 되면 TabBarFlowCoordinator에서 TabBarController의 delegate을 채택하여 감지가될 때마다 tabBarController을 다시 화면에 띄워주도록 구현했습니다.
그래서 어느 ViewController에 있어도 Notfication이 감지가 되면 tabBarController에서 감지하기 때문에 초기 화면으로 돌아갈 수 있게했습니다.

``` swift
extension TabBarFlowCoordinator: TimeZoneDelegate {
    func didChangeTimeZone() {
        socialViewController = nil
        childCoordinators = []
        start()
    }
}

```
 혹여나 메모리 누수의 문제가 있을까 싶어서 메모리에서 이전의 ViewController, Coordinator, DIContainer, VIewModel들이 다 해제되는 것을 확인했습니다~!

### 사용자간의 TimeZone 대응
BE분들과 의논한대로 TimeZone이 변경될 때 & 사용자가 디바이스를 실행한 경우에 GMT기준으로 현재 시차가 +- 몇시간인지 서버에 전달하는 것으로 대응완료했습니다.

NSSystemTimeZoneDidChange은 앱이 실행되어있을 때만 TimeZone이 바뀐 것을 감지하기 때문에 앱이 실행되지 않았을 경우에도 TimeZone이 바뀐 것을 대응해줘야했습니다. 

결론은 앱이 켜져있을 때에도 TimeZone이 변경되면 TimerViewController로 무조건 화면이 전환되고 앱을 처음 실행했을 때에도 TImerViewController로 화면이 전환되기 때문에 TimerViewController의 ViewDidLoad시점에 TimeZone 업데이트하는 것으로 구현했습니다.

다만 해당 방식대로 구현했을 때 TimeZone이 변경되지 않아도 앱을 처음 1번 실행시킬 때 사용자의 TimeZone을 보낸다는 단점이 있긴한데 현재로서는 앱을 키지 않았을 때 TimeZone이 바뀐 경우를 알 방법이 없기 때문에 해당 방식밖에 떠오르지 않아서 해당 방식대로 구현했습니다~


