### PR TITLE
[BE#505] 팔로우 조회 커서기반 pagination

### DIFF
--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -20,7 +20,9 @@ import { User } from 'src/users/decorator/user.decorator';
 import {
   ApiBearerAuth,
   ApiConsumes,
+  ApiCreatedResponse,
   ApiExcludeEndpoint,
+  ApiOkResponse,
   ApiOperation,
   ApiResponse,
   ApiTags,
@@ -32,6 +34,8 @@ import { ConfigService } from '@nestjs/config';
 import { ENV } from 'src/common/const/env-keys.const';
 import { getImageUrl } from 'src/common/utils/utils';
 import { ResponseDto } from 'src/common/response.dto';
+import { UpdateInfoDto } from './dto/response/update-info.dto';
+import { GetInfoDto } from './dto/response/get-info.dto';
 
 @ApiTags('로그인 페이지')
 @Controller('auth')
@@ -81,7 +85,10 @@ export class AuthController {
   @UseInterceptors(FileInterceptor('image'))
   @ApiOperation({ summary: '유저 정보 설정 (완)' })
   @ApiConsumes('multipart/form-data')
-  @ApiResponse({ status: 200, description: '프로필 변경 성공' })
+  @ApiCreatedResponse({
+    type: UpdateInfoDto,
+    description: '유저 정보가 성공적으로 업데이트 되었습니다.',
+  })
   @ApiResponse({ status: 400, description: '잘못된 요청' })
   @ApiResponse({ status: 401, description: '인증 실패' })
   @ApiBearerAuth()
@@ -89,7 +96,7 @@ export class AuthController {
     @User('id') user_id: number,
     @Body() user: UpdateUserDto,
     @UploadedFile() file: Express.Multer.File,
-  ): Promise<any> {
+  ): Promise<UpdateInfoDto> {
     let image_url: string;
     if (file) {
       const isNomal = await this.usersService.isNormalImage(file);
@@ -120,11 +127,11 @@ export class AuthController {
   @Get('info')
   @UseGuards(AccessTokenGuard)
   @ApiOperation({ summary: '유저 정보 조회 (완)' })
-  @ApiResponse({ status: 200, description: '프로필 조회 성공' })
+  @ApiOkResponse({ type: GetInfoDto, description: '프로필 조회 성공' })
   @ApiResponse({ status: 400, description: '잘못된 요청' })
   @ApiResponse({ status: 401, description: '인증 실패' })
   @ApiBearerAuth()
-  async getUser(@User('id') user_id: number): Promise<any> {
+  async getUser(@User('id') user_id: number): Promise<GetInfoDto> {
     const user = await this.usersService.findUserById(user_id);
     const followsCount = await this.usersService.getFollowsCount(user_id);
     return {
@@ -142,7 +149,7 @@ export class AuthController {
   @Patch('timezone')
   @UseGuards(AccessTokenGuard)
   @ApiOperation({ summary: '유저 타임존 설정 (완)' })
-  @ApiResponse({ status: 200, description: '타임존 설정 성공' })
+  @ApiOkResponse({ type: ResponseDto, description: '타임존 설정 성공' })
   @ApiResponse({ status: 400, description: '잘못된 요청' })
   @ApiResponse({ status: 401, description: '인증 실패' })
   @ApiBearerAuth()

--- a/BE/src/auth/dto/response/get-info.dto.ts
+++ b/BE/src/auth/dto/response/get-info.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetInfoDto {
+  @ApiProperty({
+    type: 'string',
+    example: '어린콩',
+    description: '닉네임',
+  })
+  nickname: string;
+
+  @ApiProperty({
+    type: 'string',
+    example: 'example@co.kr',
+    description: '이메일',
+  })
+  email: string;
+
+  @ApiProperty({
+    type: 'string',
+    example: 'https://imageurl.com',
+    description: '이미지 경로',
+  })
+  image_url: string;
+
+  @ApiProperty({
+    type: 'number',
+    example: 20,
+    description: '팔로워 수',
+  })
+  follower_count: number;
+
+  @ApiProperty({
+    type: 'number',
+    example: 10,
+    description: '팔로잉 수',
+  })
+  following_count: number;
+}

--- a/BE/src/auth/dto/response/update-info.dto.ts
+++ b/BE/src/auth/dto/response/update-info.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateInfoDto {
+  @ApiProperty({
+    type: 'string',
+    example: '어린콩',
+    description: '닉네임',
+  })
+  nickname: string;
+
+  @ApiProperty({
+    type: 'string',
+    example: 'example@co.kr',
+    description: '이메일',
+  })
+  email: string;
+
+  @ApiProperty({
+    type: 'string',
+    example: 'https://imageurl.com',
+    description: '이미지 경로',
+  })
+  image_url: string;
+}

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -32,7 +32,14 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, swaggerConfig);
   SwaggerModule.setup('api', app, document);
 
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true, // Enable transformation
+      transformOptions: {
+        enableImplicitConversion: true, // Enable implicit conversion
+      },
+    }),
+  );
   app.useGlobalInterceptors(new LoggingInterceptor());
   app.useGlobalFilters(new HttpExceptionFilter());
 

--- a/BE/src/mates/dto/request/pagination-query.dto.ts
+++ b/BE/src/mates/dto/request/pagination-query.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber, Min } from 'class-validator';
+
+export class PaginationQueryDto {
+  @ApiProperty({
+    type: 'number',
+    example: 1,
+    description: '현재 cursor 위치 (default: 1)',
+  })
+  @Type(() => Number) // Add this line
+  @IsNumber()
+  @Min(1)
+  cursor: number = 1;
+}

--- a/BE/src/mates/dto/request/pagination-query.dto.ts
+++ b/BE/src/mates/dto/request/pagination-query.dto.ts
@@ -6,10 +6,10 @@ export class PaginationQueryDto {
   @ApiProperty({
     type: 'number',
     example: 1,
-    description: '현재 cursor 위치 (default: 1)',
+    description: '현재 page 위치 (default: 1)',
   })
   @Type(() => Number) // Add this line
   @IsNumber()
   @Min(1)
-  cursor: number = 1;
+  page: number = 1;
 }

--- a/BE/src/mates/dto/response/follower-info.dto.ts
+++ b/BE/src/mates/dto/response/follower-info.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FollowerInfoDto {
+  @ApiProperty({
+    type: 'number',
+    example: 1,
+    description: '친구 관계 id',
+  })
+  id: number;
+
+  @ApiProperty({
+    type: 'string',
+    example: '어린콩',
+    description: '친구 닉네임',
+  })
+  nickname: string;
+
+  @ApiProperty({
+    type: 'string',
+    example: 'https://imageurl.com',
+    description: '친구 이미지 경로',
+  })
+  image_url: string;
+
+  @ApiProperty({
+    type: 'boolean',
+    example: false,
+    description: '이미 친구관게인지',
+  })
+  is_followed: boolean;
+}

--- a/BE/src/mates/dto/response/mates-info.dto.ts
+++ b/BE/src/mates/dto/response/mates-info.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MatesInfoDto {
+  @ApiProperty({
+    type: 'number',
+    example: 1,
+    description: '친구 관계 id',
+  })
+  id: number;
+
+  @ApiProperty({
+    type: 'string',
+    example: '어린콩',
+    description: '친구 닉네임',
+  })
+  nickname: string;
+
+  @ApiProperty({
+    type: 'string',
+    example: 'https://imageurl.com',
+    description: '친구 이미지 경로',
+  })
+  image_url: string;
+}

--- a/BE/src/mates/dto/response/mates.dto.ts
+++ b/BE/src/mates/dto/response/mates.dto.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class MatesDto {
   @ApiProperty({
     type: 'number',
-    example: '1',
+    example: 1,
     description: '친구 관계 id',
   })
   id: number;

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -63,7 +63,7 @@ export class MatesController {
     @Query() query: PaginationQueryDto,
   ): Promise<object> {
     console.log(query);
-    return this.matesService.getFollowersInfo(user_id, query.cursor);
+    return this.matesService.getFollowersInfo(user_id, query.page);
   }
 
   @Get('/followings')
@@ -74,7 +74,7 @@ export class MatesController {
     @User('id') user_id: number,
     @Query() query: PaginationQueryDto,
   ): Promise<object> {
-    return this.matesService.getFollowingsInfo(user_id, query.cursor);
+    return this.matesService.getFollowingsInfo(user_id, query.page);
   }
 
   @Get('/status')
@@ -256,6 +256,6 @@ export class MatesController {
     @User('id') user_id: number,
     @Query() query: PaginationQueryDto,
   ): Promise<object> {
-    return this.matesService.getBlockedFollowersInfo(user_id, query.cursor);
+    return this.matesService.getBlockedFollowersInfo(user_id, query.page);
   }
 }

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -23,6 +23,7 @@ import { StatusMessageDto } from './dto/response/status-message.dto';
 import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
 import { UsersModel } from 'src/users/entity/users.entity';
 import { ResponseDto } from 'src/common/response.dto';
+import { PaginationQueryDto } from './dto/request/pagination-query.dto';
 
 @Controller('mates')
 @ApiTags('소셜 페이지')
@@ -57,16 +58,23 @@ export class MatesController {
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '나를 팔로우 하는 사람들 조회하기' })
-  getFollowers(@User('id') user_id: number): Promise<object> {
-    return this.matesService.getFollowersInfo(user_id);
+  getFollowers(
+    @User('id') user_id: number,
+    @Query() query: PaginationQueryDto,
+  ): Promise<object> {
+    console.log(query);
+    return this.matesService.getFollowersInfo(user_id, query.cursor);
   }
 
   @Get('/followings')
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '내가 팔로우 하는 사람들 조회하기' })
-  getFollowings(@User('id') user_id: number): Promise<object> {
-    return this.matesService.getFollowingsInfo(user_id);
+  getFollowings(
+    @User('id') user_id: number,
+    @Query() query: PaginationQueryDto,
+  ): Promise<object> {
+    return this.matesService.getFollowingsInfo(user_id, query.cursor);
   }
 
   @Get('/status')
@@ -244,7 +252,10 @@ export class MatesController {
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '내가 차단한 사람들 조회하기' })
-  getBlockedMate(@User('id') user_id: number): Promise<object> {
-    return this.matesService.getBlockedFollowersInfo(user_id);
+  getBlockedMate(
+    @User('id') user_id: number,
+    @Query() query: PaginationQueryDto,
+  ): Promise<object> {
+    return this.matesService.getBlockedFollowersInfo(user_id, query.cursor);
   }
 }

--- a/BE/src/mates/mates.controller.ts
+++ b/BE/src/mates/mates.controller.ts
@@ -13,6 +13,7 @@ import {
   ApiBearerAuth,
   ApiBody,
   ApiCreatedResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiQuery,
   ApiTags,
@@ -24,6 +25,8 @@ import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
 import { UsersModel } from 'src/users/entity/users.entity';
 import { ResponseDto } from 'src/common/response.dto';
 import { PaginationQueryDto } from './dto/request/pagination-query.dto';
+import { MatesInfoDto } from './dto/response/mates-info.dto';
+import { FollowerInfoDto } from './dto/response/follower-info.dto';
 
 @Controller('mates')
 @ApiTags('소셜 페이지')
@@ -58,11 +61,15 @@ export class MatesController {
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '나를 팔로우 하는 사람들 조회하기' })
+  @ApiOkResponse({
+    type: FollowerInfoDto,
+    isArray: true,
+    description: '나를 팔로우한 사람들 정보(차단한 사람들은 제외)',
+  })
   getFollowers(
     @User('id') user_id: number,
     @Query() query: PaginationQueryDto,
-  ): Promise<object> {
-    console.log(query);
+  ): Promise<FollowerInfoDto[]> {
     return this.matesService.getFollowersInfo(user_id, query.page);
   }
 
@@ -70,10 +77,15 @@ export class MatesController {
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '내가 팔로우 하는 사람들 조회하기' })
+  @ApiOkResponse({
+    type: MatesInfoDto,
+    isArray: true,
+    description: '팔로우 한 사람들 정보',
+  })
   getFollowings(
     @User('id') user_id: number,
     @Query() query: PaginationQueryDto,
-  ): Promise<object> {
+  ): Promise<MatesInfoDto[]> {
     return this.matesService.getFollowingsInfo(user_id, query.page);
   }
 
@@ -200,6 +212,9 @@ export class MatesController {
       },
     },
   })
