### PR TITLE
[iOS#508] 주간 막대 그래프  SwiftUI -> UIKit 리팩토링

### DIFF
--- a/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
+++ b/iOS/FlipMate/FlipMate.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		2C8D21D32B7216EF00632718 /* FlipMateFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5CDA552B025426007AFC57 /* FlipMateFont.swift */; };
 		2C8D21D52B7217C800632718 /* DefaultWithdrawUesCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8D21D42B7217C800632718 /* DefaultWithdrawUesCase.swift */; };
 		2C8D21D72B721DB400632718 /* WithdrawUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8D21D62B721DB400632718 /* WithdrawUseCase.swift */; };
+		2C8D21D92B735E2B00632718 /* BarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8D21D82B735E2B00632718 /* BarChartView.swift */; };
 		2CD272ED2B21A619000CB9E5 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2CD272EF2B21A619000CB9E5 /* Localizable.strings */; };
 		2DD8D73E476DE7C9EAF99CD3 /* Pods_FlipMate_FlipMateUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4022DA62BEB41D4AE6C12507 /* Pods_FlipMate_FlipMateUITests.framework */; };
 		429B3DF652F07625CAB531EF /* Pods_FlipMateTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B285F39D7D27E5C564F4D31 /* Pods_FlipMateTests.framework */; };
@@ -344,6 +345,7 @@
 		2C8D20F42B678A6C00632718 /* LabelListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelListView.swift; sourceTree = "<group>"; };
 		2C8D21D42B7217C800632718 /* DefaultWithdrawUesCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultWithdrawUesCase.swift; sourceTree = "<group>"; };
 		2C8D21D62B721DB400632718 /* WithdrawUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WithdrawUseCase.swift; sourceTree = "<group>"; };
+		2C8D21D82B735E2B00632718 /* BarChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarChartView.swift; sourceTree = "<group>"; };
 		2C9F61F62B14EFA200AE63F9 /* CategoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryManager.swift; sourceTree = "<group>"; };
 		2C9F61F82B14F33600AE63F9 /* CategoryManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryManageable.swift; sourceTree = "<group>"; };
 		2C9F61FA2B15C96100AE63F9 /* CategoryModifyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModifyViewModel.swift; sourceTree = "<group>"; };
@@ -1568,6 +1570,7 @@
 				2CB4AFE12B64D3CD003F5D0F /* LabelView.swift */,
 				2CB4AFE32B64E94A003F5D0F /* CustonChartView.swift */,
 				2C8D20F42B678A6C00632718 /* LabelListView.swift */,
+				2C8D21D82B735E2B00632718 /* BarChartView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1920,6 +1923,7 @@
 				2C8D21132B7216EE00632718 /* CategoryViewModel.swift in Sources */,
 				2C8D21142B7216EE00632718 /* TimerFinishViewModel.swift in Sources */,
 				2C8D21152B7216EE00632718 /* CategoryModifyViewModel.swift in Sources */,
+				2C8D21D92B735E2B00632718 /* BarChartView.swift in Sources */,
 				2C8D21162B7216EE00632718 /* TimerViewController.swift in Sources */,
 				2C8D21172B7216EE00632718 /* CategorySettingViewController.swift in Sources */,
 				2C8D21182B7216EE00632718 /* CategoryModifyViewController.swift in Sources */,

