### PR TITLE
[BE#494] 팔로워들 차단하기

### DIFF
--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -209,7 +209,7 @@ export class MatesController {
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
   @ApiOperation({
-    summary: '친구 목록에서 차단/차단 해제(나를 팔로우하고 있는 사람만 가능)',
+    summary: '팔로워 목록에서 차단/차단 해제(나를 팔로우하고 있는 사람만 가능)',
   })
   @ApiBody({
     schema: {
@@ -238,5 +238,13 @@ export class MatesController {
       statusCode: 200,
       message: '수정 완료',
     };
+  }
+
+  @Get('/blockings')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '내가 차단한 사람들 조회하기' })
+  getBlockedMate(@User('id') user_id: number): Promise<object> {
+    return this.matesService.getBlockedFollowersInfo(user_id);
   }
 }

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -204,4 +204,39 @@ export class MatesController {
       message: '수정 완료',
     };
   }
+
+  @Patch('blocking')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: '친구 목록에서 차단/차단 해제(나를 팔로우하고 있는 사람만 가능)',
+  })
+  @ApiBody({
+    schema: {
+      properties: {
+        following_id: {
+          type: 'number',
+          description: '친구의 id',
+          example: '1',
+        },
+        fixation: {
+          type: 'boolean',
+          description: '차단/차단 해제 여부',
+          example: 'true',
+        },
+      },
+    },
+  })
+  async blockMate(
+    @User('id') id: number,
+    @Body('following_id') following_id: number,
+    @Body('is_blocked') is_blocked: boolean,
+  ): Promise<StatusMessageDto> {
+    await this.matesService.blockMate(id, following_id, is_blocked);
+
+    return {
+      statusCode: 200,
+      message: '수정 완료',
+    };
+  }
 }

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -214,7 +214,7 @@ export class MatesController {
   @ApiBody({
     schema: {
       properties: {
-        following_id: {
+        follower_id: {
           type: 'number',
           description: '친구의 id',
           example: '1',
@@ -229,10 +229,10 @@ export class MatesController {
   })
   async blockMate(
     @User('id') id: number,
-    @Body('following_id') following_id: number,
+    @Body('follower_id') follower_id: number,
     @Body('is_blocked') is_blocked: boolean,
   ): Promise<StatusMessageDto> {
-    await this.matesService.blockMate(id, following_id, is_blocked);
+    await this.matesService.blockMate(id, follower_id, is_blocked);
 
     return {
       statusCode: 200,

--- a/BE/src/mates/mates.entity.ts
+++ b/BE/src/mates/mates.entity.ts
@@ -28,4 +28,7 @@ export class Mates {
 
   @Column({ type: 'boolean', default: false })
   is_fixed: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  is_blocked: boolean;
 }

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -247,14 +247,14 @@ export class MatesService {
   async fixationMate(
     id: number,
     following_id: number,
-    is_blocked: boolean,
+    is_fixed: boolean,
   ): Promise<void> {
     const result = await this.matesRepository.update(
       {
         follower_id: { id: id },
         following_id: { id: following_id },
       },
-      { is_blocked: is_blocked },
+      { is_fixed: is_fixed },
     );
 
     if (!result) {
@@ -264,15 +264,15 @@ export class MatesService {
 
   async blockMate(
     id: number,
-    following_id: number,
-    is_fixed: boolean,
+    follower_id: number,
+    is_blocked: boolean,
   ): Promise<void> {
     const result = await this.matesRepository.update(
       {
-        follower_id: { id: following_id },
+        follower_id: { id: follower_id },
         following_id: { id: id },
       },
-      { is_fixed: is_fixed },
+      { is_blocked: is_blocked },
     );
 
     if (!result) {

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -71,6 +71,17 @@ export class MatesService {
     );
   }
 
+  getBlockedFollowersInfo(user_id: number) {
+    return this.matesRepository.query(
+      `SELECT u.id, u.nickname, u.image_url 
+       FROM mates 
+       INNER JOIN users_model as u ON u.id = mates.follower_id 
+       WHERE mates.following_id = ? AND mates.is_blocked = true
+       ORDER BY u.nickname`,
+      [user_id],
+    );
+  }
+
   getFollowingsInfo(user_id: number) {
     return this.matesRepository.query(
       `SELECT u.id, u.nickname, u.image_url 

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -245,14 +245,32 @@ export class MatesService {
   }
 
   async fixationMate(
-    id,
+    id: number,
     following_id: number,
-    is_fixed: boolean,
+    is_blocked: boolean,
   ): Promise<void> {
     const result = await this.matesRepository.update(
       {
         follower_id: { id: id },
         following_id: { id: following_id },
+      },
+      { is_blocked: is_blocked },
+    );
+
+    if (!result) {
+      throw new NotFoundException('해당 친구 관계는 존재하지 않습니다.');
+    }
+  }
+
+  async blockMate(
+    id: number,
+    following_id: number,
+    is_fixed: boolean,
+  ): Promise<void> {
+    const result = await this.matesRepository.update(
+      {
+        follower_id: { id: following_id },
+        following_id: { id: id },
       },
       { is_fixed: is_fixed },
     );

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -65,7 +65,7 @@ export class MatesService {
       `SELECT u.id, u.nickname, u.image_url 
        FROM mates 
        INNER JOIN users_model as u ON u.id = mates.follower_id 
-       WHERE mates.following_id = ?
+       WHERE mates.following_id = ? AND mates.is_blocked = false
        ORDER BY u.nickname`,
       [user_id],
     );

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -22,7 +22,7 @@ export class UsersService {
   async getFollowsCount(user_id: number) {
     const [followsCount] = await this.usersRepository.query(
       `SELECT 
-        (SELECT COUNT(*) FROM mates WHERE following_id = ?) AS follower_count,
+        (SELECT COUNT(*) FROM mates WHERE following_id = ? AND is_blocked = false) AS follower_count,
         (SELECT COUNT(*) FROM mates WHERE follower_id = ?) AS following_count`,
       [user_id, user_id],
     );


### PR DESCRIPTION
close #494 

## 완료된 기능
- 차단/차단해제
- 팔로워 목록 조회시 차단된 유저 제외
- 차단한 사람들만 조회

## 고민과 해결과정
- 기존에 작성한 fixation 관련 함수와 동일하게 작성했습니다.