+  @ApiOkResponse({
+    type: ResponseDto,
+  })
   async fixationMate(
     @User('id') id: number,
     @Body('following_id') following_id: number,
@@ -235,6 +250,9 @@ export class MatesController {
       },
     },
   })
+  @ApiOkResponse({
+    type: ResponseDto,
+  })
   async blockMate(
     @User('id') id: number,
     @Body('follower_id') follower_id: number,
@@ -252,10 +270,15 @@ export class MatesController {
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '내가 차단한 사람들 조회하기' })
+  @ApiOkResponse({
+    type: MatesInfoDto,
+    isArray: true,
+    description: '차단한 사람들 정보',
+  })
   getBlockedMate(
     @User('id') user_id: number,
     @Query() query: PaginationQueryDto,
-  ): Promise<object> {
+  ): Promise<MatesInfoDto[]> {
     return this.matesService.getBlockedFollowersInfo(user_id, query.page);
   }
 }

--- a/BE/src/mates/mates.service.spec.ts
+++ b/BE/src/mates/mates.service.spec.ts
@@ -85,6 +85,7 @@ describe('MatesService', () => {
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 3 } as UsersModel,
         is_fixed: false,
+        is_blocked: false,
       });
       const result = await service.addMate(user, '어린콩3');
       expect(result).toStrictEqual({
@@ -136,6 +137,7 @@ describe('MatesService', () => {
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 3 } as UsersModel,
         is_fixed: false,
+        is_blocked: false,
       });
       expect(service.addMate(user, '어린콩2')).rejects.toThrow(
         BadRequestException,
@@ -180,6 +182,7 @@ describe('MatesService', () => {
           follower_id: { id: 1 } as UsersModel,
           following_id: { id: 2 } as UsersModel,
           is_fixed: false,
+          is_blocked: false,
         },
       ]);
       jest
@@ -276,6 +279,7 @@ describe('MatesService', () => {
         follower_id: { id: 1 } as UsersModel,
         following_id: { id: 2 } as UsersModel,
         is_fixed: false,
+        is_blocked: false,
       });
       const result = await service.findMate(user, '어린콩2');
       expect(result).toStrictEqual({

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -301,6 +301,7 @@ export class MatesService {
       },
       { is_fixed: is_fixed },
     );
+
     if (result.affected === 0) {
       throw new NotFoundException('해당 친구 관계는 존재하지 않습니다.');
     }

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -301,8 +301,7 @@ export class MatesService {
       },
       { is_fixed: is_fixed },
     );
-
-    if (!result) {
+    if (result.affected === 0) {
       throw new NotFoundException('해당 친구 관계는 존재하지 않습니다.');
     }
   }
@@ -320,7 +319,7 @@ export class MatesService {
       { is_blocked: is_blocked },
     );
 
-    if (!result) {
+    if (result.affected === 0) {
       throw new NotFoundException('해당 친구 관계는 존재하지 않습니다.');
     }
   }

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -15,6 +15,8 @@ import { ENV } from 'src/common/const/env-keys.const';
 import { StudyLogsService } from 'src/study-logs/study-logs.service';
 import moment from 'moment';
 import { MATES_MAXIMUM } from 'src/common/const/service-var.const';
+import { MatesInfoDto } from './dto/response/mates-info.dto';
+import { FollowerInfoDto } from './dto/response/follower-info.dto';
 
 @Injectable()
 export class MatesService {
@@ -60,8 +62,11 @@ export class MatesService {
     };
   }
 
-  async getFollowersInfo(user_id: number, page: number) {
-    const take = 1;
+  async getFollowersInfo(
+    user_id: number,
+    page: number,
+  ): Promise<FollowerInfoDto[]> {
+    const take = 10;
     const followers = await this.matesRepository.query(
       `SELECT 
          u.id, 
@@ -87,9 +92,12 @@ export class MatesService {
     }));
   }
 
-  async getBlockedFollowersInfo(user_id: number, page: number) {
+  async getBlockedFollowersInfo(
+    user_id: number,
+    page: number,
+  ): Promise<MatesInfoDto[]> {
     const take = 10;
-    const blockedFollowers = await this.matesRepository.query(
+    return this.matesRepository.query(
       `SELECT u.id, u.nickname, u.image_url 
        FROM mates 
        INNER JOIN users_model as u ON u.id = mates.follower_id 
@@ -99,17 +107,14 @@ export class MatesService {
        OFFSET ?`,
       [user_id, take, (page - 1) * take],
     );
-
-    return {
-      data: blockedFollowers,
-      page: blockedFollowers.length === take ? page + 1 : null,
-      count: blockedFollowers.length,
-    };
   }
 
-  async getFollowingsInfo(user_id: number, page: number) {
+  async getFollowingsInfo(
+    user_id: number,
+    page: number,
+  ): Promise<MatesInfoDto[]> {
     const take = 10;
-    const followings = await this.matesRepository.query(
+    return this.matesRepository.query(
       `SELECT u.id, u.nickname, u.image_url 
        FROM mates 
        INNER JOIN users_model as u ON u.id = mates.following_id 
@@ -119,12 +124,6 @@ export class MatesService {
        OFFSET ?`,
       [user_id, take, (page - 1) * take],
     );
-
-    return {
-      data: followings,
-      page: followings.length === take ? page + 1 : null,
-      count: followings.length,
-    };
   }
 
   async getMates(

--- a/BE/src/mates/mates.service.ts
+++ b/BE/src/mates/mates.service.ts
@@ -60,8 +60,8 @@ export class MatesService {
     };
   }
 
-  async getFollowersInfo(user_id: number, cursor: number) {
-    const take = 10;
+  async getFollowersInfo(user_id: number, page: number) {
+    const take = 1;
     const followers = await this.matesRepository.query(
       `SELECT 
          u.id, 
@@ -78,20 +78,16 @@ export class MatesService {
        ORDER BY u.nickname
        LIMIT ?
        OFFSET ?`,
-      [user_id, user_id, take, (cursor - 1) * take],
+      [user_id, user_id, take, (page - 1) * take],
     );
 
-    return {
-      data: followers.map((follower) => ({
-        ...follower,
-        is_followed: follower.is_followed === 1,
-      })),
-      cursor: followers.length === take ? cursor + 1 : null,
-      count: followers.length,
-    };
+    return followers.map((follower) => ({
+      ...follower,
+      is_followed: follower.is_followed === 1,
+    }));
   }
 
-  async getBlockedFollowersInfo(user_id: number, cursor: number) {
+  async getBlockedFollowersInfo(user_id: number, page: number) {
     const take = 10;
     const blockedFollowers = await this.matesRepository.query(
       `SELECT u.id, u.nickname, u.image_url 
@@ -101,17 +97,17 @@ export class MatesService {
        ORDER BY u.nickname
        LIMIT ?
        OFFSET ?`,
-      [user_id, take, (cursor - 1) * take],
+      [user_id, take, (page - 1) * take],
     );
 
     return {
       data: blockedFollowers,
-      cursor: blockedFollowers.length === take ? cursor + 1 : null,
+      page: blockedFollowers.length === take ? page + 1 : null,
       count: blockedFollowers.length,
     };
   }
 
-  async getFollowingsInfo(user_id: number, cursor: number) {
+  async getFollowingsInfo(user_id: number, page: number) {
     const take = 10;
     const followings = await this.matesRepository.query(
       `SELECT u.id, u.nickname, u.image_url 
@@ -121,12 +117,12 @@ export class MatesService {
        ORDER BY u.nickname
        LIMIT ?
        OFFSET ?`,
-      [user_id, take, (cursor - 1) * take],
+      [user_id, take, (page - 1) * take],
     );
 
     return {
       data: followings,
-      cursor: followings.length === take ? cursor + 1 : null,
+      page: followings.length === take ? page + 1 : null,
       count: followings.length,
     };
   }

--- a/BE/src/study-logs/study-logs.controller.ts
+++ b/BE/src/study-logs/study-logs.controller.ts
@@ -140,8 +140,4 @@ export class StatsController {
       ),
     };
   }
-
-  @Get('/monthly')
-  @ApiOperation({ summary: '월간 통계 조회하기' })
-  getMonthlyStats() {}
 }

--- a/BE/src/users/dto/response/nickname-validation.dto.ts
+++ b/BE/src/users/dto/response/nickname-validation.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NicknameValidationDto {
+  @ApiProperty({
+    type: 'boolean',
+    example: true,
+    description: '가능한지 여부',
+  })
+  is_unique: boolean;
+}

--- a/BE/src/users/dto/response/user-profile.dto.ts
+++ b/BE/src/users/dto/response/user-profile.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserProfileDto {
+  @ApiProperty({
+    type: 'string',
+    example: 'https://imgurl.com/path/file.png',
+    description: '유저 프로필 사진',
+  })
+  image_url: string;
+}

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -8,6 +8,8 @@ import {
 } from '@nestjs/swagger';
 
 import { UsersService } from './users.service';
+import { NicknameValidationDto } from './dto/response/nickname-validation.dto';
+import { UserProfileDto } from './dto/response/user-profile.dto';
 @ApiTags('로그인 페이지')
 @Controller('user')
 export class UsersController {
@@ -23,13 +25,15 @@ export class UsersController {
     description: '검증할 유저 닉네임',
   })
   @ApiOkResponse({
-    type: Boolean,
+    type: NicknameValidationDto,
     description: '닉네임 검증 확인 결과 true(사용가능), false(불가능)',
   })
   @ApiBadRequestResponse({
     description: '잘못된 요청',
   })
-  async validateNickname(@Query('nickname') nickname: string): Promise<object> {
+  async validateNickname(
+    @Query('nickname') nickname: string,
+  ): Promise<NicknameValidationDto> {
     return this.usersService.isUniqueNickname(nickname);
   }
 
@@ -43,7 +47,7 @@ export class UsersController {
     description: '검증할 유저 닉네임',
   })
   @ApiOkResponse({
-    type: String,
+    type: UserProfileDto,
     description: '유저 프로필 이미지 url',
   })
   @ApiBadRequestResponse({
@@ -51,7 +55,7 @@ export class UsersController {
   })
   async getUserProfileByNickname(
     @Query('nickname') nickname: string,
-  ): Promise<object> {
+  ): Promise<UserProfileDto> {
     return {
       image_url: await this.usersService.getUserProfileByNickname(nickname),
     };

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -9,6 +9,7 @@ import { S3Service } from 'src/common/s3.service';
 import { ENV } from 'src/common/const/env-keys.const';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { getImageUrl } from 'src/common/utils/utils';
+import { NicknameValidationDto } from './dto/response/nickname-validation.dto';
 
 @Injectable()
 export class UsersService {
@@ -101,7 +102,7 @@ export class UsersService {
     return updatedUser;
   }
 
-  async isUniqueNickname(nickname: string): Promise<object> {
+  async isUniqueNickname(nickname: string): Promise<NicknameValidationDto> {
     const isDuplicated = await this.usersRepository.exist({
       where: { nickname },
     });


### PR DESCRIPTION
close #505 

## 완료된 기능
- test코드에 이전에 추가한 is_blocked 추가되지 않아 추가
- auth, user 관련 잘못된 스웨거 문서 작성 (response dto 작성)
- GET /mates/followers 요청에 is_followed 추가
  <img width="500" alt="스크린샷 2024-01-23 오후 12 35 35" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/a614c04c-46b9-4b35-99a4-cecb84f2ba1e">
- 커서기반 페이지네이션
  <img width="554" alt="스크린샷 2024-01-23 오후 1 12 18" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/018cf0ab-d51a-458d-8a84-6aed8d83c577">

## 고민과 해결과정

### class-transformer를 통한 타입변환
query를 통해 받으면 무조건 string이라 매번 number로 변환 시켜주는 것에 대해 회의감을 느껴 pagination DTO에 class-transformer에서 제공해주는 데코레이터를 활용했습니다.
<img width="406" alt="스크린샷 2024-01-23 오후 1 13 49" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/4b464ea7-f017-473b-a79a-5446b8ed16bb">
클라이언트로부터 요청을 받으면 이 dto를 검증하는 과정에서 변환도 같이 해주는 것인데, 이를 위해 main함수에 useGlobalPipes에 관련 설정을 추가해야 했습니다.
<img width="584" alt="스크린샷 2024-01-23 오후 1 15 27" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/251a9afe-1b20-4516-8820-cdc6878d00be">

### 페이지네이션
<img width="504" alt="스크린샷 2024-01-23 오후 1 16 59" src="https://github.com/boostcampwm2023/iOS06-FlipMate/assets/56269396/71bbe809-94a1-4845-b1a2-2e4d89c29841">

기존 쿼리에 limit와 offset을 추가하여 했습니다. 그런데 지금와서 보니 실수한 것 같습니다...! 이건 페이지기반 페이지네이션이네요.. 일단 PR 올려두고 수정하겠습니다ㅠ