### PR TITLE
[iOS/#476] 버튼 다중 터치 버그 수정

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/TimerScene/ViewController/TimerFinishViewController.swift
@@ -53,7 +53,7 @@ final class TimerFinishViewController: BaseViewController {
         return button
     }()
     
-    private lazy var cancleButton: UIButton = {
+    private lazy var cancelButton: UIButton = {
         let button = UIButton()
         button.setTitle(Constant.cancle, for: .normal)
         button.backgroundColor = FlipMateColor.darkBlue.color
@@ -102,6 +102,10 @@ final class TimerFinishViewController: BaseViewController {
     }
     
     // MARK: - Life Cycle
+    override func viewDidAppear(_ animated: Bool) {
+        makeButtonsEnabled()
+    }
+    
     override func viewDidDisappear(_ animated: Bool) {
         deviceMotionManager.startDeviceMotion()
     }
@@ -114,7 +118,7 @@ final class TimerFinishViewController: BaseViewController {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        [saveButton, cancleButton, titleLabel, learningTimeTitleLabel, learningTimeContentLabel].forEach {
+        [saveButton, cancelButton, titleLabel, learningTimeTitleLabel, learningTimeContentLabel].forEach {
             finishView.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
@@ -147,10 +151,10 @@ final class TimerFinishViewController: BaseViewController {
             saveButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
             saveButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2),
             
-            cancleButton.bottomAnchor.constraint(equalTo: finishView.bottomAnchor),
-            cancleButton.leadingAnchor.constraint(equalTo: finishView.leadingAnchor),
-            cancleButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
-            cancleButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2)
+            cancelButton.bottomAnchor.constraint(equalTo: finishView.bottomAnchor),
+            cancelButton.leadingAnchor.constraint(equalTo: finishView.leadingAnchor),
+            cancelButton.widthAnchor.constraint(equalTo: finishView.widthAnchor, multiplier: 0.5),
+            cancelButton.heightAnchor.constraint(equalTo: finishView.heightAnchor, multiplier: 0.2)
         ])
     }
     
@@ -168,15 +172,27 @@ final class TimerFinishViewController: BaseViewController {
 private extension TimerFinishViewController {
     @objc func saveButtonDidTapped() {
         viewModel.saveButtonDidTapped()
+        makeButtonsDisabled()
     }
     
     @objc func cancleButtonDidTapped() {
         viewModel.cancleButtonDidTapped()
+        makeButtonsDisabled()
     }
 }
 
 private extension TimerFinishViewController {
     func updateLearningTime(time: Int) {
         learningTimeContentLabel.text = time.secondsToStringTime()
+    }
+    
+    func makeButtonsDisabled() {
+        cancelButton.isEnabled = false
+        saveButton.isEnabled = false
+    }
+    
+    func makeButtonsEnabled() {
+        cancelButton.isEnabled = true
+        saveButton.isEnabled = true
     }
 }


### PR DESCRIPTION
# 이슈번호-작업이름
close #476 

## 완료된 기능

- Timer-Finish View에서 [예] 버튼 다중 터치시 누적되어 저장되는 버그 수정

## 고민과 해결과정

직관적으로 Button의 isEnabled Property를 다루는 방법으로 수정했습니다.

다만 버튼과 관련하여 해당 버그와 같은 경우가 많을 것 같은데, 그럴때마다 위 방법으로 하는 것이 맞는지도 조금 의문이 듭니다 -
만약 모든 버튼이 일회성 터치만 요구한다면, UIButton Extension으로 뺄 수 있을 것 같기도 하네요