### PR TITLE
[BE#501] 친구 목록 페이지네이션 추가

### DIFF
--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -49,9 +49,10 @@ export class MatesController {
     @User('id') user_id: number,
     @Query('datetime') datetime: string,
     @Query('timezone') timezone: string,
-    @Query('page') page: number,
+    @Query('page') page: string = '0',
   ): Promise<object> {
-    return this.matesService.getMates(user_id, datetime, timezone, page);
+    const page_num = parseInt(page);
+    return this.matesService.getMates(user_id, datetime, timezone, page_num);
   }
 
   @Get('/followers')

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -49,8 +49,9 @@ export class MatesController {
     @User('id') user_id: number,
     @Query('datetime') datetime: string,
     @Query('timezone') timezone: string,
+    @Query('page') page: number,
   ): Promise<object> {
-    return this.matesService.getMates(user_id, datetime, timezone);
+    return this.matesService.getMates(user_id, datetime, timezone, page);
   }
 
   @Get('/followers')

--- a/BE/src/mates/mates.service.spec.ts
+++ b/BE/src/mates/mates.service.spec.ts
@@ -85,6 +85,7 @@ describe('MatesService', () => {
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 3 } as UsersModel,
         is_fixed: false,
+        is_blocked: false,
       });
       const result = await service.addMate(user, '어린콩3');
       expect(result).toStrictEqual({
@@ -92,18 +93,6 @@ describe('MatesService', () => {
         follower_id: 1,
         following_id: 3,
       });
-    });
-
-    it('친구는 최대 10명까지 추가할 수 있다.', async () => {
-      jest.spyOn(usersRepository, 'findOne').mockResolvedValueOnce({
-        id: 3,
-        nickname: '어린콩3',
-        image_url: null,
-      } as UsersModel);
-      jest.spyOn(repository, 'count').mockResolvedValueOnce(10);
-      expect(service.addMate(user, '어린콩3')).rejects.toThrow(
-        BadRequestException,
-      );
     });
 
     it('자신을 친구 추가 할 수 없다.', async () => {
@@ -136,6 +125,7 @@ describe('MatesService', () => {
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 3 } as UsersModel,
         is_fixed: false,
+        is_blocked: false,
       });
       expect(service.addMate(user, '어린콩2')).rejects.toThrow(
         BadRequestException,
@@ -180,6 +170,7 @@ describe('MatesService', () => {
           follower_id: { id: 1 } as UsersModel,
           following_id: { id: 2 } as UsersModel,
           is_fixed: false,
+          is_blocked: false,
         },
       ]);
       jest
@@ -276,6 +267,7 @@ describe('MatesService', () => {
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 2 } as UsersModel,
         is_fixed: false,
+        is_blocked: false,
       });
       const result = await service.findMate(user, '어린콩2');
       expect(result).toStrictEqual({


### PR DESCRIPTION
# 이슈번호-작업이름
close #501 
## 완료된 기능
- 친구 목록 페이지네이션 
- 10명 이상이어도 친구 추가 가능
- 한 번에 9명씩 나오도록
- 요청 uri `/datetime/timezone` -> `/datetime/timezone/page` 변동
- page는 0부터 1씩 증가하도록 넣어주면 정상 동작