### PR TITLE
[BE#487] 친구 고정 기능

### DIFF
--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -163,6 +163,11 @@ export class MatesController {
   @ApiBody({
     schema: {
       properties: {
+        following_id: {
+          type: 'number',
+          description: '친구의 id',
+          example: '1',
+        },
         fixation: {
           type: 'boolean',
           description: '고정/고정 해제 여부',
@@ -172,10 +177,11 @@ export class MatesController {
     },
   })
   async fixationMate(
-    @Body('id') id: number,
+    @User('id') id: number,
+    @Body('following_id') following_id: number,
     @Body('fixation') fixation: boolean,
   ): Promise<StatusMessageDto> {
-    await this.matesService.fixationMate(id, fixation);
+    await this.matesService.fixationMate(id, following_id, fixation);
 
     return {
       statusCode: 200,

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -160,6 +160,17 @@ export class MatesController {
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '친구 목록에서 고정/고정 해제' })
+  @ApiBody({
+    schema: {
+      properties: {
+        fixation: {
+          type: 'boolean',
+          description: '고정/고정 해제 여부',
+          example: 'true',
+        },
+      },
+    },
+  })
   async fixationMate(
     @Body('id') id: number,
     @Body('fixation') fixation: boolean,

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   UseGuards,
   Query,
+  Patch,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -152,6 +153,22 @@ export class MatesController {
     return {
       statusCode: 200,
       message: '성공적으로 삭제되었습니다.',
+    };
+  }
+
+  @Patch('fixation')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '친구 목록에서 고정/고정 해제' })
+  async fixationMate(
+    @Body('id') id: number,
+    @Body('fixation') fixation: boolean,
+  ): Promise<StatusMessageDto> {
+    await this.matesService.fixationMate(id, fixation);
+
+    return {
+      statusCode: 200,
+      message: '수정 완료',
     };
   }
 }

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -179,9 +179,9 @@ export class MatesController {
   async fixationMate(
     @User('id') id: number,
     @Body('following_id') following_id: number,
-    @Body('fixation') fixation: boolean,
+    @Body('is_fixed') is_fixed: boolean,
   ): Promise<StatusMessageDto> {
-    await this.matesService.fixationMate(id, following_id, fixation);
+    await this.matesService.fixationMate(id, following_id, is_fixed);
 
     return {
       statusCode: 200,

--- a/BE/src/mates/mates.entity.ts
+++ b/BE/src/mates/mates.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  Column,
+} from 'typeorm';
 import { UsersModel } from 'src/users/entity/users.entity';
 
 @Entity()
@@ -19,4 +25,7 @@ export class Mates {
   })
   @JoinColumn({ name: 'following_id' })
   following_id: UsersModel;
+
+  @Column({ type: 'boolean', default: false })
+  fixataion: boolean;
 }

--- a/BE/src/mates/mates.entity.ts
+++ b/BE/src/mates/mates.entity.ts
@@ -27,5 +27,5 @@ export class Mates {
   following_id: UsersModel;
 
   @Column({ type: 'boolean', default: false })
-  fixataion: boolean;
+  fixation: boolean;
 }

--- a/BE/src/mates/mates.entity.ts
+++ b/BE/src/mates/mates.entity.ts
@@ -27,5 +27,5 @@ export class Mates {
   following_id: UsersModel;
 
   @Column({ type: 'boolean', default: false })
-  fixation: boolean;
+  is_fixed: boolean;
 }

--- a/BE/src/mates/mates.service.spec.ts
+++ b/BE/src/mates/mates.service.spec.ts
@@ -78,11 +78,13 @@ describe('MatesService', () => {
         id: 2,
         follower_id: { id: 1 },
         following_id: { id: 3 },
+        fixation: false,
       } as never);
       jest.spyOn(repository, 'save').mockResolvedValueOnce({
         id: 2,
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 3 } as UsersModel,
+        fixation: false,
       });
       const result = await service.addMate(user, '어린콩3');
       expect(result).toStrictEqual({
@@ -133,6 +135,7 @@ describe('MatesService', () => {
         id: 1,
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 3 } as UsersModel,
+        fixation: false,
       });
       expect(service.addMate(user, '어린콩2')).rejects.toThrow(
         BadRequestException,
@@ -176,6 +179,7 @@ describe('MatesService', () => {
           id: 1,
           follower_id: { id: 1 } as UsersModel,
           following_id: { id: 2 } as UsersModel,
+          fixation: false,
         },
       ]);
       jest
@@ -198,7 +202,7 @@ describe('MatesService', () => {
       jest
         .spyOn(redisService, 'hget')
         .mockResolvedValueOnce('2023-11-29 16:00:00');
-      const result = await service.getMates(1, '2023-11-29', '09:00');
+      const result = await service.getMates(1, '2023-11-29', '+09:00');
       expect(result).toStrictEqual([
         {
           id: 2,
@@ -271,6 +275,7 @@ describe('MatesService', () => {
         id: 1,
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 2 } as UsersModel,
+        fixation: false,
       });
       const result = await service.findMate(user, '어린콩2');
       expect(result).toStrictEqual({

--- a/BE/src/mates/mates.service.spec.ts
+++ b/BE/src/mates/mates.service.spec.ts
@@ -84,7 +84,7 @@ describe('MatesService', () => {
         id: 2,
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 3 } as UsersModel,
-        fixation: false,
+        is_fixed: false,
       });
       const result = await service.addMate(user, '어린콩3');
       expect(result).toStrictEqual({
@@ -135,7 +135,7 @@ describe('MatesService', () => {
         id: 1,
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 3 } as UsersModel,
-        fixation: false,
+        is_fixed: false,
       });
       expect(service.addMate(user, '어린콩2')).rejects.toThrow(
         BadRequestException,
@@ -179,7 +179,7 @@ describe('MatesService', () => {
           id: 1,
           follower_id: { id: 1 } as UsersModel,
           following_id: { id: 2 } as UsersModel,
-          fixation: false,
+          is_fixed: false,
         },
       ]);
       jest
@@ -202,7 +202,7 @@ describe('MatesService', () => {
       jest
         .spyOn(redisService, 'hget')
         .mockResolvedValueOnce('2023-11-29 16:00:00');
-      const result = await service.getMates(1, '2023-11-29', '+09:00');
+      const result = await service.getMates(1, '2023-11-29 00:00:00', ' 09:00');
       expect(result).toStrictEqual([
         {
           id: 2,
@@ -215,7 +215,7 @@ describe('MatesService', () => {
     });
     it('친구가 없는 유저는 빈 배열을 가져온다.', async () => {
       jest.spyOn(service, 'getMatesStudyTime').mockResolvedValueOnce([]);
-      const result = await service.getMates(3, '2023-11-29', '09:00');
+      const result = await service.getMates(3, '2023-11-29 00:00:00', '09:00');
       expect(result).toStrictEqual([]);
     });
   });
@@ -275,7 +275,7 @@ describe('MatesService', () => {
         id: 1,
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 2 } as UsersModel,
-        fixation: false,
+        is_fixed: false,
       });
       const result = await service.findMate(user, '어린콩2');
       expect(result).toStrictEqual({

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -224,14 +224,14 @@ export class MatesService {
   async fixationMate(
     id,
     following_id: number,
-    fixataion: boolean,
+    is_fixed: boolean,
   ): Promise<void> {
     const result = await this.matesRepository.update(
       {
         follower_id: { id: id },
         following_id: { id: following_id },
       },
-      { fixation: fixataion },
+      { is_fixed: is_fixed },
     );
 
     if (!result) {

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -221,6 +221,17 @@ export class MatesService {
     }
   }
 
+  async fixationMate(id: number, fixataion: boolean): Promise<void> {
+    const result = await this.matesRepository.update(
+      { id: id },
+      { fixataion: fixataion },
+    );
+
+    if (!result) {
+      throw new NotFoundException('해당 친구 관계는 존재하지 않습니다.');
+    }
+  }
+
   entityToDto(mate: Mates): MatesDto {
     const { id, follower_id, following_id } = mate;
     const mateDto = {

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -224,7 +224,7 @@ export class MatesService {
   async fixationMate(id: number, fixataion: boolean): Promise<void> {
     const result = await this.matesRepository.update(
       { id: id },
-      { fixataion: fixataion },
+      { fixation: fixataion },
     );
 
     if (!result) {

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -106,8 +106,8 @@ export class MatesService {
         LEFT JOIN mates m ON m.following_id = u.id
         LEFT JOIN study_logs s ON s.user_id = u.id AND s.date = DATE(CONVERT_TZ(?, ?, u.timezone))
         WHERE m.follower_id = ? 
-        GROUP BY u.id
-        ORDER BY total_time DESC
+        GROUP BY u.id, m.fixation
+        ORDER BY m.fixation DESC, total_time DESC
       `,
       [followerDate, followerTimezone, followerId],
     );

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -221,9 +221,16 @@ export class MatesService {
     }
   }
 
-  async fixationMate(id: number, fixataion: boolean): Promise<void> {
+  async fixationMate(
+    id,
+    following_id: number,
+    fixataion: boolean,
+  ): Promise<void> {
     const result = await this.matesRepository.update(
-      { id: id },
+      {
+        follower_id: { id: id },
+        following_id: { id: following_id },
+      },
       { fixation: fixataion },
     );
 


### PR DESCRIPTION
# 이슈번호-작업이름
close#487
## 완료된 기능
- 친구 고정 기능 구현
- 친구 목록 불러올 때 고정된 것 우선적으로 받아오기

## 고민과 해결과정
- entity에 fixation 열 추가 (true면 고정, false면 고정x)
- Body로 친구id, 고정/해제 여부 받아서 수정하기
