### PR TITLE
[iOS/#434] DatePicker 오늘 날짜로 스크롤 되게 수정

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/CustomCalenderView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct CustomCalenderView: View {
     @Binding var selectedDate: Date
     @ObservedObject var viewModel: ChartViewModel
+    @State private var todayIndex: Int?
     @Environment(\.colorScheme) var colorScheme
     private let calendar = Calendar.current
     
@@ -64,34 +65,41 @@ struct CustomCalenderView: View {
         // swiftlint:disable force_unwrapping
         let today = calendar.date(from: Calendar.current.dateComponents([.year, .month], from: selectedDate))!
         
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 10) {
-                let components = (0..<calendar.range(of: .day, in: .month, for: today)!.count)
-                    .map {
-                        calendar.date(byAdding: .day, value: $0, to: today)!
-                    }
-                
-                ForEach(components, id: \.self) { date in
-                    VStack {
-                        Text(day(from: date))
-                            .font(.caption)
-                        Text("\(calendar.component(.day, from: date))")
-                    }
-                    .frame(width: 30, height: 30)
-                    .padding(5)
-                    .background(calendar.isDate(selectedDate, equalTo: date, toGranularity: .day) ? 
-                                (colorScheme == .dark ? .white : .darkBlue) : Color.clear)
-                    .cornerRadius(16)
-                    .foregroundColor(calendar.isDate(selectedDate, equalTo: date, toGranularity: .day) ? (colorScheme == .dark ? .black : .white) : 
-                                        (colorScheme == .dark ? .white : .black))
-                    .onTapGesture {
-                        selectedDate = date
-                        
+        ScrollViewReader { scrollView in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    let components = (0..<calendar.range(of: .day, in: .month, for: today)!.count)
+                        .map {
+                            calendar.date(byAdding: .day, value: $0, to: today)!
+                        }
+                    
+                    ForEach(components.indices, id: \.self) { index in
+                        VStack {
+                            Text(day(from: components[index]))
+                                .font(.caption)
+                                .id(index)
+                            Text("\(calendar.component(.day, from: components[index]))")
+                        }
+                        .frame(width: 30, height: 30)
+                        .padding(5)
+                        .background(calendar.isDate(selectedDate, equalTo: components[index], toGranularity: .day) ?
+                                    (colorScheme == .dark ? .white : .darkBlue) : Color.clear)
+                        .cornerRadius(16)
+                        .foregroundColor(calendar.isDate(selectedDate, equalTo: components[index], toGranularity: .day) ? 
+                                         (colorScheme == .dark ? .black : .white) :
+                                            (colorScheme == .dark ? .white : .black))
+                        .onTapGesture {
+                            selectedDate = components[index]
+                            
+                        }
                     }
                 }
             }
             .padding(.leading, 15)
             .padding(.trailing, 15)
+            .onAppear {
+                scrollView.scrollTo((calendar.dateComponents([.day], from: Date()).day ?? 1) - 1)
+            }
         }
         // swiftlint:enable force_unwrapping
     }


### PR DESCRIPTION
# 이슈번호-작업이름

close #434 

## 완료된 기능

- DatePicker 오늘 날짜로 스크롤 되게 수정

## 고민과 해결과정

막상 완성해보니까 별 거 아니었는데, 구현 중 SwiftUI에서 View Life Cycle과 관련해서 자꾸 버그가 있었습니다.
각 날짜 마다 index를 매겨서 (1일 - 0, 2일 - 1, 3일 - 2, ... , 31일 - 30), 오늘 날짜 - 1로 강제 스크롤하게 하였습니다.

++
실수로 main에 푸쉬해서 revert 하였습니다 !!
