### PR TITLE
[iOS/#489] 팔로워 확인을 위한 Social tap UI - HeaderView 변경

### DIFF
--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/SocialUserInfoHeaderView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/SocialUserInfoHeaderView.swift
@@ -11,9 +11,9 @@ final class SocialUserInfoHeaderView: UICollectionReusableView {
       
     // MARK: - Constant
     private enum Constant {
-        static let defaultNickName = "닉네임"
-        static let following = "팔로잉"
-        static let follower = "팔로워"
+        static let defaultNickName = NSLocalizedString("nickname", comment: "")
+        static let following = NSLocalizedString("followingNumber", comment: "")
+        static let follower = NSLocalizedString("followerNumber", comment: "")
         static let defaultTime = "00:00:00"
         static let defaultNumber = "0"
     }
@@ -22,13 +22,13 @@ final class SocialUserInfoHeaderView: UICollectionReusableView {
         static var width: CGFloat = 60
         static var height: CGFloat = 60
         static var top: CGFloat = 32
-        static var leading: CGFloat = 10
+        static var leading: CGFloat = 20
         static var spacing: CGFloat = 5
     }
     
     private enum UserNameLabelConstant {
         static var bottom: CGFloat = 8
-        static var title = "닉네임"
+        static var title = Constant.defaultNickName
     }
     
     private enum LearningTimeLabelConstant {

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/SocialUserInfoHeaderView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/View/SocialUserInfoHeaderView.swift
@@ -12,13 +12,18 @@ final class SocialUserInfoHeaderView: UICollectionReusableView {
     // MARK: - Constant
     private enum Constant {
         static let defaultNickName = "닉네임"
+        static let following = "팔로잉"
+        static let follower = "팔로워"
         static let defaultTime = "00:00:00"
+        static let defaultNumber = "0"
     }
     
     private enum ProfileImageViewConstant {
-        static var width: CGFloat = 90
-        static var height: CGFloat = 90
+        static var width: CGFloat = 60
+        static var height: CGFloat = 60
         static var top: CGFloat = 32
+        static var leading: CGFloat = 10
+        static var spacing: CGFloat = 5
     }
     
     private enum UserNameLabelConstant {
@@ -29,6 +34,11 @@ final class SocialUserInfoHeaderView: UICollectionReusableView {
     private enum LearningTimeLabelConstant {
         static var bottom: CGFloat = 8
         static var title = "00:00:00"
+    }
+    
+    private enum FollowViewConstant {
+        static var spacing: CGFloat = 10
+        static var trailing: CGFloat = -20
     }
     
     private enum DividerConstant {
@@ -48,6 +58,91 @@ final class SocialUserInfoHeaderView: UICollectionReusableView {
         return imageView
     }()
     
+    private lazy var userInfoStackView: UIStackView = {
+        let view = UIStackView()
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.axis = .vertical
+        view.alignment = .leading
+        view.distribution = .equalSpacing
+        view.spacing = ProfileImageViewConstant.spacing
+        
+        return view
+    }()
+    
+    private lazy var followInfoStackView: UIStackView = {
+        let view = UIStackView()
+        
+        view.axis = .vertical
+        view.alignment = .leading
+        view.distribution = .equalSpacing
+        view.spacing = FollowViewConstant.spacing
+        
+        return view
+    }()
+    
+    private lazy var followingStackView: UIStackView = {
+        let view = UIStackView()
+        
+        view.axis = .horizontal
+        view.alignment = .leading
+        view.distribution = .equalSpacing
+        view.spacing = FollowViewConstant.spacing
+        
+        return view
+    }()
+    
+    private lazy var followingLabel: UILabel = {
+        let label = UILabel()
+        
+        label.font = FlipMateFont.mediumRegular.font
+        label.text = Constant.following
+        label.textColor = FlipMateColor.gray2.color
+        
+        return label
+    }()
+    
+    private lazy var followingNumberLabel: UILabel = {
+        let label = UILabel()
+        
+        label.font = FlipMateFont.mediumBold.font
+        label.textColor = .label
+        label.text = Constant.defaultNumber
+        
+        return label
+    }()
+    
+    private lazy var followerStackView: UIStackView = {
+        let view = UIStackView()
+        
+        view.axis = .horizontal
+        view.alignment = .leading
+        view.distribution = .equalSpacing
+        view.spacing = FollowViewConstant.spacing
+        
+        return view
+    }()
+    
+    private lazy var followerLabel: UILabel = {
+        let label = UILabel()
+        
+        label.font = FlipMateFont.mediumRegular.font
+        label.text = Constant.follower
+        label.textColor = FlipMateColor.gray2.color
+        
+        return label
+    }()
+    
+    private lazy var followerNumberLabel: UILabel = {
+        let label = UILabel()
+        
+        label.font = FlipMateFont.mediumBold.font
+        label.textColor = .label
+        label.text = Constant.defaultNumber
+        
+        return label
+    }()
+    
     private lazy var userNameLabel: UILabel = {
         let label = UILabel()
         label.font = FlipMateFont.mediumBold.font
@@ -61,7 +156,7 @@ final class SocialUserInfoHeaderView: UICollectionReusableView {
         let label = UILabel()
         label.font = FlipMateFont.mediumBold.font
         label.text = Constant.defaultTime
-        label.textColor = .label
+        label.textColor = FlipMateColor.gray2.color
         label.textAlignment = .center
         return label
     }()
@@ -93,33 +188,53 @@ final class SocialUserInfoHeaderView: UICollectionReusableView {
     func update(learningTime: Int) {
         learningTimeLabel.text = learningTime.secondsToStringTime()
     }
+    
+    func update(following: Int) {
+        followingNumberLabel.text = "\(following)"
+    }
+    
+    func update(follower: Int) {
+        followerNumberLabel.text = "\(follower)"
+    }
 }
 
 // MARK: - UI Setting
 private extension SocialUserInfoHeaderView {
     func configureUI() {
-        [ profileImageView, userNameLabel, learningTimeLabel, divider ].forEach {
+        [ profileImageView, userInfoStackView, followInfoStackView, divider ].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             self.addSubview($0)
+        }
+        
+        [userNameLabel, learningTimeLabel].forEach {
+            self.userInfoStackView.addArrangedSubview($0)
+        }
+        
+        [followingStackView, followerStackView].forEach {
+            self.followInfoStackView.addArrangedSubview($0)
+        }
+        
+        [followingLabel, followingNumberLabel].forEach {
+            self.followingStackView.addArrangedSubview($0)
+        }
+        
+        [followerLabel, followerNumberLabel].forEach {
+            self.followerStackView.addArrangedSubview($0)
         }
         
         NSLayoutConstraint.activate([
             profileImageView.topAnchor.constraint(equalTo: self.topAnchor, constant: ProfileImageViewConstant.top),
             profileImageView.widthAnchor.constraint(equalToConstant: ProfileImageViewConstant.width),
             profileImageView.heightAnchor.constraint(equalToConstant: ProfileImageViewConstant.height),
-            profileImageView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            profileImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: ProfileImageViewConstant.leading),
             
-            userNameLabel.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: UserNameLabelConstant.bottom),
-            userNameLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            userNameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            userNameLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            userInfoStackView.centerYAnchor.constraint(equalTo: profileImageView.centerYAnchor),
+            userInfoStackView.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: ProfileImageViewConstant.leading),
             
-            learningTimeLabel.topAnchor.constraint(equalTo: userNameLabel.bottomAnchor, constant: LearningTimeLabelConstant.bottom),
-            learningTimeLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            learningTimeLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            learningTimeLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            followInfoStackView.centerYAnchor.constraint(equalTo: profileImageView.centerYAnchor),
+            followInfoStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: FollowViewConstant.trailing),
             
-            divider.topAnchor.constraint(equalTo: learningTimeLabel.bottomAnchor, constant: DividerConstant.bottom),
+            divider.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: DividerConstant.bottom),
             divider.leadingAnchor.constraint(equalTo: leadingAnchor),
             divider.trailingAnchor.constraint(equalTo: trailingAnchor),
             divider.heightAnchor.constraint(equalToConstant: DividerConstant.height)

--- a/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/SocialScene/ViewController/SocialViewController.swift
@@ -28,7 +28,7 @@ final class SocialViewController: BaseViewController {
         layout.minimumInteritemSpacing = LayoutConstant.itemSpacing
         layout.itemSize = CGSize(
             width: UIScreen.main.bounds.width / LayoutConstant.itemCountForLine - LayoutConstant.itemSpacing * 2,
-            height: LayoutConstant.iemHeight)
+            height: LayoutConstant.itemHeight)
         layout.headerReferenceSize = CGSize(width: LayoutConstant.sectionWidth, height: LayoutConstant.sectionHeight)
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.register(FriendsCollectionViewCell.self)
@@ -165,11 +165,12 @@ final class SocialViewController: BaseViewController {
     func bindFriendsRelatedPublisher() {
         viewModel.freindsPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] friends in
+            .sink { [weak self] followings in
                 guard let self = self else { return }
+                guard let header = findHeader() else { return }
                 var snapshot = Snapshot()
                 snapshot.appendSections([.main])
-                snapshot.appendItems(friends.map { Friend(
+                snapshot.appendItems(followings.map { Friend(
                     id: $0.id,
                     nickName: $0.nickName,
                     profileImageURL: $0.profileImageURL,
@@ -177,6 +178,7 @@ final class SocialViewController: BaseViewController {
                     startedTime: $0.startedTime,
                     isStuding: $0.isStuding)}
                 )
+                header.update(following: followings.count)
                 self.diffableDataSource.apply(snapshot, animatingDifferences: true)
             }
             .store(in: &cancellables)
@@ -283,11 +285,11 @@ private extension SocialViewController {
         
         static var lineSpacing: CGFloat = 16
         static var itemSpacing: CGFloat = 16
-        static var iemHeight: CGFloat = 179
+        static var itemHeight: CGFloat = 179
         static var itemCountForLine = 3.0
         
         static var sectionWidth: CGFloat = 50
-        static var sectionHeight: CGFloat = 200
+        static var sectionHeight: CGFloat = 110
     }
     
     private enum ProfileImageViewConstant {
@@ -304,10 +306,5 @@ private extension SocialViewController {
     private enum LearningTimeLabelConstant {
         static var bottom: CGFloat = 8
         static var title = "00:00:00"
-    }
-    
-    private enum DividerConstant {
-        static var bottom: CGFloat = 24
-        static var height: CGFloat = 1
     }
 }

--- a/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/en.lproj/Localizable.strings
@@ -132,6 +132,9 @@ If you have any questions or concerns about this privacy policy, or if you have 
 "min" = "min";
 "me" = "Me";
 "friend" = "Friend";
+"nickname" = "Nickname";
+"followingNumber" = "Following";
+"followerNumber" = "Follower";
 
 // MARK: - ChartViewController
 "daily" = "Daily";

--- a/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ja.lproj/Localizable.strings
@@ -133,6 +133,9 @@
 "min" = "分";
 "me" = "私";
 "friend" = "友達";
+"nickname" = "ニックネーム";
+"followingNumber" = "フォロー";
+"followerNumber" = "フォロワー";
 
 // MARK: - ChartViewController
 "daily" = "毎日";

--- a/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
+++ b/iOS/FlipMate/FlipMate/Resources/ko.lproj/Localizable.strings
@@ -130,6 +130,9 @@
 "min" = "분(m)";
 "me" = "나";
 "friend" = "친구";
+"nickname" = "닉네임";
+"followingNumber" = "팔로잉";
+"followerNumber" = "팔로워";
 
 // MARK: - Chart Scene
 "daily" = "일간";


### PR DESCRIPTION
# 이슈번호-작업이름
close #489 

## 완료된 기능

<img width="374" alt="image" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/138603822/15c5e8b7-7ef6-4560-8b73-b6249cbd4486">


## 고민과 해결과정

사실 팔로잉 확인 기능 구현 태스크 중 하나의 과정인데, PR 양이 방대해질 것 같아 해당 Task를 조금씩 쪼개기로 하였습니다.

1. 현재 UI도 다소 어색한 부분이 있습니다. 향후 계획은 팔로워 목록을 확인하기 위해서는 `팔로워` 라벨을 터치하게끔 하고 싶은데, 현재 디자인상 팔로잉 목록은 CollectionView로 자동으로 표현되어 있는 상황입니다. 팔로잉 목록도 `팔로잉` 라벨을 터치했을 때 보여주게 하면 하단이 텅 비어있어 대대적인 교체가 필요할 것 같습니다.

2. 팔로잉, 팔로워 라벨을 스택뷰로 구현하였는데, 사실 같은 모양이라 상위 view로 묶어 구현하였으면 편리하였을 것 같기도 한데, 귀찮기도 하고 해당 UI가 단 2개(소셜 탭의 팔로잉, 팔로워)만 사용되어 HeaderView에 중복된 코드가 작성된 감이 있습니다.

3. 또한 소셜과 소셜 상세창의 UX는 비슷한데 UI는 조금 달라 친구를 탭하여 상세 화면 진입시 다소 이질감이 느껴집니다.