--- a/iOS/FlipMate/FlipMate/Application/DIContainer/ChartDIContainer.swift
+++ b/iOS/FlipMate/FlipMate/Application/DIContainer/ChartDIContainer.swift
@@ -25,12 +25,14 @@ final class ChartDIContainer: ChartFlowCoordinatorDependencies {
     }
     
     func makeChartViewController() -> UIViewController {
+        let repository = DefaultChartRepository(provider: dependencies.provider)
         return ChartViewController(
             viewModel: ChartViewModel(
                 dailyChartUseCase: DefaultFetchDailyChartUseCase(
-                    repository: DefaultChartRepository(
-                        provider: dependencies.provider
-                    )
+                    repository: repository
+                ),
+                weeklyChartUseCase: DefaultFetchWeeklyChartUseCase(
+                    repository: repository
                 )
             )
         )

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Chart/DefaultFetchWeeklyChartUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Chart/DefaultFetchWeeklyChartUseCase.swift
@@ -14,7 +14,7 @@ final class DefaultFetchWeeklyChartUseCase: FetchWeeklyChartUseCase {
         self.repository = repository
     }
     
-    func fetchWeeklyChartLog() async throws -> WeeklyChartLog {
+    func fetchWeeklyChartLog(at date: Date) async throws -> WeeklyChartLog {
         return try await repository.fetchWeeklyLog()
     }
 }

--- a/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/Chart/FetchWeeklyChartUseCase.swift
+++ b/iOS/FlipMate/FlipMate/Domain/UseCases/Protocol/Chart/FetchWeeklyChartUseCase.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol FetchWeeklyChartUseCase {
-    func fetchWeeklyChartLog() async throws -> WeeklyChartLog
+    func fetchWeeklyChartLog(at date: Date) async throws -> WeeklyChartLog
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/BarChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/BarChartView.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class BarChartView: UIView {
     // MARK: - Properties
+    private var textLayerArray = [CATextLayer]()
     private var dailyDatas: [DailyData]? {
         didSet {
             setNeedsDisplay()
@@ -36,6 +37,8 @@ final class BarChartView: UIView {
 
 private extension BarChartView {
     func drawBarChart() {
+        textLayerArray.forEach { $0.removeFromSuperlayer() }
+
         guard let context = UIGraphicsGetCurrentContext(),
               let dailyDatas = dailyDatas, let maxPoint = dailyDatas.map({ $0.studyTime }).max(),
               let darkBlueColor = FlipMateColor.darkBlue.color?.cgColor else { return }
@@ -52,22 +55,24 @@ private extension BarChartView {
             let yPosition = frame.height - barHeight
             let barRect = CGRect(x: xPosition, y: yPosition, width: barWidth, height: barHeight)
             context.fill(barRect)
-            drawStudyTimeText(xPos: xPosition, yPos: yPosition, point: dataPoint, width: barWidth)
+            addTextLayer(position: CGPoint(x: xPosition, y: yPosition), text: "\(dailyData.studyTime)", width: barWidth)
+            addTextLayer(position: CGPoint(x: xPosition, y: frame.height + 40), text: "\(dailyData.day)", width: barWidth)
             xPosition += barWidth + Constant.xSpacing
         }
     }
     
-    func drawStudyTimeText(xPos: CGFloat, yPos: CGFloat, point: CGFloat, width: CGFloat) {
+    func addTextLayer(position: CGPoint, text: String, width: CGFloat) {
         let textLayer = CATextLayer()
         textLayer.frame = CGRect(x: 0, y: 0, width: width, height: Constant.chartTextFontSize)
-        textLayer.position = CGPoint(x: xPos + width / 2, y: yPos - 20)
+        textLayer.position = CGPoint(x: position.x + width / 2, y: position.y - 20)
         textLayer.foregroundColor = FlipMateColor.gray5.color?.cgColor
-        textLayer.string = "\(Int(point))"
+        textLayer.string = text
         textLayer.alignmentMode = .center
         textLayer.fontSize = Constant.chartTextFontSize
         textLayer.font = Constant.chartTextFont as CFTypeRef
         textLayer.isWrapped = true
         layer.addSublayer(textLayer)
+        textLayerArray.append(textLayer)
     }
 }
 

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/BarChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/BarChartView.swift
@@ -51,7 +51,8 @@ private extension BarChartView {
         
         for dailyData in dailyDatas {
             let dataPoint = CGFloat(dailyData.studyTime)
-            let barHeight = (dataPoint / CGFloat(maxPoint)) * frame.height
+            var barHeight = dataPoint / CGFloat(maxPoint) * frame.height
+            if barHeight.isNaN { barHeight = 0.0 }
             let yPosition = frame.height - barHeight
             let barRect = CGRect(x: xPosition, y: yPosition, width: barWidth, height: barHeight)
             context.fill(barRect)

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/BarChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/BarChartView.swift
@@ -1,0 +1,37 @@
+//
+//  BarChartView.swift
+//  FlipMate
+//
+//  Created by 임현규 on 2024/02/07.
+//
+
+import UIKit
+
+final class BarChartView: UIView {
+
+    // MARK: - Properties
+    private var dataPoints: [Int]? {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life cycle
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+    }
+    
+    // MARK: - Methods
+    func fetchData(dataPoints: [Int]) {
+        self.dataPoints = dataPoints
+    }
+}

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/BarChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/BarChartView.swift
@@ -8,9 +8,8 @@
 import UIKit
 
 final class BarChartView: UIView {
-
     // MARK: - Properties
-    private var dataPoints: [Int]? {
+    private var dataPoints: [CGFloat]? {
         didSet {
             setNeedsDisplay()
         }
@@ -22,16 +21,37 @@ final class BarChartView: UIView {
     }
     
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        fatalError("Don't use StoryBoard")
     }
     
     // MARK: - Life cycle
     override func draw(_ rect: CGRect) {
-        super.draw(rect)
+        guard let context = UIGraphicsGetCurrentContext(),
+              let dataPoints = dataPoints, let maxPoint = dataPoints.max(),
+              let darkBlueColor = FlipMateColor.darkBlue.color?.cgColor else { return }
+
+        context.clear(rect)
+        context.setFillColor(darkBlueColor)
+        
+        let barWidth = rect.width / CGFloat(dataPoints.count) - Constant.xSpacing
+        var xPosition = Constant.xPos
+        
+        for dataPoint in dataPoints {
+            let barHeight = (dataPoint / maxPoint) * rect.height
+            let barRect = CGRect(x: xPosition, y: rect.height - barHeight, width: barWidth, height: barHeight)
+            context.fill(barRect)
+            xPosition += barWidth + Constant.xSpacing
+        }
     }
     
-    // MARK: - Methods
-    func fetchData(dataPoints: [Int]) {
+    func fetchData(dataPoints: [CGFloat]) {
         self.dataPoints = dataPoints
+    }
+}
+
+private extension BarChartView {
+    enum Constant {
+        static let xPos: CGFloat = 10
+        static let xSpacing: CGFloat = 20
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/BarChartView.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/View/BarChartView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class BarChartView: UIView {
     // MARK: - Properties
-    private var dataPoints: [CGFloat]? {
+    private var dailyDatas: [DailyData]? {
         didSet {
             setNeedsDisplay()
         }
@@ -26,26 +26,48 @@ final class BarChartView: UIView {
     
     // MARK: - Life cycle
     override func draw(_ rect: CGRect) {
+        drawBarChart()
+    }
+    
+    func fetchData(dailyDatas: [DailyData]) {
+        self.dailyDatas = dailyDatas
+    }
+}
+
+private extension BarChartView {
+    func drawBarChart() {
         guard let context = UIGraphicsGetCurrentContext(),
-              let dataPoints = dataPoints, let maxPoint = dataPoints.max(),
+              let dailyDatas = dailyDatas, let maxPoint = dailyDatas.map({ $0.studyTime }).max(),
               let darkBlueColor = FlipMateColor.darkBlue.color?.cgColor else { return }
 
-        context.clear(rect)
+        context.clear(frame)
         context.setFillColor(darkBlueColor)
         
-        let barWidth = rect.width / CGFloat(dataPoints.count) - Constant.xSpacing
+        let barWidth = frame.width / CGFloat(dailyDatas.count) - Constant.xSpacing
         var xPosition = Constant.xPos
         
-        for dataPoint in dataPoints {
-            let barHeight = (dataPoint / maxPoint) * rect.height
-            let barRect = CGRect(x: xPosition, y: rect.height - barHeight, width: barWidth, height: barHeight)
+        for dailyData in dailyDatas {
+            let dataPoint = CGFloat(dailyData.studyTime)
+            let barHeight = (dataPoint / CGFloat(maxPoint)) * frame.height
+            let yPosition = frame.height - barHeight
+            let barRect = CGRect(x: xPosition, y: yPosition, width: barWidth, height: barHeight)
             context.fill(barRect)
+            drawStudyTimeText(xPos: xPosition, yPos: yPosition, point: dataPoint, width: barWidth)
             xPosition += barWidth + Constant.xSpacing
         }
     }
     
-    func fetchData(dataPoints: [CGFloat]) {
-        self.dataPoints = dataPoints
+    func drawStudyTimeText(xPos: CGFloat, yPos: CGFloat, point: CGFloat, width: CGFloat) {
+        let textLayer = CATextLayer()
+        textLayer.frame = CGRect(x: 0, y: 0, width: width, height: Constant.chartTextFontSize)
+        textLayer.position = CGPoint(x: xPos + width / 2, y: yPos - 20)
+        textLayer.foregroundColor = FlipMateColor.gray5.color?.cgColor
+        textLayer.string = "\(Int(point))"
+        textLayer.alignmentMode = .center
+        textLayer.fontSize = Constant.chartTextFontSize
+        textLayer.font = Constant.chartTextFont as CFTypeRef
+        textLayer.isWrapped = true
+        layer.addSublayer(textLayer)
     }
 }
 
@@ -53,5 +75,7 @@ private extension BarChartView {
     enum Constant {
         static let xPos: CGFloat = 10
         static let xSpacing: CGFloat = 20
+        static let chartTextFont = "AvenirNext-Bold"
+        static let chartTextFontSize: CGFloat = 15
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -13,6 +13,7 @@ final class ChartViewController: BaseViewController {
     private enum Constant {
         static let daily = NSLocalizedString("daily", comment: "")
         static let weekly = NSLocalizedString("weekly", comment: "")
+        static let weeklyChart = NSLocalizedString("weeklyLearingChart", comment: "")
     }
     
     // MARK: - Properties
@@ -59,6 +60,15 @@ final class ChartViewController: BaseViewController {
         return chartView
     }()
     
+    private lazy var weeklyChartLabel: UILabel = {
+        let label = UILabel()
+        label.text = Constant.weeklyChart
+        label.font = FlipMateFont.largeBold.font
+        label.textColor = .label
+        label.isHidden = true
+        return label
+    }()
+    
     private lazy var barChartView: BarChartView = {
         let barChartView = BarChartView()
         barChartView.isHidden = true
@@ -70,7 +80,8 @@ final class ChartViewController: BaseViewController {
             guard let shouldHideDailyChartView = self.shouldHideDailyChartView else { return }
             donutChartView.isHidden = shouldHideDailyChartView
             weeklyCalendarView.isHidden = shouldHideDailyChartView
-            barChartView.isHidden = !donutChartView.isHidden
+            barChartView.isHidden = !shouldHideDailyChartView
+            weeklyChartLabel.isHidden = !shouldHideDailyChartView
             barChartView.fetchData(dataPoints: [10, 20, 30, 15, 100, 44, 73])
         }
     }
@@ -96,7 +107,7 @@ final class ChartViewController: BaseViewController {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        [ weeklyCalendarView, donutChartView, barChartView ] .forEach {
+        [ weeklyCalendarView, donutChartView, weeklyChartLabel, barChartView ] .forEach {
             scrollContentView.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
@@ -128,7 +139,11 @@ final class ChartViewController: BaseViewController {
             donutChartView.trailingAnchor.constraint(equalTo: scrollContentView.trailingAnchor, constant: -15),
             donutChartView.bottomAnchor.constraint(equalTo: scrollContentView.bottomAnchor, constant: -80),
             
-            barChartView.topAnchor.constraint(equalTo: scrollContentView.topAnchor),
+            weeklyChartLabel.topAnchor.constraint(equalTo: scrollContentView.topAnchor, constant: 15),
+            weeklyChartLabel.leadingAnchor.constraint(equalTo: scrollContentView.leadingAnchor, constant: 15),
+            weeklyChartLabel.trailingAnchor.constraint(equalTo: scrollContentView.trailingAnchor),
+            
+            barChartView.topAnchor.constraint(equalTo: weeklyChartLabel.bottomAnchor, constant: 40),
             barChartView.leadingAnchor.constraint(equalTo: scrollContentView.leadingAnchor),
             barChartView.trailingAnchor.constraint(equalTo: scrollContentView.trailingAnchor),
             barChartView.heightAnchor.constraint(equalTo: scrollContentView.widthAnchor)

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -59,14 +59,22 @@ final class ChartViewController: BaseViewController {
         return chartView
     }()
     
-    private var weeklyChartView = UIView()
+    private lazy var barChartView: BarChartView = {
+        let barChartView = BarChartView(frame: CGRect(
+            x: .zero,
+            y: .zero,
+            width: view.frame.width,
+            height: view.frame.width))
+        barChartView.isHidden = true
+        return barChartView
+    }()
     
     var shouldHideDailyChartView: Bool? {
         didSet {
             guard let shouldHideDailyChartView = self.shouldHideDailyChartView else { return }
             donutChartView.isHidden = shouldHideDailyChartView
             weeklyCalendarView.isHidden = shouldHideDailyChartView
-            weeklyChartView.isHidden = !donutChartView.isHidden
+            barChartView.isHidden = !donutChartView.isHidden
         }
     }
     
@@ -91,7 +99,7 @@ final class ChartViewController: BaseViewController {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        [ weeklyCalendarView, donutChartView ] .forEach {
+        [ weeklyCalendarView, donutChartView, barChartView ] .forEach {
             scrollContentView.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
@@ -121,7 +129,12 @@ final class ChartViewController: BaseViewController {
             donutChartView.topAnchor.constraint(equalTo: weeklyCalendarView.bottomAnchor, constant: 20),
             donutChartView.leadingAnchor.constraint(equalTo: scrollContentView.leadingAnchor, constant: 15),
             donutChartView.trailingAnchor.constraint(equalTo: scrollContentView.trailingAnchor, constant: -15),
-            donutChartView.bottomAnchor.constraint(equalTo: scrollContentView.bottomAnchor, constant: -80)
+            donutChartView.bottomAnchor.constraint(equalTo: scrollContentView.bottomAnchor, constant: -80),
+            
+            barChartView.topAnchor.constraint(equalTo: scrollContentView.topAnchor),
+            barChartView.leadingAnchor.constraint(equalTo: scrollContentView.leadingAnchor),
+            barChartView.trailingAnchor.constraint(equalTo: scrollContentView.trailingAnchor),
+            barChartView.bottomAnchor.constraint(equalTo: scrollContentView.bottomAnchor)
         ])
         
         NSLayoutConstraint.activate([

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -170,10 +170,9 @@ final class ChartViewController: BaseViewController {
         
         viewModel.weeklyChartPulisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] dailyData in
+            .sink { [weak self] dailyDatas in
                 guard let self = self else { return }
-                let dataPoints = dailyData.map { CGFloat($0.studyTime) }
-                barChartView.fetchData(dataPoints: dataPoints)
+                barChartView.fetchData(dailyDatas: dailyDatas)
             }
             .store(in: &cancellables)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -65,6 +65,7 @@ final class ChartViewController: BaseViewController {
         didSet {
             guard let shouldHideDailyChartView = self.shouldHideDailyChartView else { return }
             donutChartView.isHidden = shouldHideDailyChartView
+            weeklyCalendarView.isHidden = shouldHideDailyChartView
             weeklyChartView.isHidden = !donutChartView.isHidden
         }
     }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -82,7 +82,6 @@ final class ChartViewController: BaseViewController {
             weeklyCalendarView.isHidden = shouldHideDailyChartView
             barChartView.isHidden = !shouldHideDailyChartView
             weeklyChartLabel.isHidden = !shouldHideDailyChartView
-            barChartView.fetchData(dataPoints: [10, 20, 30, 15, 100, 44, 73])
         }
     }
     
@@ -166,6 +165,15 @@ final class ChartViewController: BaseViewController {
             .sink { [weak self] studyLog in
                 guard let self = self else { return }
                 donutChartView.fetchLog(studyLog: studyLog)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.weeklyChartPulisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] dailyData in
+                guard let self = self else { return }
+                let dataPoints = dailyData.map { CGFloat($0.studyTime) }
+                barChartView.fetchData(dataPoints: dataPoints)
             }
             .store(in: &cancellables)
     }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewController/ChartViewController.swift
@@ -60,11 +60,7 @@ final class ChartViewController: BaseViewController {
     }()
     
     private lazy var barChartView: BarChartView = {
-        let barChartView = BarChartView(frame: CGRect(
-            x: .zero,
-            y: .zero,
-            width: view.frame.width,
-            height: view.frame.width))
+        let barChartView = BarChartView()
         barChartView.isHidden = true
         return barChartView
     }()
@@ -75,6 +71,7 @@ final class ChartViewController: BaseViewController {
             donutChartView.isHidden = shouldHideDailyChartView
             weeklyCalendarView.isHidden = shouldHideDailyChartView
             barChartView.isHidden = !donutChartView.isHidden
+            barChartView.fetchData(dataPoints: [10, 20, 30, 15, 100, 44, 73])
         }
     }
     
@@ -134,7 +131,7 @@ final class ChartViewController: BaseViewController {
             barChartView.topAnchor.constraint(equalTo: scrollContentView.topAnchor),
             barChartView.leadingAnchor.constraint(equalTo: scrollContentView.leadingAnchor),
             barChartView.trailingAnchor.constraint(equalTo: scrollContentView.trailingAnchor),
-            barChartView.bottomAnchor.constraint(equalTo: scrollContentView.bottomAnchor)
+            barChartView.heightAnchor.constraint(equalTo: scrollContentView.widthAnchor)
         ])
         
         NSLayoutConstraint.activate([

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
@@ -15,6 +15,7 @@ protocol ChartViewModelInput {
 
 protocol ChartViewModelOutput {
     var dailyChartPublisher: AnyPublisher<StudyLog, Never> { get }
+    var weeklyChartPulisher: AnyPublisher<DailyData, Never> { get }
 }
 
 typealias ChartViewModelProtocol = ChartViewModelInput & ChartViewModelOutput
@@ -25,24 +26,31 @@ final class ChartViewModel: ChartViewModelProtocol {
     private var selectedDate = Date()
     
     // MARK: - UseCase
-//    private let chartUseCase: ChartUseCase
     private let dailyChartUseCase: FetchDailyChartUseCase
-    
+    private let weeklyChartUseCase: FetchWeeklyChartUseCase
+
     // MARK: - Subject
     private let dailyChartSubject = PassthroughSubject<StudyLog, Never>()
-    
+    private let weeklyChartSubject = PassthroughSubject<StudyLog, Never>()
     // MARK: - Publihser
     var dailyChartPublisher: AnyPublisher<StudyLog, Never> {
         return dailyChartSubject.eraseToAnyPublisher()
     }
     
-    init(dailyChartUseCase: FetchDailyChartUseCase) {
+    var weeklyChartPulisher: AnyPublisher<StudyLog, Never> {
+        return weeklyChartSubject.eraseToAnyPublisher()
+    }
+    
+    init(dailyChartUseCase: FetchDailyChartUseCase,
+         weeklyChartUseCase: FetchWeeklyChartUseCase) {
         self.dailyChartUseCase = dailyChartUseCase
+        self.weeklyChartUseCase = weeklyChartUseCase
     }
     
     // MARK: - input
     func viewDidLoad() {
         fetchDailyChartLog(at: selectedDate)
+        fetchWeeklyChartLog(at: selectedDate)
     }
     
     func dateDidSelected(date: Date) {
@@ -56,6 +64,13 @@ private extension ChartViewModel {
         Task {
             let log = try await dailyChartUseCase.fetchDailyChartLog(at: date)
             dailyChartSubject.send(log.studyLog)
+        }
+    }
+    
+    func fetchWeeklyChartLog(at date: Date) {
+        Task {
+            let log = try await weeklyChartUseCase.fetchWeeklyChartLog(at: date)
+            weeklyChartSubject.send(log.dailyData)
         }
     }
 }

--- a/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
+++ b/iOS/FlipMate/FlipMate/Presentation/ChartScene/ViewModel/ChartViewModel.swift
@@ -15,7 +15,7 @@ protocol ChartViewModelInput {
 
 protocol ChartViewModelOutput {
     var dailyChartPublisher: AnyPublisher<StudyLog, Never> { get }
-    var weeklyChartPulisher: AnyPublisher<DailyData, Never> { get }
+    var weeklyChartPulisher: AnyPublisher<[DailyData], Never> { get }
 }
 
 typealias ChartViewModelProtocol = ChartViewModelInput & ChartViewModelOutput
@@ -31,13 +31,13 @@ final class ChartViewModel: ChartViewModelProtocol {
 
     // MARK: - Subject
     private let dailyChartSubject = PassthroughSubject<StudyLog, Never>()
-    private let weeklyChartSubject = PassthroughSubject<StudyLog, Never>()
+    private let weeklyChartSubject = PassthroughSubject<[DailyData], Never>()
     // MARK: - Publihser
     var dailyChartPublisher: AnyPublisher<StudyLog, Never> {
         return dailyChartSubject.eraseToAnyPublisher()
     }
     
-    var weeklyChartPulisher: AnyPublisher<StudyLog, Never> {
+    var weeklyChartPulisher: AnyPublisher<[DailyData], Never> {
         return weeklyChartSubject.eraseToAnyPublisher()
     }
     


### PR DESCRIPTION
closed #508 

## 완료된 기능
- CGContext을 통한 막대 그래프 구현
- 주간 학습 기록과 막대 그래프 연동

## 실행 결과

https://github.com/boostcampwm2023/iOS06-FlipMate/assets/48830320/d17bec72-e308-4de6-af44-8378240bf999


## 고민과 해결과정
### 막대의 높이
barChartView의 frame의 height을 기준으로 데이터와의 비율을 통해서 막대를 그리다보니 값이 작은 데이터가 들어간 경우에는 전체적으로 막대들의 높이가 작게 그려지는 문제가 있었습니다.

해당 문제를 해결하기 위해서 barChartView의 frame의 height을 기준으로 잡지 않고 전달받은 데이터 배열 중에 가장 큰 값을 기준으로 나머지 데이터들의 비율을 구해서 막대의 높이를 설정하는 것으로 수정해 문제를 해결했습니다!

``` swift
for dailyData in dailyDatas {
    let dataPoint = CGFloat(dailyData.studyTime)
    let barHeight = (dataPoint / CGFloat(maxPoint)) * frame.height
    let yPosition = frame.height - barHeight
    let barRect = CGRect(x: xPosition, y: yPosition, width: barWidth, height: barHeight)
    context.fill(barRect)
    addTextLayer(position: CGPoint(x: xPosition, y: yPosition), text: "\(dailyData.studyTime)", width: barWidth)
    addTextLayer(position: CGPoint(x: xPosition, y: frame.height + 40), text: "\(dailyData.day)", width: barWidth)
    xPosition += barWidth + Constant.xSpacing
}
```
### DTO -> Entity
 현재 ChartViewController의 viewDidLoad() 메소드 호출 시 해당 주의 학습 기록을 가져오는 API을 호출하고  Respository에서 Provider을 통해 전달받은 ResponseDTO을 통해 직접 Entity로 변환해주고 있습니다.
 
 DTO        
```swift

struct WeeklyChartLogResponseDTO: Decodable {
    let totalTime: Int
    let dailyData: [Int]
    let primaryCategory: String?
    let percentage: Double
    
    private enum CodingKeys: String, CodingKey {
        case totalTime = "total_time"
        case dailyData = "daily_data"
        case primaryCategory = "primary_category"
        case percentage
    }
}

```
        
Entity        

```swift
struct WeeklyChartLog: Identifiable {
    let id: UUID = UUID()
    
    var totalTime: Int
    var dailyData: [DailyData]
    var primaryCategory: String?
    var percentage: Double
}

struct DailyData: Identifiable {
    let id: UUID = UUID()
    
    var day: String
    var studyTime: Int
}
```
DTO(Data Transfer Object)는 JSON의 response를 Entity로 변환하는 역할을 가지고 있는데에 반면, 현재 프로젝트에서는 Repository에서 Provider을 통해 얻은 ResponseDTO을 통해 직접 Entity로 변환해주고 있습니다.
            
```swift
  final class DefaultChartRepository: ChartRepositoryPortocol {
            
    // 생략
    func fetchWeeklyLog() async throws -> WeeklyChartLog {
        let endpoint = ChartEndpoints.fetchWeeklyLog()
        let responseDTO = try await provider.request(with: endpoint)
        
        let transformedDailyData: [DailyData] = responseDTO.dailyData.enumerated().map { index, studyTime in
            let dayIndex = responseDTO.dailyData.count - 1 - index
            let dayOfWeekString = dayOfWeek(at: dateForDayIndex(dayIndex))
            return DailyData(day: dayOfWeekString, studyTime: studyTime)
        }
        
        return WeeklyChartLog(
            totalTime: responseDTO.totalTime,
            dailyData: transformedDailyData,
            primaryCategory: responseDTO.primaryCategory,
            percentage: responseDTO.percentage)
    }
}
```
위와 같이 현재 DefaultChartRepository에서 DailyData의 생성자를 통해 직접 DTO의 값을 전달해 Entity로 변환하고 있습니다.
DailyData 구조체 내부에 또 다른 변수가 추가되거나 기존에 있는 변수가 삭제되는 경우 DTO → Entity로 변환하는 부분은 Repository에서 하고 있으니 Repository에 접근하여 해당 DailyData로 변환하는 부분을 수정해야되는 문제가 생기고,
            
결국에 Entity가 바뀐 것이 Repository까지 영향을 끼치게 되니 Repository가 Entity에 의존성을 가지게 된다고 생각해 변환 부분을 DTO 객체가 해야되지 않나 생각이 드는데 어떻게 생각하는지 의견이 궁금합니다!!
            
### 주간 학습 기록이 없는 경우 생기는 문제
현재 막대 그래프를 그리는 로직은 가장 학습 시간이 많은 일자를 기준으로 각 요일마다의 비율을 통해서 그리고 있습니다.
        
```swift
    func drawBarChart() {
        textLayerArray.forEach { $0.removeFromSuperlayer() }

        guard let context = UIGraphicsGetCurrentContext(),
              let dailyDatas = dailyDatas, let maxPoint = dailyDatas.map({ $0.studyTime }).max(),
              let darkBlueColor = FlipMateColor.darkBlue.color?.cgColor else { return }

        context.clear(frame)
        context.setFillColor(darkBlueColor)
        
        let barWidth = frame.width / CGFloat(dailyDatas.count) - Constant.xSpacing
        var xPosition = Constant.xPos
        
        for dailyData in dailyDatas {
            let dataPoint = CGFloat(dailyData.studyTime)
            var barHeight = dataPoint / CGFloat(maxPoint) * frame.height
            if barHeight.isNaN { barHeight = 0.0 }
            let yPosition = frame.height - barHeight
            let barRect = CGRect(x: xPosition, y: yPosition, width: barWidth, height: barHeight)
            context.fill(barRect)
            addTextLayer(position: CGPoint(x: xPosition, y: yPosition), text: "\(dailyData.studyTime)", width: barWidth)
            addTextLayer(position: CGPoint(x: xPosition, y: frame.height + 40), text: "\(dailyData.day)", width: barWidth)
            xPosition += barWidth + Constant.xSpacing
        }
    }
```
        
여기서 막대 그래프의 높이를 구하는 과정에서 문제가 생겨버렸는데요..
막대 그래프의 높이는 `해당 요일의 공부 시간 / 요일 중 최대 공부 시간 * 뷰의 높이`로 계산하고 있는데, 만약에 모든 요일의 공부 시간이 0인 경우에 `0.0 / 0.0`의 연산을 실행해 값이 nan이 되어서 barHeight와 yPosition이 nan이 되어버리는 문제였습니다.
부동 소수점 연산은 부동 소수점 수를 사용하여 연산을 수행하기 때문에 0.0을 0.0으로 나눈 몫을 구하려고 하는 경우 IEEE 754 표준에 의해 이러한 값을 nan이라는 특수 부동 소수점을 통해 나타내고 있었습니다..
        
    
```swift
  if barHeigth.isNan { barHeight == 0.0 }
```
        
코드를 한 줄 추가해 barHeight가 nan인 경우에 0.0으로 값을 설정해주어서 해결했습니다~!

## 개선할 사항
저번 PR에도 남겼던 사항이지만 현재 CustomChartView 클래스가 도넛 차트만 지원하고 있어서
추후에 막대 그래프와 걲은 선 그래프도 지원할 수 있도록 구현하겠습니다!