### PR TITLE
[iOS/#464] 카테고리 추가/변경 규칙 설정

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/Flows/CategorySettingCoordinator.swift
@@ -49,6 +49,8 @@ final class CategoryFlowCoordinator: Coordinator {
     }
     
     func didFinishCategoryModify() {
-        navigationController?.popViewController(animated: true)
+        DispatchQueue.main.async {
+            self.navigationController?.popViewController(animated: true)
+        }
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
@@ -20,7 +20,8 @@ final class TimerFinishViewController: BaseViewController {
     private let viewModel: TimerFinishViewModelProtocol
     private var cancellables = Set<AnyCancellable>()
     private let deviceMotionManager = DeviceMotionManager.shared
-
+    private var buttonEnabled: Bool = true
+    
     // MARK: - UI Components
     private lazy var backgroundView: UIView = {
         let view = UIView()
@@ -53,7 +54,7 @@ final class TimerFinishViewController: BaseViewController {
         return button
     }()
     
-    private lazy var cancleButton: UIButton = {
+    private lazy var cancelButton: UIButton = {
         let button = UIButton()
         button.setTitle(Constant.cancle, for: .normal)
         button.backgroundColor = FlipMateColor.darkBlue.color
@@ -102,6 +103,10 @@ final class TimerFinishViewController: BaseViewController {
     }
     
     // MARK: - Life Cycle
+    override func viewDidAppear(_ animated: Bool) {
+        makeButtonEnabled()
+    }
+    
     override func viewDidDisappear(_ animated: Bool) {
         deviceMotionManager.startDeviceMotion()
     }
@@ -114,7 +119,7 @@ final class TimerFinishViewController: BaseViewController {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        [saveButton, cancleButton, titleLabel, learningTimeTitleLabel, learningTimeContentLabel].forEach {
+        [saveButton, cancelButton, titleLabel, learningTimeTitleLabel, learningTimeContentLabel].forEach {
             finishView.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
@@ -147,10 +152,10 @@ final class TimerFinishViewController: BaseViewController {
             saveButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
             saveButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2),
             
-            cancleButton.bottomAnchor.constraint(equalTo: finishView.bottomAnchor),
-            cancleButton.leadingAnchor.constraint(equalTo: finishView.leadingAnchor),
-            cancleButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
-            cancleButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2)
+            cancelButton.bottomAnchor.constraint(equalTo: finishView.bottomAnchor),
+            cancelButton.leadingAnchor.constraint(equalTo: finishView.leadingAnchor),
+            cancelButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
+            cancelButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2)
         ])
     }
     
@@ -168,15 +173,27 @@ final class TimerFinishViewController: BaseViewController {
 private extension TimerFinishViewController {
     @objc func saveButtonDidTapped() {
         viewModel.saveButtonDidTapped()
+        makeButtonDisabled()
     }
     
     @objc func cancleButtonDidTapped() {
         viewModel.cancleButtonDidTapped()
+        makeButtonDisabled()
     }
 }
 
 private extension TimerFinishViewController {
     func updateLearningTime(time: Int) {
         learningTimeContentLabel.text = time.secondsToStringTime()
+    }
+    
+    func makeButtonDisabled() {
+        saveButton.isEnabled = false
+        cancelButton.isEnabled = false
+    }
+    
+    func makeButtonEnabled() {
+        saveButton.isEnabled = true
+        cancelButton.isEnabled = true
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
@@ -20,8 +20,7 @@ final class TimerFinishViewController: BaseViewController {
     private let viewModel: TimerFinishViewModelProtocol
     private var cancellables = Set<AnyCancellable>()
     private let deviceMotionManager = DeviceMotionManager.shared
-    private var buttonEnabled: Bool = true
-    
+
     // MARK: - UI Components
     private lazy var backgroundView: UIView = {
         let view = UIView()
@@ -54,7 +53,7 @@ final class TimerFinishViewController: BaseViewController {
         return button
     }()
     
-    private lazy var cancelButton: UIButton = {
+    private lazy var cancleButton: UIButton = {
         let button = UIButton()
         button.setTitle(Constant.cancle, for: .normal)
         button.backgroundColor = FlipMateColor.darkBlue.color
@@ -103,10 +102,6 @@ final class TimerFinishViewController: BaseViewController {
     }
     
     // MARK: - Life Cycle
-    override func viewDidAppear(_ animated: Bool) {
-        makeButtonEnabled()
-    }
-    
     override func viewDidDisappear(_ animated: Bool) {
         deviceMotionManager.startDeviceMotion()
     }
@@ -119,7 +114,7 @@ final class TimerFinishViewController: BaseViewController {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        [saveButton, cancelButton, titleLabel, learningTimeTitleLabel, learningTimeContentLabel].forEach {
+        [saveButton, cancleButton, titleLabel, learningTimeTitleLabel, learningTimeContentLabel].forEach {
             finishView.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
@@ -152,10 +147,10 @@ final class TimerFinishViewController: BaseViewController {
             saveButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
             saveButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2),
             
-            cancelButton.bottomAnchor.constraint(equalTo: finishView.bottomAnchor),
-            cancelButton.leadingAnchor.constraint(equalTo: finishView.leadingAnchor),
-            cancelButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
-            cancelButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2)
+            cancleButton.bottomAnchor.constraint(equalTo: finishView.bottomAnchor),
+            cancleButton.leadingAnchor.constraint(equalTo: finishView.leadingAnchor),
+            cancleButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
+            cancleButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2)
         ])
     }
     
@@ -173,27 +168,15 @@ final class TimerFinishViewController: BaseViewController {
 private extension TimerFinishViewController {
     @objc func saveButtonDidTapped() {
         viewModel.saveButtonDidTapped()
-        makeButtonDisabled()
     }
     
     @objc func cancleButtonDidTapped() {
         viewModel.cancleButtonDidTapped()
-        makeButtonDisabled()
     }
 }
 
 private extension TimerFinishViewController {
     func updateLearningTime(time: Int) {
         learningTimeContentLabel.text = time.secondsToStringTime()
-    }
-    
-    func makeButtonDisabled() {
-        saveButton.isEnabled = false
-        cancelButton.isEnabled = false
-    }
-    
-    func makeButtonEnabled() {
-        saveButton.isEnabled = true
-        cancelButton.isEnabled = true
     }
 }

--- a/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
@@ -22,6 +22,10 @@
 "categoryNamePlaceHolder" = "Please enter the category name";
 "social" = "Social";
 "categoryAddMessage" = "You cannot add more than 10 categories";
+"categoryErrorTitle" = "Category Add / Modify Error";
+"categoryNameCountError" = "Category names must be 1 to 10 characters long.";
+"categoryNameIsDuplicated" = "Category names cannot be duplicated.";
+"unknownError" = "Unknown Error occurred.";
 
 // MARK: - MyPage Scene
 "myPage" = "MyPage";

--- a/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
@@ -22,6 +22,10 @@
 "categoryNamePlaceHolder" = "カテゴリ名を入力してください。";
 "social" = "ソーシャル";
 "categoryAddMessage" = "カテゴリは10個まで追加できます。";
+"categoryErrorTitle" = "カテゴリ追加・変更エラー";
+"categoryNameCountError" = "カテゴリ名の長さは 1 ～ 10 文字にする必要があります。";
+"categoryNameIsDuplicated" = "カテゴリ名は重複できません。";
+"unknownError" = "不明なエラーが発生しました。";
 
 // MARK: - MyPage Scene
 "myPage" = "マイページ";

--- a/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
@@ -22,6 +22,10 @@
 "categoryNamePlaceHolder" = "카테고리 이름을 입력해주세요.";
 "social" = "소셜";
 "categoryAddMessage" = "카테고리는 10개까지 추가할 수 있습니다.";
+"categoryErrorTitle" = "카테고리 추가 / 변경 실패";
+"categoryNameCountError" = "카테고리 이름은 1~10자여야 합니다.";
+"categoryNameIsDuplicated" = "카테고리 이름은 중복될 수 없습니다.";
+"unknownError" = "알 수 없는 오류가 발생했습니다.";
 
 // MARK: - MyPage Scene
 "myPage" = "마이페이지";


### PR DESCRIPTION

close #464 
## 완료된 기능

1. 카테고리 1~10자
2. 카테고리 이름 중복시

## 고민과 해결과정

기존 NickNameValidator를 사용하려면 NameValidatorable 같은 protocol로 추상화 하여야 했는데, 귀찮아서 그냥 viewModel에서 로직 체크하도록 하였습니다.

Alert 띄우도록 했는데, 어색하면 추후 수정하는게 좋을 것 같습니다.
(닉네임처럼 작성 중 경고를 띄울 지 ...)